### PR TITLE
Fix script.log_event notify call to use notify.send_message with target

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1122,7 +1122,9 @@ script:
       notes:
         description: "Additional notes"
     sequence:
-      - action: notify.event_journal
+      - action: notify.send_message
+        target:
+          entity_id: notify.event_journal
         data:
           message: >-
             {{ now().isoformat() }},{{ event_type | default('') }},{{ entity_id | default('') }},{{ zone | default('') }},{{ old_state | default('') }},{{ new_state | default('') }},{{ requested_mode | default('') }},{{ requested_setpoint | default('') }},{{ requested_fan_mode | default('') }},{{ actual_mode_after | default('') }},{{ actual_setpoint_after | default('') }},{{ actor | default('') }},{{ reason | default('') }},{{ supervisor_branch | default('') }},{{ states('input_select.hvac_season_mode') if states('input_select.hvac_season_mode') not in ['unknown', 'unavailable'] else '' }},{{ states('timer.manual_hvac_override') if states('timer.manual_hvac_override') not in ['unknown', 'unavailable'] else '' }},{{ 'true' if states('timer.manual_hvac_override') == 'active' else 'false' }},{{ source_automation | default('') }},{{ correlation_id | default('') }},{{ notes | default('') }}


### PR DESCRIPTION
### Motivation
- Home Assistant rejects a direct `notify.event_journal` action in this context, so the script must call the generic `notify.send_message` service with an explicit `target.entity_id` to preserve the CSV telemetry pipeline.

### Description
- Replaced the `script.log_event` sequence action `notify.event_journal` with `notify.send_message` and added `target: entity_id: notify.event_journal`, preserving the exact CSV message template and leaving all surrounding automations and observability sections untouched.

### Testing
- The file was updated and committed successfully (`git commit`), the changed lines were displayed to verify the patch, an attempted YAML parse using `python -c "import yaml; yaml.safe_load(open('configuration.yaml'))"` failed due to missing `PyYAML` in this environment, and a PR record was created; please run Home Assistant’s `Developer Tools → YAML → Check Configuration` and restart HA to complete runtime validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f64edcfb508323a1ebf663e7b71e48)