### PR TITLE
Add Event Journal observer automations and file-based logging infrastructure

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -1482,3 +1482,138 @@
           (setpoint {{ setpoint }}°F, outdoor
           {{ states('sensor.deck_temperature_truth') }}°F)
         entity_id: "{{ entity }}"
+
+# =============================================================================
+# SECTION 12: EVENT JOURNAL OBSERVER (PHASE 1A)
+# =============================================================================
+# ⚠️  Observability-only. These automations only append event rows and do not
+#     control HVAC devices. Section 3 WAF automation remains the timer owner.
+# =============================================================================
+
+- id: ej_hvac_mode_changed
+  alias: "EJ: HVAC Mode Changed"
+  mode: queued
+  trigger:
+    - platform: state
+      entity_id:
+        - climate.living_room_air
+        - climate.master_bedroom_air
+        - climate.lincoln_air
+        - climate.lilly_air
+  condition:
+    - condition: template
+      value_template: >-
+        {{ trigger.from_state is not none and trigger.to_state is not none and trigger.from_state.state != trigger.to_state.state }}
+  action:
+    - action: script.log_event
+      data:
+        event_type: hvac_mode_changed
+        entity_id: "{{ trigger.entity_id }}"
+        zone: >-
+          {% if 'living_room' in trigger.entity_id %}living_room{% elif 'master' in trigger.entity_id %}master{% elif 'lincoln' in trigger.entity_id %}lincoln{% elif 'lilly' in trigger.entity_id %}lilly{% else %}system{% endif %}
+        old_state: "{{ trigger.from_state.state }}"
+        new_state: "{{ trigger.to_state.state }}"
+        actual_mode_after: "{{ trigger.to_state.state }}"
+        actual_setpoint_after: "{{ trigger.to_state.attributes.temperature | default('') }}"
+        actor: observer
+        reason: state_trigger
+        source_automation: automation.ej_hvac_mode_changed
+
+- id: ej_setpoint_changed
+  alias: "EJ: Setpoint Changed"
+  mode: queued
+  trigger:
+    - platform: state
+      entity_id:
+        - climate.living_room_air
+        - climate.master_bedroom_air
+        - climate.lincoln_air
+        - climate.lilly_air
+      attribute: temperature
+  condition:
+    - condition: template
+      value_template: >-
+        {{ trigger.from_state is not none and trigger.to_state is not none and trigger.from_state.attributes.temperature != trigger.to_state.attributes.temperature }}
+  action:
+    - action: script.log_event
+      data:
+        event_type: setpoint_changed
+        entity_id: "{{ trigger.entity_id }}"
+        zone: >-
+          {% if 'living_room' in trigger.entity_id %}living_room{% elif 'master' in trigger.entity_id %}master{% elif 'lincoln' in trigger.entity_id %}lincoln{% elif 'lilly' in trigger.entity_id %}lilly{% else %}system{% endif %}
+        old_state: "{{ trigger.from_state.attributes.temperature | default('') }}"
+        new_state: "{{ trigger.to_state.attributes.temperature | default('') }}"
+        actual_mode_after: "{{ trigger.to_state.state }}"
+        actual_setpoint_after: "{{ trigger.to_state.attributes.temperature | default('') }}"
+        actor: observer
+        reason: attribute_temperature_trigger
+        source_automation: automation.ej_setpoint_changed
+
+- id: ej_manual_override_detected
+  alias: "EJ: Manual Override Detected"
+  mode: queued
+  trigger:
+    - platform: state
+      entity_id:
+        - climate.living_room_air
+        - climate.master_bedroom_air
+        - climate.lincoln_air
+        - climate.lilly_air
+      attribute: temperature
+  condition:
+    - condition: template
+      value_template: >-
+        {{ trigger.from_state is not none and trigger.to_state is not none and trigger.to_state.context is not none and trigger.to_state.context.parent_id is none and trigger.from_state.attributes.temperature != trigger.to_state.attributes.temperature }}
+  action:
+    - action: script.log_event
+      data:
+        event_type: manual_override_detected
+        entity_id: "{{ trigger.entity_id }}"
+        zone: >-
+          {% if 'living_room' in trigger.entity_id %}living_room{% elif 'master' in trigger.entity_id %}master{% elif 'lincoln' in trigger.entity_id %}lincoln{% elif 'lilly' in trigger.entity_id %}lilly{% else %}system{% endif %}
+        old_state: "{{ trigger.from_state.attributes.temperature | default('') }}"
+        new_state: "{{ trigger.to_state.attributes.temperature | default('') }}"
+        actual_mode_after: "{{ trigger.to_state.state }}"
+        actual_setpoint_after: "{{ trigger.to_state.attributes.temperature | default('') }}"
+        actor: human
+        reason: setpoint_change_no_parent_context
+        source_automation: automation.ej_manual_override_detected
+
+- id: ej_waf_started
+  alias: "EJ: WAF Started"
+  mode: queued
+  trigger:
+    - platform: state
+      entity_id: timer.manual_hvac_override
+      to: active
+  action:
+    - action: script.log_event
+      data:
+        event_type: waf_started
+        entity_id: timer.manual_hvac_override
+        zone: system
+        old_state: "{{ trigger.from_state.state if trigger.from_state is not none else '' }}"
+        new_state: "{{ trigger.to_state.state if trigger.to_state is not none else '' }}"
+        actor: waf_watcher
+        reason: timer_active
+        source_automation: automation.ej_waf_started
+
+- id: ej_waf_expired
+  alias: "EJ: WAF Expired"
+  mode: queued
+  trigger:
+    - platform: state
+      entity_id: timer.manual_hvac_override
+      from: active
+      to: idle
+  action:
+    - action: script.log_event
+      data:
+        event_type: waf_expired
+        entity_id: timer.manual_hvac_override
+        zone: system
+        old_state: "{{ trigger.from_state.state if trigger.from_state is not none else '' }}"
+        new_state: "{{ trigger.to_state.state if trigger.to_state is not none else '' }}"
+        actor: waf_watcher
+        reason: timer_idle
+        source_automation: automation.ej_waf_expired

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1060,3 +1060,61 @@ sensor:
 # - sensor.office_temperature_control
 # - sensor.laundry_temperature_control
 # - sensor.deck_temperature_control
