### PR TITLE
docs: reconcile runtime docs after event journal containment

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -1406,10 +1406,18 @@
         entity_id: "{{ entity }}"
 
 # =============================================================================
-# SECTION 12: EVENT JOURNAL OBSERVER (PHASE 1A)
+# SECTION 12: EVENT JOURNAL OBSERVER (PHASE 1A) — DISABLED
 # =============================================================================
 # ⚠️  Observability-only. These automations only append event rows and do not
 #     control HVAC devices. Section 3 WAF automation remains the timer owner.
+#
+# ⚠️  CONTAINED post-PR #26: all five EJ observers below carry
+#     initial_state: false, and script.log_event in configuration.yaml
+#     Section 13 is a safe no-op. notify.event_journal never registered
+#     on this HA build (PRs #19/#22/#23/#24/#25 failed to land a sink).
+#     Do NOT re-enable these observers and do NOT introduce another sink
+#     without first satisfying the live-spike rules in
+#     docs/postmortems/2026-05-02_event_journal_containment.md §6.
 # =============================================================================
 
 - id: ej_hvac_mode_changed

--- a/docs/5_runtime_layer.md
+++ b/docs/5_runtime_layer.md
@@ -113,10 +113,11 @@ The live truth runtime includes:
 The runtime depends on several helpers. The live automations file explicitly lists helper dependencies including:
 - `input_select.hvac_season_mode`
 - `input_boolean.night_mode_lr_primary`
-- `input_boolean.precool_active` (explicitly noted as orphaned in V8.2 but still toggled by Section 3B)
 - `timer.manual_hvac_override`
 - `timer.shade_manual_override`
 - `input_boolean.away_mode`
+- `input_boolean.lr_heating_recovery_boost_active` (Section 14 V8.4 LR boost latch)
+- `timer.lr_heating_recovery_boost_max_runtime` (Section 14 V8.4 LR boost timeout, `restore: true`)
 *(These helpers are not just UI artifacts. They are part of the live control path and must exist for runtime behavior to function properly.)*
 
 ### 6.6 Evidence / Runtime Observation Components
@@ -143,9 +144,11 @@ The live V8.3 runtime does not implement explicit multi-head capacity arbitratio
 
 ### 7.4 Orphaned / Transitional Runtime Pieces
 The live file explicitly identifies:
