### PR TITLE
Feature: Initialize V9 Architecture (Docs, Interlock, Timers)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ Current Engineering Goals:
 * Build evidence before introducing complexity
 * Improve telemetry quality for future experiments
 
+**Before suggesting any code changes, silently read the Markdown files in the `docs/` folder to understand the Moose House thermal constraints and V9 architecture.**
+
 When reviewing or modifying automations:
 
 1. Explain the current behavior

--- a/automations.yaml
+++ b/automations.yaml
@@ -584,6 +584,40 @@
 # =============================================================================
 
 # -----------------------------------------------------------------------------
+# V9 SLEEP PRIORITY INTERLOCK
+# -----------------------------------------------------------------------------
+# Solves cross-mode contention lockout during shoulder seasons. If the Master
+# Bedroom requires cooling while the Living Room is actively heating, V9
+# explicitly forces the Living Room to off (provided LR truth remains safely
+# above the 60°F structural floor) to ensure proper mode arbitration at the
+# outdoor compressor.
+# -----------------------------------------------------------------------------
+- id: v9_sleep_priority_interlock
+  alias: "V9: Sleep Priority Interlock (Cross-Mode Contention)"
+  mode: single
+  trigger:
+    - platform: state
+      entity_id: climate.master_bedroom_air
+      to: "cool"
+    - platform: state
+      entity_id: climate.living_room_air
+      to: "heat"
+  condition:
+    - condition: state
+      entity_id: climate.master_bedroom_air
+      state: "cool"
+    - condition: state
+      entity_id: climate.living_room_air
+      state: "heat"
+    - condition: numeric_state
+      entity_id: sensor.living_room_temperature_truth
+      above: 60
+  action:
+    - action: climate.set_hvac_mode
+      target: { entity_id: climate.living_room_air }
+      data: { hvac_mode: "off" }
+
+# -----------------------------------------------------------------------------
 # RUNAWAY COOLING CUTOFF (LR) — V8.2
 # -----------------------------------------------------------------------------
 # This is NOT a comfort gate. Normal Section 2 control turns LR off at 68°F.

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -81,6 +81,25 @@
 # Loads default set of integrations. Do not remove.
 default_config:
 
+timer:
+  lr_compressor_cooldown:
+    name: "Living Room Compressor Cooldown"
+    duration: "00:15:00"
+    icon: mdi:timer-sand
+  master_compressor_cooldown:
+    name: "Master Bedroom Compressor Cooldown"
+    duration: "00:15:00"
+    icon: mdi:timer-sand
+  lincoln_compressor_cooldown:
+    name: "Lincoln Compressor Cooldown"
+    duration: "00:15:00"
+    icon: mdi:timer-sand
+  lilly_compressor_cooldown:
+    name: "Lilly Compressor Cooldown"
+    duration: "00:15:00"
+    icon: mdi:timer-sand
+
+
 recorder:
   purge_keep_days: 30
   commit_interval: 5

--- a/docs/6_proposals.md
+++ b/docs/6_proposals.md
@@ -1,0 +1,26 @@
+# Doc 6 / Proposals
+
+**Date:** April 19, 2026
+**Document Role:** Architecture Proposals & Blueprints
+**Status:** Active pipeline for approved architectural shifts awaiting deployment windows.
+
+## 3.2 Proposed Architecture: V9 (Event-Driven / Decoupled)
+
+**Status:** Approved for development (Pending May 5th V8.2 Gate)
+**State:** V9 transitions the system from a monolithic 15-minute scheduler to an event-driven, decoupled control loop. It is justified not because V8.2 is failing, but because V8.2 enforces safety and stability through architectural coupling that can now be safely separated.
+
+### Core Architecture Shifts (The V9 Doctrine):
+
+* **Decoupled Control Loops:** The observation, decision, actuation, and protection layers are no longer multiplexed to a single clock tick. Actuation is triggered instantly by state-changes in the smoothed Truth Layer rather than a blind global scheduler.
+* **Explicit Hardware Protection:** Scheduler cadence must never be used as a proxy for hardware safety or API protection. Compressor short-cycling and Samsung API DDOS risks are now enforced via explicit, state-aware software guardrails (e.g., isolated 15-minute cooldown timers per unit).
+* **Sleep Priority Interlock:** Solves cross-mode contention lockout during shoulder seasons. If the Master Bedroom requires cooling while the Living Room is actively heating, V9 explicitly forces the Living Room to off (provided LR truth remains safely above the 60°F structural floor) to ensure proper mode arbitration at the outdoor compressor.
+* **Targeted Pre-Chill:** Replaces step-function temperature drops. Master Bedroom cooling engages aggressively (Target 61°F / Turbo) prior to occupancy at 17:00 to neutralize thermal mass, before transitioning to an asymmetric, cost-saving sleep deadband (62–64.5°F) at 18:00.
+
+### Permanent Architectural Guardrails:
+
+* **Physics vs. Latency:** Truth-layer smoothing is intentionally physics-aligned (thermal mass filtering for an 1894 structure) and must not be conflated with control latency. Control responsiveness must be solved at the actuation/scheduler layer, not by reducing truth-layer stability.
+* **Safety Invariant Rule:** If safety systems (e.g., Section 3 Runaway Gates) are firing due to predictable scheduler delay rather than true system faults, control latency is violating system invariants. Safety backstops are strictly for hardware failure, not software lag.
+* **Observability Principle:** High-frequency internal state, low-frequency external telemetry. Rapid system evaluations and transition cycle counts are handled via in-memory tracking (RAM scratchpad), while the V5 semantic heritage export remains cleanly gated to 15-minute intervals.
+
+### §12 Current System Snapshot
+**Proposals & Blueprints:** Doc 6 / Proposals (Holds the V9 Event-Driven architecture)


### PR DESCRIPTION
This pull request introduces the first steps of the V9 architecture shifts:

1. **Documentation Architecture**: Created a new `docs/` directory to serve as the permanent "brain" of the project and added `docs/6_proposals.md` with the details of the V9 architecture. Updated `AGENTS.md` to instruct all AI assistants to read these docs before suggesting changes.
2. **Explicit Hardware Protection**: Added 15-minute compressor cooldown timers (`timer.lr_compressor_cooldown`, etc.) for each mini-split unit in `configuration.yaml` to prevent short-cycling.
3. **Sleep Priority Interlock**: Added a new automation in `automations.yaml` (`v9_sleep_priority_interlock`) that forces the Living Room unit off if it is actively heating while the Master Bedroom requires cooling, provided the Living Room temperature is above 60°F.

---
*PR created automatically by Jules for task [5416989769855032051](https://jules.google.com/task/5416989769855032051) started by @ManlyRedfish*