### PR TITLE
⚡ [performance improvement] optimize state lookups in Truth Sensors

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -168,25 +168,29 @@ template:
         availability: >
           {% set fresh = namespace(count=0) %}
           {% set max_age = 7200 %}
-          {% set hub = states('sensor.hub_temperature') | float(none) %}
-          {% if hub is not none and (now() - states.sensor.hub_temperature.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
-          {% set hub2_legacy = states('sensor.hub_temperature_2') | float(none) %}
-          {% if hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
-          {% set hub2 = states('sensor.hub_2_tempsensor_temperature') | float(none) %}
-          {% if hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
-          {% set hp = states('sensor.living_room_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.living_room_air_temperature.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% set hub_obj = states.sensor.hub_temperature %}
+          {% if hub_obj is not none and hub_obj.state | float(none) is not none and (now() - hub_obj.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% set hub2_legacy_obj = states.sensor.hub_temperature_2 %}
+          {% if hub2_legacy_obj is not none and hub2_legacy_obj.state | float(none) is not none and (now() - hub2_legacy_obj.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% set hub2_obj = states.sensor.hub_2_tempsensor_temperature %}
+          {% if hub2_obj is not none and hub2_obj.state | float(none) is not none and (now() - hub2_obj.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% set hp_obj = states.sensor.living_room_air_temperature %}
+          {% if hp_obj is not none and hp_obj.state | float(none) is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {{ fresh.count > 0 }}
         state: >
           {% set max_age = 7200 %}
-          {% set hub = states('sensor.hub_temperature') | float(none) %}
-          {% set hub_ok = hub is not none and (now() - states.sensor.hub_temperature.last_changed).total_seconds() < max_age %}
-          {% set hub2_legacy = states('sensor.hub_temperature_2') | float(none) %}
-          {% set hub2_legacy_ok = hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_changed).total_seconds() < max_age %}
-          {% set hub2 = states('sensor.hub_2_tempsensor_temperature') | float(none) %}
-          {% set hub2_ok = hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_changed).total_seconds() < max_age %}
-          {% set hp = states('sensor.living_room_air_temperature') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.living_room_air_temperature.last_changed).total_seconds() < max_age %}
+          {% set hub_obj = states.sensor.hub_temperature %}
+          {% set hub = hub_obj.state | float(none) if hub_obj is not none else none %}
+          {% set hub_ok = hub is not none and (now() - hub_obj.last_changed).total_seconds() < max_age %}
+          {% set hub2_legacy_obj = states.sensor.hub_temperature_2 %}
+          {% set hub2_legacy = hub2_legacy_obj.state | float(none) if hub2_legacy_obj is not none else none %}
+          {% set hub2_legacy_ok = hub2_legacy is not none and (now() - hub2_legacy_obj.last_changed).total_seconds() < max_age %}
+          {% set hub2_obj = states.sensor.hub_2_tempsensor_temperature %}
+          {% set hub2 = hub2_obj.state | float(none) if hub2_obj is not none else none %}
+          {% set hub2_ok = hub2 is not none and (now() - hub2_obj.last_changed).total_seconds() < max_age %}
+          {% set hp_obj = states.sensor.living_room_air_temperature %}
+          {% set hp = hp_obj.state | float(none) if hp_obj is not none else none %}
+          {% set hp_ok = hp is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if hub_ok %}{% set ns.total = ns.total + (hub * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if hub2_legacy_ok %}{% set ns.total = ns.total + (hub2_legacy * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
@@ -202,25 +206,29 @@ template:
         availability: >
           {% set fresh = namespace(count=0) %}
           {% set max_age = 7200 %}
-          {% set hub = states('sensor.hub_humidity') | float(none) %}
-          {% if hub is not none and (now() - states.sensor.hub_humidity.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
-          {% set hub2_legacy = states('sensor.hub_humidity_2') | float(none) %}
-          {% if hub2_legacy is not none and (now() - states.sensor.hub_humidity_2.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
-          {% set hub2 = states('sensor.hub_2_humisensor_humidity') | float(none) %}
-          {% if hub2 is not none and (now() - states.sensor.hub_2_humisensor_humidity.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
-          {% set hp = states('sensor.living_room_air_humidity') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.living_room_air_humidity.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% set hub_obj = states.sensor.hub_humidity %}
+          {% if hub_obj is not none and hub_obj.state | float(none) is not none and (now() - hub_obj.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% set hub2_legacy_obj = states.sensor.hub_humidity_2 %}
+          {% if hub2_legacy_obj is not none and hub2_legacy_obj.state | float(none) is not none and (now() - hub2_legacy_obj.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% set hub2_obj = states.sensor.hub_2_humisensor_humidity %}
+          {% if hub2_obj is not none and hub2_obj.state | float(none) is not none and (now() - hub2_obj.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% set hp_obj = states.sensor.living_room_air_humidity %}
+          {% if hp_obj is not none and hp_obj.state | float(none) is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {{ fresh.count > 0 }}
         state: >
           {% set max_age = 7200 %}
-          {% set hub = states('sensor.hub_humidity') | float(none) %}
-          {% set hub_ok = hub is not none and (now() - states.sensor.hub_humidity.last_changed).total_seconds() < max_age %}
-          {% set hub2_legacy = states('sensor.hub_humidity_2') | float(none) %}
-          {% set hub2_legacy_ok = hub2_legacy is not none and (now() - states.sensor.hub_humidity_2.last_changed).total_seconds() < max_age %}
-          {% set hub2 = states('sensor.hub_2_humisensor_humidity') | float(none) %}
-          {% set hub2_ok = hub2 is not none and (now() - states.sensor.hub_2_humisensor_humidity.last_changed).total_seconds() < max_age %}
-          {% set hp = states('sensor.living_room_air_humidity') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.living_room_air_humidity.last_changed).total_seconds() < max_age %}
+          {% set hub_obj = states.sensor.hub_humidity %}
+          {% set hub = hub_obj.state | float(none) if hub_obj is not none else none %}
+          {% set hub_ok = hub is not none and (now() - hub_obj.last_changed).total_seconds() < max_age %}
+          {% set hub2_legacy_obj = states.sensor.hub_humidity_2 %}
+          {% set hub2_legacy = hub2_legacy_obj.state | float(none) if hub2_legacy_obj is not none else none %}
+          {% set hub2_legacy_ok = hub2_legacy is not none and (now() - hub2_legacy_obj.last_changed).total_seconds() < max_age %}
+          {% set hub2_obj = states.sensor.hub_2_humisensor_humidity %}
+          {% set hub2 = hub2_obj.state | float(none) if hub2_obj is not none else none %}
+          {% set hub2_ok = hub2 is not none and (now() - hub2_obj.last_changed).total_seconds() < max_age %}
+          {% set hp_obj = states.sensor.living_room_air_humidity %}
+          {% set hp = hp_obj.state | float(none) if hp_obj is not none else none %}
+          {% set hp_ok = hp is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if hub_ok %}{% set ns.total = ns.total + (hub * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if hub2_legacy_ok %}{% set ns.total = ns.total + (hub2_legacy * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
@@ -234,7 +242,8 @@ template:
         device_class: carbon_dioxide
         state_class: measurement
         availability: >
-          {{ states('sensor.living_room_msr_co2') | float(none) is not none and (now() - states.sensor.living_room_msr_co2.last_changed).total_seconds() < 10800 }}
+          {% set s_obj = states.sensor.living_room_msr_co2 %}
+          {{ s_obj is not none and s_obj.state | float(none) is not none and (now() - s_obj.last_changed).total_seconds() < 10800 }}
         state: >
           {{ states('sensor.living_room_msr_co2') | float(none) | round(0) }}
 
@@ -243,14 +252,14 @@ template:
         state: >
           {% set max_age = 7200 %}
           {% set parts = namespace(items=[]) %}
-          {% set hub = states('sensor.hub_temperature') | float(none) %}
-          {% if hub is not none and (now() - states.sensor.hub_temperature.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_temperature'] %}{% endif %}
-          {% set hub2_legacy = states('sensor.hub_temperature_2') | float(none) %}
-          {% if hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_temperature_2'] %}{% endif %}
-          {% set hub2 = states('sensor.hub_2_tempsensor_temperature') | float(none) %}
-          {% if hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_2_tempsensor_temperature'] %}{% endif %}
-          {% set hp = states('sensor.living_room_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.living_room_air_temperature.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['living_room_air_temperature'] %}{% endif %}
+          {% set hub_obj = states.sensor.hub_temperature %}
+          {% if hub_obj is not none and hub_obj.state | float(none) is not none and (now() - hub_obj.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_temperature'] %}{% endif %}
+          {% set hub2_legacy_obj = states.sensor.hub_temperature_2 %}
+          {% if hub2_legacy_obj is not none and hub2_legacy_obj.state | float(none) is not none and (now() - hub2_legacy_obj.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_temperature_2'] %}{% endif %}
+          {% set hub2_obj = states.sensor.hub_2_tempsensor_temperature %}
+          {% if hub2_obj is not none and hub2_obj.state | float(none) is not none and (now() - hub2_obj.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_2_tempsensor_temperature'] %}{% endif %}
+          {% set hp_obj = states.sensor.living_room_air_temperature %}
+          {% if hp_obj is not none and hp_obj.state | float(none) is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['living_room_air_temperature'] %}{% endif %}
           {{ parts.items | join(', ') if parts.items | length > 0 else 'none' }}
 
       - name: "Living Room Temperature Truth Active Count"
@@ -258,14 +267,14 @@ template:
         state: >
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
-          {% set hub = states('sensor.hub_temperature') | float(none) %}
-          {% if hub is not none and (now() - states.sensor.hub_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set hub2_legacy = states('sensor.hub_temperature_2') | float(none) %}
-          {% if hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set hub2 = states('sensor.hub_2_tempsensor_temperature') | float(none) %}
-          {% if hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set hp = states('sensor.living_room_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.living_room_air_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set hub_obj = states.sensor.hub_temperature %}
+          {% if hub_obj is not none and hub_obj.state | float(none) is not none and (now() - hub_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set hub2_legacy_obj = states.sensor.hub_temperature_2 %}
+          {% if hub2_legacy_obj is not none and hub2_legacy_obj.state | float(none) is not none and (now() - hub2_legacy_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set hub2_obj = states.sensor.hub_2_tempsensor_temperature %}
+          {% if hub2_obj is not none and hub2_obj.state | float(none) is not none and (now() - hub2_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set hp_obj = states.sensor.living_room_air_temperature %}
+          {% if hp_obj is not none and hp_obj.state | float(none) is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v }}
 
       # =========================================================
@@ -291,21 +300,24 @@ template:
         availability: >
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
-          {% set s1 = states('sensor.master_bedroom_temp_temperature_2') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.master_bedroom_temp_temperature_2.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set s2 = states('sensor.master_bedroom_temperature_temperature_2') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.master_bedroom_temperature_temperature_2.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set hp = states('sensor.master_bedroom_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.master_bedroom_air_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s1_obj = states.sensor.master_bedroom_temp_temperature_2 %}
+          {% if s1_obj is not none and s1_obj.state | float(none) is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s2_obj = states.sensor.master_bedroom_temperature_temperature_2 %}
+          {% if s2_obj is not none and s2_obj.state | float(none) is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set hp_obj = states.sensor.master_bedroom_air_temperature %}
+          {% if hp_obj is not none and hp_obj.state | float(none) is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
-          {% set s1 = states('sensor.master_bedroom_temp_temperature_2') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.master_bedroom_temp_temperature_2.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.master_bedroom_temperature_temperature_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.master_bedroom_temperature_temperature_2.last_changed).total_seconds() < max_age %}
-          {% set hp = states('sensor.master_bedroom_air_temperature') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.master_bedroom_air_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.master_bedroom_temp_temperature_2 %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_ok = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.master_bedroom_temperature_temperature_2 %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_ok = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
+          {% set hp_obj = states.sensor.master_bedroom_air_temperature %}
+          {% set hp = hp_obj.state | float(none) if hp_obj is not none else none %}
+          {% set hp_ok = hp is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
@@ -320,21 +332,24 @@ template:
         availability: >
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
-          {% set s1 = states('sensor.master_bedroom_temp_humidity_2') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.master_bedroom_temp_humidity_2.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set s2 = states('sensor.master_bedroom_temperature_humidity_2') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.master_bedroom_temperature_humidity_2.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set hp = states('sensor.master_bedroom_air_humidity') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.master_bedroom_air_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s1_obj = states.sensor.master_bedroom_temp_humidity_2 %}
+          {% if s1_obj is not none and s1_obj.state | float(none) is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s2_obj = states.sensor.master_bedroom_temperature_humidity_2 %}
+          {% if s2_obj is not none and s2_obj.state | float(none) is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set hp_obj = states.sensor.master_bedroom_air_humidity %}
+          {% if hp_obj is not none and hp_obj.state | float(none) is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
-          {% set s1 = states('sensor.master_bedroom_temp_humidity_2') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.master_bedroom_temp_humidity_2.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.master_bedroom_temperature_humidity_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.master_bedroom_temperature_humidity_2.last_changed).total_seconds() < max_age %}
-          {% set hp = states('sensor.master_bedroom_air_humidity') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.master_bedroom_air_humidity.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.master_bedroom_temp_humidity_2 %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_ok = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.master_bedroom_temperature_humidity_2 %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_ok = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
+          {% set hp_obj = states.sensor.master_bedroom_air_humidity %}
+          {% set hp = hp_obj.state | float(none) if hp_obj is not none else none %}
+          {% set hp_ok = hp is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
@@ -368,25 +383,28 @@ template:
         availability: >
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
-          {% set s1 = states('sensor.lincoln_s_temp_temperature') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set s2 = states('sensor.lincoln_s_room_temperature_temperature') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set s3 = states('sensor.lincoln_temp_temperature') | float(none) %}
-          {% if s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set hp = states('sensor.lincoln_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.lincoln_air_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s1_obj = states.sensor.lincoln_s_temp_temperature %}
+          {% if s1_obj is not none and s1_obj.state | float(none) is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s2_obj = states.sensor.lincoln_s_room_temperature_temperature %}
+          {% if s2_obj is not none and s2_obj.state | float(none) is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s3_obj = states.sensor.lincoln_temp_temperature %}
+          {% if s3_obj is not none and s3_obj.state | float(none) is not none and (now() - s3_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set hp_obj = states.sensor.lincoln_air_temperature %}
+          {% if hp_obj is not none and hp_obj.state | float(none) is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
           {% set outlier_limit = 3.0 %}
 
-          {% set s1 = states('sensor.lincoln_s_temp_temperature') | float(none) %}
-          {% set s1_fresh = s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.lincoln_s_room_temperature_temperature') | float(none) %}
-          {% set s2_fresh = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_changed).total_seconds() < max_age %}
-          {% set s3 = states('sensor.lincoln_temp_temperature') | float(none) %}
-          {% set s3_fresh = s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.lincoln_s_temp_temperature %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_fresh = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.lincoln_s_room_temperature_temperature %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_fresh = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
+          {% set s3_obj = states.sensor.lincoln_temp_temperature %}
+          {% set s3 = s3_obj.state | float(none) if s3_obj is not none else none %}
+          {% set s3_fresh = s3 is not none and (now() - s3_obj.last_changed).total_seconds() < max_age %}
 
           {% set base_total = (s1 if s1_fresh else 0) + (s2 if s2_fresh else 0) + (s3 if s3_fresh else 0) %}
           {% set base_count = (1 if s1_fresh else 0) + (1 if s2_fresh else 0) + (1 if s3_fresh else 0) %}
@@ -395,8 +413,9 @@ template:
           {% set s1_ok = s1_fresh and (base_mean is none or ((s1 - base_mean) | abs <= outlier_limit)) %}
           {% set s2_ok = s2_fresh and (base_mean is none or ((s2 - base_mean) | abs <= outlier_limit)) %}
           {% set s3_ok = s3_fresh and (base_mean is none or ((s3 - base_mean) | abs <= outlier_limit)) %}
-          {% set hp = states('sensor.lincoln_air_temperature') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.lincoln_air_temperature.last_changed).total_seconds() < max_age %}
+          {% set hp_obj = states.sensor.lincoln_air_temperature %}
+          {% set hp = hp_obj.state | float(none) if hp_obj is not none else none %}
+          {% set hp_ok = hp is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}
 
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
@@ -413,25 +432,29 @@ template:
         availability: >
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
-          {% set s1 = states('sensor.lincoln_s_temp_humidity') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.lincoln_s_temp_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set s2 = states('sensor.lincoln_s_room_temperature_humidity') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set s3 = states('sensor.lincoln_temp_humidity') | float(none) %}
-          {% if s3 is not none and (now() - states.sensor.lincoln_temp_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set hp = states('sensor.lincoln_air_humidity') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.lincoln_air_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s1_obj = states.sensor.lincoln_s_temp_humidity %}
+          {% if s1_obj is not none and s1_obj.state | float(none) is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s2_obj = states.sensor.lincoln_s_room_temperature_humidity %}
+          {% if s2_obj is not none and s2_obj.state | float(none) is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s3_obj = states.sensor.lincoln_temp_humidity %}
+          {% if s3_obj is not none and s3_obj.state | float(none) is not none and (now() - s3_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set hp_obj = states.sensor.lincoln_air_humidity %}
+          {% if hp_obj is not none and hp_obj.state | float(none) is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
-          {% set s1 = states('sensor.lincoln_s_temp_humidity') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.lincoln_s_temp_humidity.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.lincoln_s_room_temperature_humidity') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_humidity.last_changed).total_seconds() < max_age %}
-          {% set s3 = states('sensor.lincoln_temp_humidity') | float(none) %}
-          {% set s3_ok = s3 is not none and (now() - states.sensor.lincoln_temp_humidity.last_changed).total_seconds() < max_age %}
-          {% set hp = states('sensor.lincoln_air_humidity') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.lincoln_air_humidity.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.lincoln_s_temp_humidity %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_ok = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.lincoln_s_room_temperature_humidity %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_ok = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
+          {% set s3_obj = states.sensor.lincoln_temp_humidity %}
+          {% set s3 = s3_obj.state | float(none) if s3_obj is not none else none %}
+          {% set s3_ok = s3 is not none and (now() - s3_obj.last_changed).total_seconds() < max_age %}
+          {% set hp_obj = states.sensor.lincoln_air_humidity %}
+          {% set hp = hp_obj.state | float(none) if hp_obj is not none else none %}
+          {% set hp_ok = hp is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
@@ -445,20 +468,23 @@ template:
           {% set max_age = 7200 %}
           {% set outlier_limit = 3.0 %}
           {% set parts = namespace(items=[]) %}
-          {% set s1 = states('sensor.lincoln_s_temp_temperature') | float(none) %}
-          {% set s1_fresh = s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.lincoln_s_room_temperature_temperature') | float(none) %}
-          {% set s2_fresh = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_changed).total_seconds() < max_age %}
-          {% set s3 = states('sensor.lincoln_temp_temperature') | float(none) %}
-          {% set s3_fresh = s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.lincoln_s_temp_temperature %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_fresh = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.lincoln_s_room_temperature_temperature %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_fresh = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
+          {% set s3_obj = states.sensor.lincoln_temp_temperature %}
+          {% set s3 = s3_obj.state | float(none) if s3_obj is not none else none %}
+          {% set s3_fresh = s3 is not none and (now() - s3_obj.last_changed).total_seconds() < max_age %}
           {% set base_total = (s1 if s1_fresh else 0) + (s2 if s2_fresh else 0) + (s3 if s3_fresh else 0) %}
           {% set base_count = (1 if s1_fresh else 0) + (1 if s2_fresh else 0) + (1 if s3_fresh else 0) %}
           {% set base_mean = (base_total / base_count) if base_count > 0 else none %}
           {% if s1_fresh and (base_mean is none or ((s1 - base_mean) | abs <= outlier_limit)) %}{% set parts.items = parts.items + ['lincoln_s_temp_temperature'] %}{% endif %}
           {% if s2_fresh and (base_mean is none or ((s2 - base_mean) | abs <= outlier_limit)) %}{% set parts.items = parts.items + ['lincoln_s_room_temperature_temperature'] %}{% endif %}
           {% if s3_fresh and (base_mean is none or ((s3 - base_mean) | abs <= outlier_limit)) %}{% set parts.items = parts.items + ['lincoln_temp_temperature'] %}{% endif %}
-          {% set hp = states('sensor.lincoln_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.lincoln_air_temperature.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['lincoln_air_temperature'] %}{% endif %}
+          {% set hp_obj = states.sensor.lincoln_air_temperature %}
+          {% if hp_obj is not none and hp_obj.state | float(none) is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['lincoln_air_temperature'] %}{% endif %}
           {{ parts.items | join(', ') if parts.items | length > 0 else 'none' }}
 
       - name: "Lincoln Temperature Truth Rejected"
@@ -467,15 +493,18 @@ template:
           {% set max_age = 7200 %}
           {% set outlier_limit = 3.0 %}
           {% set parts = namespace(items=[]) %}
-          {% set s1_raw = states('sensor.lincoln_s_temp_temperature') %}
-          {% set s2_raw = states('sensor.lincoln_s_room_temperature_temperature') %}
-          {% set s3_raw = states('sensor.lincoln_temp_temperature') %}
+          {% set s1_obj = states.sensor.lincoln_s_temp_temperature %}
+          {% set s2_obj = states.sensor.lincoln_s_room_temperature_temperature %}
+          {% set s3_obj = states.sensor.lincoln_temp_temperature %}
+          {% set s1_raw = s1_obj.state if s1_obj is not none else 'none' %}
+          {% set s2_raw = s2_obj.state if s2_obj is not none else 'none' %}
+          {% set s3_raw = s3_obj.state if s3_obj is not none else 'none' %}
           {% set s1 = s1_raw | float(none) %}
           {% set s2 = s2_raw | float(none) %}
           {% set s3 = s3_raw | float(none) %}
-          {% set s1_fresh = s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_changed).total_seconds() < max_age %}
-          {% set s2_fresh = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_changed).total_seconds() < max_age %}
-          {% set s3_fresh = s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_fresh = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_fresh = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
+          {% set s3_fresh = s3 is not none and (now() - s3_obj.last_changed).total_seconds() < max_age %}
           {% set base_total = (s1 if s1_fresh else 0) + (s2 if s2_fresh else 0) + (s3 if s3_fresh else 0) %}
           {% set base_count = (1 if s1_fresh else 0) + (1 if s2_fresh else 0) + (1 if s3_fresh else 0) %}
           {% set base_mean = (base_total / base_count) if base_count > 0 else none %}
@@ -508,20 +537,23 @@ template:
           {% set max_age = 7200 %}
           {% set outlier_limit = 3.0 %}
           {% set count = namespace(v=0) %}
-          {% set s1 = states('sensor.lincoln_s_temp_temperature') | float(none) %}
-          {% set s1_fresh = s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.lincoln_s_room_temperature_temperature') | float(none) %}
-          {% set s2_fresh = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_changed).total_seconds() < max_age %}
-          {% set s3 = states('sensor.lincoln_temp_temperature') | float(none) %}
-          {% set s3_fresh = s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.lincoln_s_temp_temperature %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_fresh = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.lincoln_s_room_temperature_temperature %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_fresh = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
+          {% set s3_obj = states.sensor.lincoln_temp_temperature %}
+          {% set s3 = s3_obj.state | float(none) if s3_obj is not none else none %}
+          {% set s3_fresh = s3 is not none and (now() - s3_obj.last_changed).total_seconds() < max_age %}
           {% set base_total = (s1 if s1_fresh else 0) + (s2 if s2_fresh else 0) + (s3 if s3_fresh else 0) %}
           {% set base_count = (1 if s1_fresh else 0) + (1 if s2_fresh else 0) + (1 if s3_fresh else 0) %}
           {% set base_mean = (base_total / base_count) if base_count > 0 else none %}
           {% if s1_fresh and (base_mean is none or ((s1 - base_mean) | abs <= outlier_limit)) %}{% set count.v = count.v + 1 %}{% endif %}
           {% if s2_fresh and (base_mean is none or ((s2 - base_mean) | abs <= outlier_limit)) %}{% set count.v = count.v + 1 %}{% endif %}
           {% if s3_fresh and (base_mean is none or ((s3 - base_mean) | abs <= outlier_limit)) %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set hp = states('sensor.lincoln_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.lincoln_air_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set hp_obj = states.sensor.lincoln_air_temperature %}
+          {% if hp_obj is not none and hp_obj.state | float(none) is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v }}
 
       # =========================================================
@@ -548,21 +580,24 @@ template:
         availability: >
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
-          {% set s1 = states('sensor.lilly_temperature') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.lilly_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set s2 = states('sensor.lilly_room_temperature_temperature') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.lilly_room_temperature_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set hp = states('sensor.lilly_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.lilly_air_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s1_obj = states.sensor.lilly_temperature %}
+          {% if s1_obj is not none and s1_obj.state | float(none) is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s2_obj = states.sensor.lilly_room_temperature_temperature %}
+          {% if s2_obj is not none and s2_obj.state | float(none) is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set hp_obj = states.sensor.lilly_air_temperature %}
+          {% if hp_obj is not none and hp_obj.state | float(none) is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
-          {% set s1 = states('sensor.lilly_temperature') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.lilly_temperature.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.lilly_room_temperature_temperature') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.lilly_room_temperature_temperature.last_changed).total_seconds() < max_age %}
-          {% set hp = states('sensor.lilly_air_temperature') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.lilly_air_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.lilly_temperature %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_ok = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.lilly_room_temperature_temperature %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_ok = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
+          {% set hp_obj = states.sensor.lilly_air_temperature %}
+          {% set hp = hp_obj.state | float(none) if hp_obj is not none else none %}
+          {% set hp_ok = hp is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
@@ -577,21 +612,24 @@ template:
         availability: >
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
-          {% set s1 = states('sensor.lilly_humidity') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.lilly_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set s2 = states('sensor.lilly_room_temperature_humidity') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.lilly_room_temperature_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set hp = states('sensor.lilly_air_humidity') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.lilly_air_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s1_obj = states.sensor.lilly_humidity %}
+          {% if s1_obj is not none and s1_obj.state | float(none) is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s2_obj = states.sensor.lilly_room_temperature_humidity %}
+          {% if s2_obj is not none and s2_obj.state | float(none) is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set hp_obj = states.sensor.lilly_air_humidity %}
+          {% if hp_obj is not none and hp_obj.state | float(none) is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
-          {% set s1 = states('sensor.lilly_humidity') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.lilly_humidity.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.lilly_room_temperature_humidity') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.lilly_room_temperature_humidity.last_changed).total_seconds() < max_age %}
-          {% set hp = states('sensor.lilly_air_humidity') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.lilly_air_humidity.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.lilly_humidity %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_ok = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.lilly_room_temperature_humidity %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_ok = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
+          {% set hp_obj = states.sensor.lilly_air_humidity %}
+          {% set hp = hp_obj.state | float(none) if hp_obj is not none else none %}
+          {% set hp_ok = hp is not none and (now() - hp_obj.last_changed).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
@@ -622,21 +660,24 @@ template:
         availability: >
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
-          {% set s1 = states('sensor.office_temp_temperature') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.office_temp_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set s2 = states('sensor.office_temperature_2') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.office_temperature_2.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set net = states('sensor.indoor_temperature') | float(none) %}
-          {% if net is not none and (now() - states.sensor.indoor_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s1_obj = states.sensor.office_temp_temperature %}
+          {% if s1_obj is not none and s1_obj.state | float(none) is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s2_obj = states.sensor.office_temperature_2 %}
+          {% if s2_obj is not none and s2_obj.state | float(none) is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set net_obj = states.sensor.indoor_temperature %}
+          {% if net_obj is not none and net_obj.state | float(none) is not none and (now() - net_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
-          {% set s1 = states('sensor.office_temp_temperature') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.office_temp_temperature.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.office_temperature_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.office_temperature_2.last_changed).total_seconds() < max_age %}
-          {% set net = states('sensor.indoor_temperature') | float(none) %}
-          {% set net_ok = net is not none and (now() - states.sensor.indoor_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.office_temp_temperature %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_ok = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.office_temperature_2 %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_ok = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
+          {% set net_obj = states.sensor.indoor_temperature %}
+          {% set net = net_obj.state | float(none) if net_obj is not none else none %}
+          {% set net_ok = net is not none and (now() - net_obj.last_changed).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 0.95) %}{% set ns.weight = ns.weight + 0.95 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.95) %}{% set ns.weight = ns.weight + 0.95 %}{% endif %}
@@ -651,21 +692,24 @@ template:
         availability: >
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
-          {% set s1 = states('sensor.office_temp_humidity') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.office_temp_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set s2 = states('sensor.office_humidity_2') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.office_humidity_2.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set net = states('sensor.indoor_humidity') | float(none) %}
-          {% if net is not none and (now() - states.sensor.indoor_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s1_obj = states.sensor.office_temp_humidity %}
+          {% if s1_obj is not none and s1_obj.state | float(none) is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s2_obj = states.sensor.office_humidity_2 %}
+          {% if s2_obj is not none and s2_obj.state | float(none) is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set net_obj = states.sensor.indoor_humidity %}
+          {% if net_obj is not none and net_obj.state | float(none) is not none and (now() - net_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
-          {% set s1 = states('sensor.office_temp_humidity') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.office_temp_humidity.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.office_humidity_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.office_humidity_2.last_changed).total_seconds() < max_age %}
-          {% set net = states('sensor.indoor_humidity') | float(none) %}
-          {% set net_ok = net is not none and (now() - states.sensor.indoor_humidity.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.office_temp_humidity %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_ok = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.office_humidity_2 %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_ok = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
+          {% set net_obj = states.sensor.indoor_humidity %}
+          {% set net = net_obj.state | float(none) if net_obj is not none else none %}
+          {% set net_ok = net is not none and (now() - net_obj.last_changed).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 0.95) %}{% set ns.weight = ns.weight + 0.95 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.95) %}{% set ns.weight = ns.weight + 0.95 %}{% endif %}
@@ -678,7 +722,8 @@ template:
         device_class: carbon_dioxide
         state_class: measurement
         availability: >
-          {{ states('sensor.indoor_carbon_dioxide') | float(none) is not none and (now() - states.sensor.indoor_carbon_dioxide.last_changed).total_seconds() < 10800 }}
+          {% set s_obj = states.sensor.indoor_carbon_dioxide %}
+          {{ s_obj is not none and s_obj.state | float(none) is not none and (now() - s_obj.last_changed).total_seconds() < 10800 }}
         state: >
           {{ states('sensor.indoor_carbon_dioxide') | float(none) | round(0) }}
 
@@ -705,17 +750,19 @@ template:
         availability: >
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
-          {% set s1 = states('sensor.laundry_temperature') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.laundry_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set s2 = states('sensor.bathroom_downstairs_temperature') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.bathroom_downstairs_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s1_obj = states.sensor.laundry_temperature %}
+          {% if s1_obj is not none and s1_obj.state | float(none) is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s2_obj = states.sensor.bathroom_downstairs_temperature %}
+          {% if s2_obj is not none and s2_obj.state | float(none) is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
-          {% set s1 = states('sensor.laundry_temperature') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.laundry_temperature.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.bathroom_downstairs_temperature') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.bathroom_downstairs_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.laundry_temperature %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_ok = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.bathroom_downstairs_temperature %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_ok = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.8) %}{% set ns.weight = ns.weight + 0.8 %}{% endif %}
@@ -729,17 +776,19 @@ template:
         availability: >
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
-          {% set s1 = states('sensor.laundry_humidity') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.laundry_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set s2 = states('sensor.bathroom_downstairs_humidity') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.bathroom_downstairs_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s1_obj = states.sensor.laundry_humidity %}
+          {% if s1_obj is not none and s1_obj.state | float(none) is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s2_obj = states.sensor.bathroom_downstairs_humidity %}
+          {% if s2_obj is not none and s2_obj.state | float(none) is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
-          {% set s1 = states('sensor.laundry_humidity') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.laundry_humidity.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.bathroom_downstairs_humidity') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.bathroom_downstairs_humidity.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.laundry_humidity %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_ok = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.bathroom_downstairs_humidity %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_ok = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.8) %}{% set ns.weight = ns.weight + 0.8 %}{% endif %}
@@ -767,17 +816,21 @@ template:
         state_class: measurement
         availability: >
           {% set max_age = 7200 %}
-          {% set s1 = states('sensor.deck_temp_temperature') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.deck_temp_temperature.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.deck_temp_temperature_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.deck_temp_temperature_2.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.deck_temp_temperature %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_ok = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.deck_temp_temperature_2 %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_ok = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
           {{ s1_ok or s2_ok }}
         state: >
           {% set max_age = 7200 %}
-          {% set s1 = states('sensor.deck_temp_temperature') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.deck_temp_temperature.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.deck_temp_temperature_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.deck_temp_temperature_2.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.deck_temp_temperature %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_ok = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.deck_temp_temperature_2 %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_ok = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
           {% if s1_ok and s2_ok %}
             {{ ((s1 + s2) / 2) | round(2) }}
           {% elif s1_ok %}
@@ -793,17 +846,21 @@ template:
         state_class: measurement
         availability: >
           {% set max_age = 7200 %}
-          {% set s1 = states('sensor.deck_temp_humidity') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.deck_temp_humidity.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.deck_temp_humidity_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.deck_temp_humidity_2.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.deck_temp_humidity %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_ok = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.deck_temp_humidity_2 %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_ok = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
           {{ s1_ok or s2_ok }}
         state: >
           {% set max_age = 7200 %}
-          {% set s1 = states('sensor.deck_temp_humidity') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.deck_temp_humidity.last_changed).total_seconds() < max_age %}
-          {% set s2 = states('sensor.deck_temp_humidity_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.deck_temp_humidity_2.last_changed).total_seconds() < max_age %}
+          {% set s1_obj = states.sensor.deck_temp_humidity %}
+          {% set s1 = s1_obj.state | float(none) if s1_obj is not none else none %}
+          {% set s1_ok = s1 is not none and (now() - s1_obj.last_changed).total_seconds() < max_age %}
+          {% set s2_obj = states.sensor.deck_temp_humidity_2 %}
+          {% set s2 = s2_obj.state | float(none) if s2_obj is not none else none %}
+          {% set s2_ok = s2 is not none and (now() - s2_obj.last_changed).total_seconds() < max_age %}
           {% if s1_ok and s2_ok %}
             {{ ((s1 + s2) / 2) | round(1) }}
           {% elif s1_ok %}


### PR DESCRIPTION
I have implemented a systemic performance optimization in `configuration.yaml`. The issue identified a repeated state lookup for `sensor.lilly_temperature`, which I generalized to all "Truth Sensors" across the codebase.

By caching the state object (e.g., `{% set s_obj = states.sensor.entity_id %}`), we avoid redundant calls to the Home Assistant state engine when accessing both the state and attributes like `last_changed`. 

While direct performance measurement was impractical due to the lack of a Home Assistant execution environment in the sandbox, this is a well-documented optimization for Jinja2 templates in HA that reduces CPU overhead during template rendering. 

I verified the changes by carefully reviewing the logic to ensure correctness and checking for Jinja2 syntax balance.

---
*PR created automatically by Jules for task [13612249007081049021](https://jules.google.com/task/13612249007081049021) started by @ManlyRedfish*