### PR TITLE
🧹 docs: Remove Deprecated VTherm Reference from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,6 @@ This file contains multiple independent systems:
 
 Key Architectural Notes:
 
-* VTherm has been deprecated.
 * The current architecture uses custom orchestration logic.
 * The system intentionally separates:
 


### PR DESCRIPTION
🎯 **What:** Removed the deprecated reference to VTherm (`* VTherm has been deprecated.`) from the "Key Architectural Notes" section in `AGENTS.md`.
💡 **Why:** The VTherm architecture has been deprecated and its removal is already well-documented. Removing this reference reduces clutter and cleans up outdated documentation to improve readability and maintainability.
✅ **Verification:** Verified via manual inspection and `markdownlint` to ensure the structure remained intact and no unexpected formatting errors were introduced.
✨ **Result:** A cleaner `AGENTS.md` file that solely reflects the current architectural context without obsolete references.

---
*PR created automatically by Jules for task [12696689213625349732](https://jules.google.com/task/12696689213625349732) started by @ManlyRedfish*