### PR TITLE
Fix event_journal shell_command to remove unsupported Jinja b64encode

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1079,7 +1079,7 @@ sensor:
 
 shell_command:
   event_journal_append: >-
-    printf '%s\n' "$(echo '{{ row | default("") | b64encode }}' | base64 -d)" >> /config/logs/event_journal.csv
+    printf '%s\n' '{{ row | default("") | replace("'", "'\"'\"'") }}' >> /config/logs/event_journal.csv
 
 script:
   log_event:


### PR DESCRIPTION
### Motivation
- The `shell_command.event_journal_append` used the `b64encode` Jinja filter which is not available in Home Assistant templates, causing a `TemplateAssertionError` that prevented event rows from being appended to `/config/logs/event_journal.csv`.

### Description
- Updated `configuration.yaml` (Section 13 event journal) to replace the failing template with a Jinja-compatible direct append: `printf '%s\n' '{{ row | default("") | replace("'", "'\"'\"'") }}' >> /config/logs/event_journal.csv`, which safely escapes single quotes for the current CSV row format and restores the append path.

### Testing
- No automated Home Assistant configuration checks were run in this environment; please run `Developer Tools → YAML → Check Configuration` in Home Assistant and restart if it passes, then trigger a known event and confirm a new row is appended to `/config/logs/event_journal.csv`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6970952208323acb8dab5b9547960)