-- **PRE-COOL LATCH:** (ORPHANED — helper retained, nothing reads it)
+- **PRE-COOL LATCH (Section 3B):** (REMOVED in PR #28 — the orphaned Section 3B `v8_precool_latch` automation was deleted from `automations.yaml`. The `input_boolean.precool_active` helper is no longer toggled or read by any YAML; if it persists as a UI-defined helper it has no remaining writers or readers.)
 - **MASTER PRE-COOL:** (DISABLED — superseded by V8.1/V8.2 cooling branch)
 - **HVAC TRANSITION LOGGER:** (Expanded in V8.3 to capture heating hysteresis transitions)
+- **EVENT JOURNAL (Section 13 + Section 12):** (CONTAINED in PR #26 — `script.log_event` is a safe no-op (`stop:` action), and all five Section 12 EJ observer automations carry `initial_state: false`. The `notify.event_journal` sink never registered on this HA build and PRs #19/#22/#23/#24/#25 failed to land a working sink. Do not re-enable observers and do not introduce another sink without first satisfying the live-spike rules in `docs/postmortems/2026-05-02_event_journal_containment.md`. Section 14 calls into the no-op script and is unaffected.)
+- **V8.4 LR HEATING RECOVERY BOOST (Section 14):** (DEPLOYED, NOT YET TRIGGERED — engage and release automations are enabled and the helpers (`input_boolean.lr_heating_recovery_boost_active`, `timer.lr_heating_recovery_boost_max_runtime`) are live, but Living Room truth has not fallen below 64°F in available V5 telemetry, so the engage path has not yet exercised. Validation evidence pipeline is HA Logbook + `VTherm_Launch_Data_v5` + Section 14 traces, per the postmortem §9.)
 *(These are part of the current runtime surface and should not be silently forgotten.)*
 
 ### 7.5 Sensor Exclusion Reality


### PR DESCRIPTION
## Summary

Morning verification audit after last night's event-journal containment and cleanup PRs (#26, #27, #28, #29). This PR aligns the prose layer and one YAML comment header with the runtime state captured by the postmortem; **no runtime behavior changes**.

## Verdict

**Docs need a small PR.** No runtime issues found.

## What changed

### `docs/5_runtime_layer.md`
- **§6.5 (Helper / Memory Components):** removed `input_boolean.precool_active` from the live helper list — Section 3B that toggled it was deleted in PR #28, so the helper is no longer part of the control path. Added the V8.4 LR boost helpers (`input_boolean.lr_heating_recovery_boost_active`, `timer.lr_heating_recovery_boost_max_runtime`) that are now live.
- **§7.4 (Orphaned / Transitional Runtime Pieces):**
  - **PRE-COOL LATCH** entry updated from "ORPHANED — helper retained" to **REMOVED in PR #28**, matching `automations.yaml`.
  - Added **EVENT JOURNAL (Section 13 + Section 12)** entry: CONTAINED in PR #26, `script.log_event` is a no-op, all five EJ observers carry `initial_state: false`, do-not-re-enable rule, pointer to the postmortem.
  - Added **V8.4 LR HEATING RECOVERY BOOST (Section 14)** entry: DEPLOYED, NOT YET TRIGGERED — engage/release automations and helpers are live but LR truth has not fallen below 64°F in available V5 telemetry, so the engage path has not yet exercised.

### `automations.yaml` Section 12 header (comments only)
- Renamed the section header to `EVENT JOURNAL OBSERVER (PHASE 1A) — DISABLED`.
- Added a containment note explicitly listing `initial_state: false`, the no-op `script.log_event`, the failed PR chain (#19/#22/#23/#24/#25), and a do-not-re-enable rule pointing to `docs/postmortems/2026-05-02_event_journal_containment.md` §6.

## Audit answers (1–10)

1. **`configuration.yaml` Section 13 accurately describes EJ as contained/no-op?** Yes — the existing header (added in PR #26) explicitly enumerates all five failed PRs and the no-op posture. No change needed.
2. **`automations.yaml` shows the five EJ observers are disabled and observability-only?** Each automation already has `initial_state: false`, but the Section 12 header read as if it were active. Updated header in this PR.
3. **Any docs still claim the event journal is active?** No live claim; Doc 5 simply did not mention the journal at all. Now it does, in §7.4.
4. **VTherm active/deprecated inconsistency after PR #27?** Doc 1 / Doc 3 / Doc 5 / AGENTS.md / `truth_sensor_architecture.md` are consistent (deprecated; `VTherm_Launch_Data_v5` is just a worksheet name per Doc 5 §6.3 Semantic Heritage Naming Disclaimer). **However**, `configuration.yaml` lines 23, 33, 843–848, and 997 (Sections 10 and 12 Smoothed Sensors) still describe the wrappers as serving "VTherm and the HA UI" or "VTherm / supervisor". These are out of scope for this PR (allowed scope was Section 13 comments only) and are flagged for a future cleanup pass.
5. **Dangling `SECTION 3B` / `input_boolean.precool_active` / `precool_active` / "Pre-Cool Latch" references after PR #28?**
   - `automations.yaml`: clean (PR #28 removed Section 3B and the helper from the dependencies list).
   - `configuration.yaml`: clean (no precool references).
   - `docs/5_runtime_layer.md` §6.5 and §7.4: stale before this PR — fixed here.
   - `docs/event_telemetry_plan.md` line 148 still says `precool_latch_toggled` is "only useful if 3B is reactivated"; this is a planning document already superseded by the postmortem and is out of scope.
6. **Doc 5 needs to mention EJ containment / observers disabled / LR boost pilot pending?** Yes — added in §7.4.
7. **Doc 1 needs an update?** No. V8.3 remains the live control architecture; V8.4 LR boost is a single-room pilot layered on top, not a doctrine change. Per Doc 1 §10 ("update only when a truth has actually changed"), it should remain stable.
8. **Doc 3 needs an anti-regression note for EJ sink loops?** No — the postmortem (added in PR #29) carries seven explicit anti-regression rules, and Doc 3 §4 is reserved for retired *control* approaches, not observability/debugging traps.
9. **YAML comments still saying VTherm should point at sensors / VTherm is active?** No "VTherm should point at" block remains (PR #27 removed it). The Section 10/12 comments in `configuration.yaml` still imply VTherm is part of the live chain — flagged as a finding (out of scope here).
10. **Other code/comment inconsistencies that could mislead future LLM sessions?**
    - `automations.yaml` Section 14 header (line ~1558) says boost cycles "should be evaluated with `event_journal.csv` and Sheets telemetry" — `event_journal.csv` does not exist on this runtime. Out of scope (Section 14 comment edits are not on the allowed change list); flagged for a future pass once an EJ replacement is decided. Postmortem §9 already documents the event-journal-free validation pipeline.
    - Section 10/12 VTherm comments in `configuration.yaml` (see #4/#9 above).

## Confirmation

- **No runtime behavior changed.** All edits are documentation + Section 12 comment text. Both `automations.yaml` and `configuration.yaml` parse cleanly.
- **Section 2 (Main Supervisor) untouched.**
- **Section 3 (Safety Gates) untouched.**
- **Section 14 (V8.4 LR Boost) untouched** — including the line 1558 `event_journal.csv` comment, which is preserved as-is.
- **`script.log_event` body untouched** — still the safe no-op from PR #26.
- **EJ observer `initial_state: false` flags untouched.**
- **No new event-journal sink** introduced; no thresholds or climate behavior modified.

## Test plan

- [x] `python3 -c yaml.safe_load(...)` on both `automations.yaml` and `configuration.yaml` (with a `!secret` pass-through loader): both files parse cleanly.
- [x] `git diff` confirms only Doc 5 §6.5/§7.4 and `automations.yaml` Section 12 header changed; nothing inside Sections 2, 3, or 14 of `automations.yaml`; nothing in Sections 1–12, 13, or 14 of `configuration.yaml`.
- [ ] On next morning operator pass: confirm Doc 5 §7.4 still matches live state (EJ contained, V8.4 not yet triggered). Update if LR boost engages for the first time.

## Morning operator checklist (carry-through from postmortem §7)

1. HA logs clean since last restart (no `Action notify.event_journal not found`, no `script.log_event` errors, no Section 14 errors).
2. All five EJ observers (`EJ: HVAC Mode Changed`, `EJ: Setpoint Changed`, `EJ: Manual Override Detected`, `EJ: WAF Started`, `EJ: WAF Expired`) show **disabled / off**.
3. `script.log_event` no-op returns success in Developer Tools → Actions (alias still reads "Log Event (no-op)").
4. `VTherm_Launch_Data_v5` Sheets row within the last ~20 minutes; column population normal.
5. Section 2 supervisor: Logbook for `climate.*_air` shows the periodic 15-min cadence with no off-storms or rapid mode flips.
6. Section 14 V8.4 LR boost engage + release automations both enabled, last trace (if any) green.
7. If LR truth drops below 64°F today: watch for `input_boolean.lr_heating_recovery_boost_active = on`, `timer.lr_heating_recovery_boost_max_runtime = active`, `climate.living_room_air = heat @ 77°F`. Capture engage/release evidence per postmortem §9.

https://claude.ai/code/session_01Js8o21r6mMHBUk9nWuWwff

---
_Generated by [Claude Code](https://claude.ai/code/session_01Js8o21r6mMHBUk9nWuWwff)_