### PR TITLE
Fix event_journal sink: use shell_command append backend

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1077,11 +1077,9 @@ sensor:
 #     run `mkdir -p /config/logs` on the HA host.
 # =============================================================================
 
-notify:
-  - name: event_journal
-    platform: file
-    filename: /config/logs/event_journal.csv
-    timestamp: false
+shell_command:
+  event_journal_append: >-
+    printf '%s\n' "$(echo '{{ row | default("") | b64encode }}' | base64 -d)" >> /config/logs/event_journal.csv
 
 script:
   log_event:
@@ -1122,11 +1120,9 @@ script:
       notes:
         description: "Additional notes"
     sequence:
-      - action: notify.send_message
-        target:
-          entity_id: notify.event_journal
+      - action: shell_command.event_journal_append
         data:
-          message: >-
+          row: >-
             {{ now().isoformat() }},{{ event_type | default('') }},{{ entity_id | default('') }},{{ zone | default('') }},{{ old_state | default('') }},{{ new_state | default('') }},{{ requested_mode | default('') }},{{ requested_setpoint | default('') }},{{ requested_fan_mode | default('') }},{{ actual_mode_after | default('') }},{{ actual_setpoint_after | default('') }},{{ actor | default('') }},{{ reason | default('') }},{{ supervisor_branch | default('') }},{{ states('input_select.hvac_season_mode') if states('input_select.hvac_season_mode') not in ['unknown', 'unavailable'] else '' }},{{ states('timer.manual_hvac_override') if states('timer.manual_hvac_override') not in ['unknown', 'unavailable'] else '' }},{{ 'true' if states('timer.manual_hvac_override') == 'active' else 'false' }},{{ source_automation | default('') }},{{ correlation_id | default('') }},{{ notes | default('') }}
 
 # =============================================================================


### PR DESCRIPTION
### Motivation
- Home Assistant did not create `notify.event_journal` from the `notify: platform: file` config so `script.log_event` could not persist rows to `/config/logs/event_journal.csv`, breaking the event journal sink.
- The intent is to preserve the existing public interface (`script.log_event` and all observer callers) while changing only the backend so rows reliably append on HA OS.
- This change avoids touching Section 2 (Main Supervisor), Section 3 (Safety Gates), Section 12 observer automations, or Section 14 LR boost behavior, and preserves the exact 20-column CSV schema and `script.log_event` field names.
- Regression risk: the new `shell_command` requires that `/config/logs` exist and that HA OS permits `shell_command` to append the file; the implementation uses base64-encoded payloads to avoid quoting/escaping regressions.

### Description
- Replaced the `notify: platform: file` sink in Section 13 with a new `shell_command.event_journal_append` that appends a decoded, newline-terminated row to `/config/logs/event_journal.csv`.
- Updated `script.log_event` to call `shell_command.event_journal_append` and pass the full CSV row as the `row` parameter instead of using `notify.send_message`, preserving the exact column order and all `script.log_event` fields.
- No other sections or files were modified; the only file changed is `configuration.yaml` (Section 13).  The output path remains `/config/logs/event_journal.csv`.
- The append implementation encodes the row payload via base64 in the template and decodes it in the shell command to avoid CSV escaping/quoting issues on the HA host.

### Testing
- Searched and verified replacements with pattern checks (`rg`) to confirm `notify.event_journal` and the old `platform: file` sink were removed and `event_journal_append` plus `log_event` references exist in `configuration.yaml` (search succeeded).
- Validated YAML syntax by loading `configuration.yaml` with Ruby YAML parser which returned `YAML_OK` (parsing succeeded).
- Confirmed only `configuration.yaml` was modified in the change set (repository status/commit showed one file changed).
- Manual runtime validation steps to run after deploying the change (not automated): call `script.log_event` from Developer Tools → Actions with a test payload and then verify the file with `tail -n 5 /config/logs/event_journal.csv` to confirm a new CSV row appears.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6887680bc832394be7124889d45ec)