### PR TITLE
🧹 Code Health: Remove deprecated VTherm comment from configuration.yaml

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1060,14 +1060,6 @@ sensor:
         time_constant: 10
         precision: 2
 
-# VTherm should point at:
-# - sensor.living_room_temperature_control
-# - sensor.master_bedroom_temperature_control
-# - sensor.lincoln_s_room_temperature_control
-# - sensor.lilly_s_room_temperature_control
-# - sensor.office_temperature_control
-# - sensor.laundry_temperature_control
-# - sensor.deck_temperature_control
 # =============================================================================
 # SECTION 13: EVENT JOURNAL INFRASTRUCTURE (PHASE 1A) — DISABLED
 # =============================================================================


### PR DESCRIPTION
🎯 **What:** Removed the deprecated `# VTherm should point at:` comment block and its associated sensor list from `configuration.yaml`.
💡 **Why:** `VTherm` is deprecated in the system (per `AGENTS.md` and `truth_sensor_architecture.md`), so these comments are misleading and no longer necessary. Removing them improves the codebase's accuracy and readability. The actual sensor wrappers were kept as they might still be used for compatibility.
✅ **Verification:** Validated the `configuration.yaml` syntax with Ruby. Verified the diff only changed comments.
✨ **Result:** Cleaned up outdated documentation while preserving all functionality.

---
*PR created automatically by Jules for task [8700275514835824858](https://jules.google.com/task/8700275514835824858) started by @ManlyRedfish*