### PR TITLE
fix: restore notify.file event journal sink (stop the shell_command loop)

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1077,9 +1077,11 @@ sensor:
 #     run `mkdir -p /config/logs` on the HA host.
 # =============================================================================
 
-shell_command:
-  event_journal_append: >-
-    printf '%s\n' '{{ row | default("") | replace("'", "'\"'\"'") }}' >> /config/logs/event_journal.csv
+notify:
+  - name: event_journal
+    platform: file
+    filename: /config/logs/event_journal.csv
+    timestamp: false
 
 script:
   log_event:
@@ -1120,9 +1122,9 @@ script:
       notes:
         description: "Additional notes"
     sequence:
-      - action: shell_command.event_journal_append
+      - action: notify.event_journal
         data:
-          row: >-
+          message: >-
             {{ now().isoformat() }},{{ event_type | default('') }},{{ entity_id | default('') }},{{ zone | default('') }},{{ old_state | default('') }},{{ new_state | default('') }},{{ requested_mode | default('') }},{{ requested_setpoint | default('') }},{{ requested_fan_mode | default('') }},{{ actual_mode_after | default('') }},{{ actual_setpoint_after | default('') }},{{ actor | default('') }},{{ reason | default('') }},{{ supervisor_branch | default('') }},{{ states('input_select.hvac_season_mode') if states('input_select.hvac_season_mode') not in ['unknown', 'unavailable'] else '' }},{{ states('timer.manual_hvac_override') if states('timer.manual_hvac_override') not in ['unknown', 'unavailable'] else '' }},{{ 'true' if states('timer.manual_hvac_override') == 'active' else 'false' }},{{ source_automation | default('') }},{{ correlation_id | default('') }},{{ notes | default('') }}
 
 # =============================================================================


### PR DESCRIPTION
## Root Cause

The event journal loop was caused by a single wrong line in PR #22.

**PR #19** had the correct design:
```yaml
action: notify.event_journal
data:
  message: "{{ csv_row }}"
```

**PR #22** broke it by changing to:
```yaml
action: notify.send_message
target:
  entity_id: notify.event_journal   # ← WRONG: notify.event_journal is a service, not an entity
```

This caused HA to reject the call silently. PRs #23 and #24 then tried to replace the working `notify.file` sink with `shell_command`, producing `b64encode` errors and printf quoting failures. The original approach was never broken — only the call site was wrong.

**The operator's original diagnosis** ("notify.event_journal did not appear in States") was a misdirection: `notify.event_journal` is a **service/action**, not an entity. It will never appear in Developer Tools → States. It lives under Developer Tools → Actions.

## What This PR Changes

`configuration.yaml` only — 7 lines changed, no automations.yaml touch:

| Before | After |
|---|---|
| `shell_command: event_journal_append: printf ...` | `notify: - name: event_journal platform: file ...` |
| `action: shell_command.event_journal_append` | `action: notify.event_journal` |
| `data: row: >- ...` | `data: message: >- ...` |

The 20-column CSV template is **unchanged**.

## Regression Check

- Section 2 Main Supervisor: **untouched**
- Section 3 Safety Gates: **untouched**
- Section 12 Observer automations: **untouched**
- Section 14 LR Boost: **untouched**
- automations.yaml: **untouched**
- 20-column event schema: **preserved**
- V8.4 LR boost helpers: **untouched**

## Critical Operator Note Before Merging

**`notify.event_journal` is a service, not an entity.**

After merging and restarting HA (full restart required — not just notify reload):
1. Go to Developer Tools → Actions (NOT States)
2. Search for `notify.event_journal`
3. If it appears, the sink is registered and ready

Do NOT look for it in States — it will never appear there.

## Test Plan

**Step 1 — Validate config before restart**
```
Settings → System → Check Configuration
```
Must pass with no errors.

**Step 2 — Full HA restart**
```
Settings → System → Restart Home Assistant
```
(Not just reload — `notify` platform requires full restart to register the service.)

**Step 3 — Verify service registered**
```
Developer Tools → Actions → search "event_journal"
```
`notify.event_journal` should appear.

**Step 4 — Test call from Developer Tools**
```yaml
action: script.log_event
data:
  event_type: test_event
  actor: manual_test
  reason: verification
  zone: living_room
```

**Step 5 — Verify file**
```bash
# From HA terminal / SSH add-on:
ls -la /config/logs/event_journal.csv
tail -5 /config/logs/event_journal.csv
```
Expected: a CSV row with current timestamp, `test_event`, `manual_test` in the actor column.

**Step 6 — If file does not appear**
Check HA logs for errors matching `notify` or `event_journal`:
```
Settings → System → Logs → search "event_journal"
```

## Rollback

Disable or remove the `notify:` block and comment out the `script.log_event` sequence action. No other file changes needed. All HVAC control continues to operate normally regardless of whether the event journal sink works.

https://claude.ai/code/session_01BqHTVVsaH7sZDVuCjsE9en

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqHTVVsaH7sZDVuCjsE9en)_