### PR TITLE
fix: contain failing event journal (no-op script + disable observers)

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -1492,6 +1492,7 @@
 
 - id: ej_hvac_mode_changed
   alias: "EJ: HVAC Mode Changed"
+  initial_state: false
   mode: queued
   trigger:
     - platform: state
@@ -1521,6 +1522,7 @@
 
 - id: ej_setpoint_changed
   alias: "EJ: Setpoint Changed"
+  initial_state: false
   mode: queued
   trigger:
     - platform: state
@@ -1551,6 +1553,7 @@
 
 - id: ej_manual_override_detected
   alias: "EJ: Manual Override Detected"
+  initial_state: false
   mode: queued
   trigger:
     - platform: state
@@ -1581,6 +1584,7 @@
 
 - id: ej_waf_started
   alias: "EJ: WAF Started"
+  initial_state: false
   mode: queued
   trigger:
     - platform: state
@@ -1600,6 +1604,7 @@
 
 - id: ej_waf_expired
   alias: "EJ: WAF Expired"
+  initial_state: false
   mode: queued
   trigger:
     - platform: state

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1069,24 +1069,32 @@ sensor:
 # - sensor.laundry_temperature_control
 # - sensor.deck_temperature_control
 # =============================================================================
-# SECTION 13: EVENT JOURNAL INFRASTRUCTURE (PHASE 1A)
+# SECTION 13: EVENT JOURNAL INFRASTRUCTURE (PHASE 1A) — DISABLED
 # =============================================================================
+# ⚠️  STATUS: BLOCKED — sink unavailable on this HA runtime.
+#     PR #19 (notify.file): notify.event_journal service did not register.
+#     PR #22 (notify.send_message): wrong API for service-style notify.
+#     PR #23 (shell_command + b64encode): Jinja2 b64encode filter missing.
+#     PR #24 (shell_command printf): file never created in live HA OS.
+#     PR #25 (notify.file restored): "Action notify.event_journal not found"
+#                                    after full restart — does not register.
+#
+#     Until a proven HA-2026 compatible sink is identified, the file-based
+#     event journal is OFF. script.log_event is preserved as a safe no-op
+#     so observers and Section 14 boost callers do not generate errors.
+#
+#     Section 12 EJ observer automations are disabled at the automation
+#     level (initial_state: false) for defense in depth.
+#
 # ⚠️  Observability-only. Do not add duplicate top-level notify: or script:
 #     blocks elsewhere in this file; extend these blocks only.
-# ⚠️  /config/logs/ must exist before Home Assistant restart:
-#     run `mkdir -p /config/logs` on the HA host.
+# ⚠️  /config/logs/ may be removed once the sink is permanently retired.
 # =============================================================================
-
-notify:
-  - name: event_journal
-    platform: file
-    filename: /config/logs/event_journal.csv
-    timestamp: false
 
 script:
   log_event:
-    alias: "Log Event"
-    description: "Append a structured Phase 1A event row to /config/logs/event_journal.csv"
+    alias: "Log Event (no-op)"
+    description: "Phase 1A event sink is currently disabled. Calls succeed silently with no file I/O."
     mode: queued
     fields:
       event_type:
@@ -1122,10 +1130,7 @@ script:
       notes:
         description: "Additional notes"
     sequence:
-      - action: notify.event_journal
-        data:
-          message: >-
-            {{ now().isoformat() }},{{ event_type | default('') }},{{ entity_id | default('') }},{{ zone | default('') }},{{ old_state | default('') }},{{ new_state | default('') }},{{ requested_mode | default('') }},{{ requested_setpoint | default('') }},{{ requested_fan_mode | default('') }},{{ actual_mode_after | default('') }},{{ actual_setpoint_after | default('') }},{{ actor | default('') }},{{ reason | default('') }},{{ supervisor_branch | default('') }},{{ states('input_select.hvac_season_mode') if states('input_select.hvac_season_mode') not in ['unknown', 'unavailable'] else '' }},{{ states('timer.manual_hvac_override') if states('timer.manual_hvac_override') not in ['unknown', 'unavailable'] else '' }},{{ 'true' if states('timer.manual_hvac_override') == 'active' else 'false' }},{{ source_automation | default('') }},{{ correlation_id | default('') }},{{ notes | default('') }}
+      - stop: "Event journal sink disabled — see Section 13 header for status"
 
 # =============================================================================
 # SECTION 14 HELPERS: V8.4 LR HEATING RECOVERY BOOST


### PR DESCRIPTION
## 1. Root Cause (Proven by Live Test)

After PR #25 was merged and HA was fully restarted:
- `notify.event_journal` does **not** appear in Developer Tools → Actions
- Calling `script.log_event` returns: **"Action notify.event_journal not found."**
- `/config/logs/event_journal.csv` is never created