+# =============================================================================
+# SECTION 13: EVENT JOURNAL INFRASTRUCTURE (PHASE 1A)
+# =============================================================================
+# ⚠️  Observability-only. Do not add duplicate top-level notify: or script:
+#     blocks elsewhere in this file; extend these blocks only.
+# ⚠️  /config/logs/ must exist before Home Assistant restart:
+#     run `mkdir -p /config/logs` on the HA host.
+# =============================================================================
+
+notify:
+  - name: event_journal
+    platform: file
+    filename: /config/logs/event_journal.csv
+    timestamp: false
+
+script:
+  log_event:
+    alias: "Log Event"
+    description: "Append a structured Phase 1A event row to /config/logs/event_journal.csv"
+    mode: queued
+    fields:
+      event_type:
+        description: "Event type"
+      entity_id:
+        description: "Primary entity id"
+      zone:
+        description: "Zone label"
+      old_state:
+        description: "Prior state"
+      new_state:
+        description: "New state"
+      actor:
+        description: "Event actor"
+      reason:
+        description: "Reason tag"
+      requested_mode:
+        description: "Requested hvac mode"
+      requested_setpoint:
+        description: "Requested setpoint"
+      requested_fan_mode:
+        description: "Requested fan mode"
+      actual_mode_after:
+        description: "Actual hvac mode after event"
+      actual_setpoint_after:
+        description: "Actual setpoint after event"
+      supervisor_branch:
+        description: "Supervisor branch label"
+      source_automation:
+        description: "Source automation id"
+      correlation_id:
+        description: "Correlation id"
+      notes:
+        description: "Additional notes"
+    sequence:
+      - action: notify.event_journal
+        data:
+          message: >-
+            {{ now().isoformat() }},{{ event_type | default('') }},{{ entity_id | default('') }},{{ zone | default('') }},{{ old_state | default('') }},{{ new_state | default('') }},{{ requested_mode | default('') }},{{ requested_setpoint | default('') }},{{ requested_fan_mode | default('') }},{{ actual_mode_after | default('') }},{{ actual_setpoint_after | default('') }},{{ actor | default('') }},{{ reason | default('') }},{{ supervisor_branch | default('') }},{{ states('input_select.hvac_season_mode') if states('input_select.hvac_season_mode') not in ['unknown', 'unavailable'] else '' }},{{ states('timer.manual_hvac_override') if states('timer.manual_hvac_override') not in ['unknown', 'unavailable'] else '' }},{{ 'true' if states('timer.manual_hvac_override') == 'active' else 'false' }},{{ source_automation | default('') }},{{ correlation_id | default('') }},{{ notes | default('') }}


### PR DESCRIPTION
### Motivation

- Add observability-only automations to capture HVAC mode, setpoint, manual override and WAF timer events for an event journal without changing device control.
- Provide a single append-only file sink for structured event rows so phase 1A events can be recorded centrally in `/config/logs/event_journal.csv`.
- Surface contextual information (zone, actor, reason, before/after states) for later analysis and correlation of HVAC events.

### Description

- Add Section 12 observer automations (`ej_hvac_mode_changed`, `ej_setpoint_changed`, `ej_manual_override_detected`, `ej_waf_started`, `ej_waf_expired`) that trigger on `climate.*` state/attribute changes and the `timer.manual_hvac_override` and call `script.log_event` with structured parameters.
- Add Section 13 event journal infrastructure: a `notify.event_journal` file platform that writes to `/config/logs/event_journal.csv` and a queued `script.log_event` that accepts typed fields and assembles a CSV row to send to `notify.event_journal`.
- Add comments and warnings about observability-only behavior and the requirement that `/config/logs/` exist before HA restart; keep prior sensor entries intact with a small comment/whitespace adjustment.

### Testing

- Home Assistant configuration check (`hass --script check_config`) was run and passed for the updated YAML.
- `script.log_event` was exercised by the new automations in a dev environment to produce CSV rows in `/config/logs/event_journal.csv` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f501e6e498832384ca7420efe2bb71)