### PR TITLE
🔒 Fix hardcoded Google Sheets config_entry ID in automations.yaml

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -99,7 +99,7 @@
   action:
   - action: google_sheets.append_sheet
     data:
-      config_entry: 01KK2B80DRS1S94GERW6XRRM1E
+      config_entry: !secret google_sheets_config_entry
       worksheet: VTherm_Launch_Data_v5
       data:
         # 1. Timestamp / Global Context
@@ -1588,7 +1588,7 @@
   action:
   - action: google_sheets.append_sheet
     data:
-      config_entry: 01KK2B80DRS1S94GERW6XRRM1E
+      config_entry: !secret google_sheets_config_entry
       worksheet: VTherm_Launch_Data_v5
       data:
         # 1. Timestamp / Global Context


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Hardcoded `config_entry` ID for the Google Sheets integration was present in multiple places in `automations.yaml`.

⚠️ **Risk:** The potential impact if left unfixed
Exposing the Google Sheets integration's config entry ID in source control could allow unauthorized actors to interact with or manipulate the connected Google Sheet, potentially leading to data corruption or leakage in the telemetry system.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced the hardcoded string `01KK2B80DRS1S94GERW6XRRM1E` with Home Assistant's standard secret manager syntax, `!secret google_sheets_config_entry`. This ensures the ID is loaded securely from the local `secrets.yaml` and is no longer stored in plain text in version control. Tested changes locally to verify YAML validity.

---
*PR created automatically by Jules for task [18399461683483700001](https://jules.google.com/task/18399461683483700001) started by @ManlyRedfish*