**Conclusion:** the legacy `notify:` YAML platform-style file integration does not register on this HA runtime. Five attempts (PRs #19, #22, #23, #24, #25) have proven this. We stop trying. Containment now.

## 2. Containment Strategy

**Stop the bleeding without breaking anything else.**

1. Remove the broken `notify:` block — it produces no service, so deleting it cannot regress anything.
2. Convert `script.log_event` to a safe **no-op** using the `stop:` action. All 16 input fields are preserved so every existing caller (Section 12 observers, Section 14 boost engage/release) continues to call it without error. The call simply returns successfully without writing anywhere.
3. Add `initial_state: false` to all 5 Section 12 EJ observer automations as defense in depth. They will not auto-enable. If a user toggles them on later, the no-op script absorbs the call cleanly.
4. Document the full failure chain of PRs #19, #22, #23, #24, #25 inline in the Section 13 header so the next person does not repeat the loop.

## 3. Files Changed

| File | Change | Lines |
|---|---|---|
| `configuration.yaml` | Remove `notify:` block, no-op `script.log_event`, doc rewrite of Section 13 header | +20 / -15 |
| `automations.yaml` | Add `initial_state: false` to 5 ej_* automations | +5 / -0 |

**Total: +25 / -15**

## 4. Test Plan

**Step 1 — Pre-restart config check**
```
Settings → System → Check Configuration
```
Must pass. The `notify:` block is gone, the script is a no-op — there is nothing to fail-load.

**Step 2 — Full HA restart**
```
Settings → System → Restart Home Assistant
```

**Step 3 — Confirm no Section 13 errors**
```
Settings → System → Logs → search "log_event" or "notify"
```
Should show no errors. The "Action notify.event_journal not found" error should be gone.

**Step 4 — Confirm script is callable and silent**
```
Developer Tools → Actions
```
Call:
```yaml
action: script.log_event
data:
  event_type: containment_test
  actor: manual
  zone: living_room
```
Expected: returns success. No errors. No file created. No log entries from the script itself (the `stop:` action exits cleanly).

**Step 5 — Confirm Section 12 observers are off**
```
Settings → Automations → search "EJ:"
```
All five `EJ: *` automations should show as **disabled** (toggle off).

**Step 6 — Confirm Section 14 boost still works**
Trigger the boost engage path (or wait for a real engagement). Verify in the log book that the boost ran normally. The boost's two `script.log_event` calls now succeed silently — they should not appear as errors.

**Step 7 — Confirm climate control unchanged**
Check that Section 2 Main Supervisor, Section 3 safety gates, Samsung Auto Guardrail, and the heating/cooling deadband operate normally on the next 15-minute supervisor tick. Telemetry to VTherm_Launch_Data_v5 should continue uninterrupted (Section 1 is unaffected).

## 5. Climate Control Untouched — Confirmation

| Section | Status |
|---|---|
| Section 1 (Data Collection / VTherm telemetry) | **Untouched** |
| Section 2 (Main Supervisor V8.3) | **Untouched** |
| Section 3 (Safety Gates: WAF, ceiling, runaway, floor, sleep priority) | **Untouched** |
| Section 4 (Ghost Assassin) | **Untouched** |
| Section 5 (Auto Season Mode) | **Untouched** |
| Section 6 (Fan Destratification) | **Untouched** |
| Section 7 (Solar Shade / Harvest) | **Untouched** |
| Section 8 (Samsung Auto Guardrail) | **Untouched** |
| Section 9 (Truth Sensor Health Alert) | **Untouched** |
| Section 11 (HVAC Transition Logger) | **Untouched** |
| Section 14 (V8.4 LR Heating Recovery Boost) | **Untouched** — calls no-op script silently |
| Truth sensors (V3.1) | **Untouched** |
| Compressor cooldown timers | **Untouched** |
| LR boost helpers (`input_boolean.lr_heating_recovery_boost_active`, `timer.lr_heating_recovery_boost_max_runtime`) | **Untouched** |
| 20-column event schema | **Preserved** in script field definitions |

## Rollback

To re-enable the journal once a working sink is identified:
1. Replace the `stop:` action in `script.log_event` with a call to the new working sink.
2. Remove `initial_state: false` from the 5 ej_* automations (or toggle them on in the UI).
3. Restart HA.

No automation rewrites needed.

## What This PR Does NOT Try To Do

This PR does **not** propose another sink mechanism. Five mechanisms have failed; the next attempt should be made deliberately, after research into what actually works on the deployed HA version (likely `homeassistant.update_entity` + a counter, or an InfluxDB add-on, or a custom integration). That investigation is out of scope for this containment.

https://claude.ai/code/session_01BqHTVVsaH7sZDVuCjsE9en

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqHTVVsaH7sZDVuCjsE9en)_