### PR TITLE
Add Runtime Layer documentation and .cursorrules

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+Before suggesting any code changes, silently read the Markdown files in the docs/ folder to understand the Moose House thermal constraints and V9 architecture.

--- a/docs/5_runtime_layer.md
+++ b/docs/5_runtime_layer.md
@@ -1,0 +1,220 @@
+# Doc 5 / Runtime Layer V2
+
+**Runtime Date:** April 25, 2026
+**Document Role:** Runtime Layer
+**Status:** Live implementation boundary for the Moose House climate system. Update when active control logic, truth-sensor logic, helper structure, safety behavior, or telemetry schema materially changes.
+
+## 1. Purpose of This Layer
+
+This layer defines the live operational truth of the Moose House climate system. Its purpose is to identify the sources that describe what the system is actually doing now, acting as the boundary between the narrative canon and the live system.
+
+## 2. What Counts as Runtime Truth
+
+The Moose House runtime layer consists of the following active sources:
+
+### 2.1 Active Control Source
+**Source:** `automations.yaml`
+**Current control architecture:** V8.3 — Comfort-First Hotfix with Stack-Effect Mitigation
+This file contains the live supervisory climate behavior, safety gates, telemetry export automation, seasonal branches, and supporting operational logic. V8.3 introduces a top-anchored heating deadband, a passive 18:00-22:00 LR setpoint reduction to mitigate stack-effect, and an expanded Section 11 HVAC Transition Logger to audit hysteresis behavior.
+
+### 2.2 Active Truth Source
+**Source:** `configuration.yaml`
+**Current truth architecture:** V3.1 — Audited Truth / Smoothed / Control
+This file contains per-room truth sensors, staleness rejection, outlier handling, smoothed sensors, runtime tracking, and control wrappers. It explicitly states the design principles of weighted per-room truth, 2-hour staleness rejection, Lincoln outlier rejection, low-weight internal Samsung sensing, and removal of failed MSR-2 DPS310 sensors.
+
+### 2.3 Active Evidence Source
+**Source:** VTherm_Launch_Data_v5
+**Current telemetry/export schema:** V5 — Semantic Heritage Schema
+The live telemetry pipeline is defined in `automations.yaml` as a 15-minute export to Google Sheets under the worksheet `VTherm_Launch_Data_v5`, with room/metric/role/transport-aware naming.
+
+### 2.4 Active Surface-State Sources
+- Live Home Assistant state
+- Helper states
+- Template sensor states
+- Logbook / history
+- Runtime counters derived from history stats and equipment-firing binary sensors
+*(These sources do not replace the YAML, but they expose runtime reality in motion.)*
+
+## 3. Authority Rule
+
+The Runtime Layer is the implementation boundary for current behavior.
+- If Doc 1 (Startup Canon) and runtime disagree, runtime wins for implementation truth.
+- If Doc 2 (Reference Map) and runtime disagree, verify whether the Reference Map is stale.
+- If Doc 4 (Operations Sheet) describes behavior that runtime does not actually implement, runtime still wins for what is happening now.
+- Telemetry reflects observed outcomes, not necessarily intended behavior.
+- Historical doctrine never overrides active runtime files.
+
+## 4. Scope of This Layer
+
+This layer should preserve, at a high level:
+- Which control architecture is currently live
+- Which truth architecture is currently live
+- Which telemetry schema is currently live
+- Which helper/template structures materially affect control
+- Which safety separations are active
+- Which known runtime compromises are intentionally tolerated
+
+This layer should not become a full YAML dump. It is a runtime map, not a code mirror.
+
+## 5. Current Active Runtime Snapshot
+
+### 5.1 Active Control Layer
+**Current active control version:** V8.3
+**Current control file:** `automations.yaml`
+**Current posture:** Comfort-first deadband hotfix with explicit safety backstops, plus LR heating deadband and stack-effect mitigation.
+
+### 5.2 Active Truth Layer
+**Current active truth version:** V3.1
+**Current truth file:** `configuration.yaml`
+**Current posture:** Audited, trimmed, smoothed truth architecture.
+
+### 5.3 Active Telemetry Layer (V5 Semantic Heritage Schema)
+**Current telemetry version:** V5
+**Current export destination:** Google Sheets
+**Current worksheet:** `VTherm_Launch_Data_v5`
+**Current schema style:** Semantic Heritage naming, mapping room + metric + role + transport into export headers.
+
+## 6. Live Runtime Components
+
+### 6.1 Control Components
+The live control runtime includes:
+- **Main Supervisor (V8.3):** Runs every 15 minutes and acts as the central climate brain for mini-split control. The live file explicitly identifies this section as the central climate supervisor.
+- **Comfort-first cooling deadband logic:** The live cooling doctrine uses:
+  - All rooms: setpoint 68, off ≤68, on >72
+  - Master sleep window (6pm–6am): setpoint 63, off ≤62, on >66
+  - Away: setpoint 74, off ≤74, on >76
+- **Heating deadband logic (V8.3):** The live heating doctrine uses:
+  - Heating/Shoulder daytime: top-anchored deadband (target 68, off ≥68, on <64) to prevent short-cycling.
+  - Bedtime (18:00-22:00, non-away): LR target drops to 64, deadband 62-64°F, to passively reduce stack-effect upstairs heating.
+- **Nest off during cooling branch:** During the cooling branch, the Nest-controlled dining/boiler climate is forced off while mini-splits govern cooling behavior.
+- **Seasonal branching:** The supervisor branches by `input_select.hvac_season_mode`, supporting cooling and shoulder-season behavior in the live file.
+- **Away mode relaxation:** Runtime behavior relaxes temperature targets when `input_boolean.away_mode` is active.
+
+### 6.2 Safety Components
+The runtime explicitly separates safety from comfort. The live automations file describes V8.3 as including:
+- LR runaway cutoff at 60°F
+- Master emergency cooling floor at 58°F
+- Ceiling gates
+- Separation of comfort logic from runaway protection as an active design direction
+*(This separation is important: safety logic is not the same thing as comfort logic, and the runtime treats them as distinct systems.)*
+
+### 6.3 Semantic Heritage Naming Disclaimer
+**Important Note:** Transport labels in V5 column names are historical/positional, not literal. For example, Lilly `*_BT` is a WiFi Wyze cam, and multiple `*_Matter` columns are removed-from-truth SwitchBot paths. Do not assume the column suffix strictly dictates the current active transport protocol.
+
+### 6.4 Truth Components
+The live truth runtime includes:
+- **Per-room weighted truth sensors:** `configuration.yaml` explicitly describes per-room weighted averages from multiple physical sensors.
+- **2-hour staleness rejection:** The design principles explicitly state a 2-hour staleness rejection policy on all inputs.
+- **Lincoln outlier rejection:** Lincoln is the pilot room for outlier rejection, with a 3°F limit against the base mean of primary sensors. Samsung internal sensing is excluded from the outlier calculation itself.
+- **Low-weight internal HVAC sensing:** Samsung internal thermistors remain present but are intentionally low-weight because they are biased hardware. This is explicitly part of the V3.1 design principles.
+- **Smoothed output → control wrappers:** `configuration.yaml` explicitly defines smoothed sensors and control wrappers as part of the architecture.
+
+### 6.5 Helper / Memory Components
+The runtime depends on several helpers. The live automations file explicitly lists helper dependencies including:
+- `input_select.hvac_season_mode`
+- `input_boolean.night_mode_lr_primary`
+- `input_boolean.precool_active` (explicitly noted as orphaned in V8.2 but still toggled by Section 3B)
+- `timer.manual_hvac_override`
+- `timer.shade_manual_override`
+- `input_boolean.away_mode`
+*(These helpers are not just UI artifacts. They are part of the live control path and must exist for runtime behavior to function properly.)*
+
+### 6.6 Evidence / Runtime Observation Components
+The runtime evidence layer includes:
+- 15-minute Google Sheets export
+- Logbook / history review
+- Equipment firing binary sensors
+- `history_stats` runtime tracking
+- Truth contributor / active count diagnostics
+*(`configuration.yaml` explicitly states that binary sensors feed runtime tracking and presence-driven automations, and that equipment-firing sensors are used for runtime counters.)*
+
+## 7. Known Runtime Constraints
+
+The current runtime includes deliberate compromises. These are known live realities, not archive trivia.
+
+### 7.1 HVAC-Mode-as-Memory
+The V8.3 supervisor uses HVAC mode as deadband memory. The live file explicitly describes this as a known-imperfect shortcut that degrades gracefully when device and controller intent diverge between 15-minute ticks.
+
+### 7.2 Command-on-Every-Tick
+Commands are issued every supervisor tick rather than only on state transitions. The live file calls this noisy but acceptable for now, and explicitly identifies it as deferred V9 cleanup.
+
+### 7.3 No Explicit Capacity Arbitration
+The live V8.3 runtime does not implement explicit multi-head capacity arbitration. The automations file explicitly states that this is deferred until there is measured evidence of real starvation under load.
+
+### 7.4 Orphaned / Transitional Runtime Pieces
+The live file explicitly identifies:
+- **PRE-COOL LATCH:** (ORPHANED — helper retained, nothing reads it)
+- **MASTER PRE-COOL:** (DISABLED — superseded by V8.1/V8.2 cooling branch)
+- **HVAC TRANSITION LOGGER:** (Expanded in V8.3 to capture heating hysteresis transitions)
+*(These are part of the current runtime surface and should not be silently forgotten.)*
+
+### 7.5 Sensor Exclusion Reality
+`configuration.yaml` currently describes both MSR-2 DPS310 sensors as removed from truth because of hardware failure. That is the active runtime position in the config file, even if later operational notes may nuance the exact diagnosis. Runtime truth comes from what the live config currently excludes, not from retrospective reinterpretation.
+
+## 8. Runtime Change Rules
+
+Update this layer only when live implementation changes.
+This layer should be updated when:
+- Active control version changes
+- Active truth version changes
+- Helper dependencies materially change
+- Safety logic materially changes
+- Telemetry schema or worksheet changes
+- A source is added to or removed from truth calculations
+- A runtime workaround is introduced, retired, or replaced
+*(Do not update this layer merely to improve prose.)*
+
+## 9. What This Layer Is Not
+
+This document is not:
+- Doc 1 / Startup Canon
+- Doc 2 / Reference Map
+- Appendix A / Historical Audit Appendix
+- Doc 3 / Regression Appendix
+- Doc 4 / Operations Sheet
+- The full YAML dump
+*(It exists to preserve runtime truth boundaries, not to duplicate every implementation detail.)*
+
+## 10. Runtime Verification Workflow
+
+When checking a runtime claim, use this order:
+1. Check active `automations.yaml`
+2. Check active `configuration.yaml`
+3. Check helper and template states
+4. Check telemetry/logbook/history for observed behavior
+5. Check Doc 2 / Reference Map for routing or source precedence
+6. Check Doc 1 / Startup Canon for intended doctrine
+7. Check Audit / Regression docs only when historical explanation is needed
+
+## 11. Minimum Runtime Inventory
+
+The runtime layer should always preserve, at minimum:
+- Active control version: V8.3
+- Active truth version: V3.1
+- Active telemetry version: V5
+- Telemetry worksheet: VTherm_Launch_Data_v5
+- Key helper dependencies
+- Key climate entities
+- Key room truth entities
+- Active safety mechanisms
+- Known excluded/degraded runtime pieces
+- Known deferred architectural debts
+
+## 12. Current Runtime Risks
+
+The primary current runtime risks are:
+- Helper-based memory shortcuts being mistaken for final architecture
+- Command-every-tick behavior creating visible noise or churn
+- Degraded transports being confused with total truth failure
+- Stale prose docs drifting away from the live files
+- Transitional instrumentation or orphaned helpers being forgotten and misinterpreted later
+*(These are runtime-management risks, not necessarily current failure events.)*
+
+## 13. Final Principle
+
+This layer exists so Moose House always has a clear implementation boundary.
+- Doc 1 (Startup Canon) tells new sessions what to believe.
+- Doc 2 (Reference Map) tells them where to look.
+- Doc 3 (Regression Appendix) tells them what not to reinvent.
+- Doc 4 (Operations Sheet) tells them whether current doctrine is working.
+- Doc 5 (Runtime Layer) tells them what is actually live now.


### PR DESCRIPTION
Creates `docs/5_runtime_layer.md` with the content of "Doc 5 / Runtime Layer V2", updated to reflect the live V8.3 control architecture found in `automations.yaml`. Also sets up `.cursorrules` to instruct the AI assistant to read the `docs/` folder before making code changes, establishing a single source of truth for the project's architectural constraints.

---
*PR created automatically by Jules for task [1389721992914194781](https://jules.google.com/task/1389721992914194781) started by @ManlyRedfish*