### PR TITLE
🧹 [Code Health] Remove ORPHANED Pre-Cool Latch section from automations.yaml

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -14,7 +14,6 @@
 #   1.  DATA COLLECTION (v5 tracker — Semantic Heritage Schema)
 #   2.  MAIN SUPERVISOR (V8.2 Deadband + V8.3 LR Heating Deadband)
 #   3.  SAFETY GATES (runaway cutoff, emergency floor, ceiling, override)
-#   3B. PRE-COOL LATCH (ORPHANED — helper retained, nothing reads it)
 #   4.  GHOST ASSASSIN (Lincoln phantom heat kill)
 #   5.  AUTO SEASON MODE (deck temp → season switching)
 #   6.  SHOULDER SEASON FAN DESTRATIFICATION (Priority 2 Airflow Mixing)
@@ -27,7 +26,6 @@
 # DEPENDENCIES (helpers that must exist):
 #   - input_select.hvac_season_mode (heating / shoulder / cooling)
 #   - input_boolean.night_mode_lr_primary (on = Claude night mode)
-#   - input_boolean.precool_active (orphaned in V8.2 but still toggled by 3B)
 #   - timer.manual_hvac_override (1 hour default)
 #   - timer.shade_manual_override (2 hour default)
 #   - input_boolean.away_mode (away/vacation — relaxes all targets)
@@ -763,82 +761,6 @@
   action:
     - action: timer.start
       target: { entity_id: timer.manual_hvac_override }
-
-# =============================================================================
-# SECTION 3B: PRE-COOL LATCH (ORPHANED)
-# =============================================================================
-# ⚠️  NOTE: V8.1 and V8.2 cooling branches do not reference precool_active.
-#     This section is ORPHANED but HARMLESS — it toggles a boolean that
-#     nothing reads. Kept intact to avoid breaking the helper entity.
-#     Can be disabled in the HA UI if desired.
-# =============================================================================
-
-- id: v8_precool_latch
-  alias: "V8: Pre-Cool Latch (ORPHANED — not read by V8.2)"
-  mode: single
-  trigger:
-    - platform: time
-      at: "13:00:00"
-      id: start_window
-    - platform: numeric_state
-      entity_id: sensor.deck_temperature_truth
-      above: 78
-      id: start_window
-    - platform: time
-      at: "17:00:00"
-      id: end_window
-    - platform: numeric_state
-      entity_id: sensor.living_room_temperature_truth
-      below: 68
-      id: house_too_cold
-  condition: []
-  action:
-    - choose:
-        - conditions:
-            - condition: trigger
-              id: start_window
-            - condition: state
-              entity_id: input_select.hvac_season_mode
-              state: "cooling"
-            - condition: state
-              entity_id: timer.manual_hvac_override
-              state: "idle"
-            - condition: state
-              entity_id: input_boolean.away_mode
-              state: "off"
-            - condition: time
-              after: "12:59:59"
-              before: "17:00:00"
-            - condition: numeric_state
-              entity_id: sensor.deck_temperature_truth
-              above: 78
-          sequence:
-            - action: input_boolean.turn_on
-              target:
-                entity_id: input_boolean.precool_active
-
-        - conditions:
-            - condition: trigger
-              id: end_window
-          sequence:
-            - action: input_boolean.turn_off
-              target:
-                entity_id: input_boolean.precool_active
-
-        - conditions:
-            - condition: trigger
-              id: house_too_cold
-            - condition: state
-              entity_id: input_select.hvac_season_mode
-              state: "cooling"
-            - condition: state
-              entity_id: input_boolean.precool_active
-              state: "on"
-          sequence:
-            - action: input_boolean.turn_off
-              target:
-                entity_id: input_boolean.precool_active
-
 
 # =============================================================================
 # SECTION 4: GHOST ASSASSIN


### PR DESCRIPTION
🎯 **What:** Removed the code block for the `V8: Pre-Cool Latch` in `automations.yaml` (Section 3B) which was labeled as orphaned and unread by current V8.2 configurations. Removed references to `SECTION 3B` and `input_boolean.precool_active` in the file header documentation.
💡 **Why:** This improves maintainability and readability by eliminating duplicate and dead code, as well as keeping the documentation up-to-date with the file content.
✅ **Verification:** Validated that the file still has perfectly correct syntax using `ruby -e "require 'yaml'; YAML.load_file('automations.yaml')"`. Ran Code Review which returned "#Correct#".
✨ **Result:** Cleaned up `automations.yaml` from obsolete sections without changing system behavior, adhering to the codebase requirements.

---
*PR created automatically by Jules for task [14003544715140134083](https://jules.google.com/task/14003544715140134083) started by @ManlyRedfish*