### PR TITLE
🧹 Remove deprecated VTherm references in documentation

### DIFF
--- a/truth_sensor_architecture.md
+++ b/truth_sensor_architecture.md
@@ -4,9 +4,9 @@
 
 Moose House Climate uses custom "truth sensors" instead of relying on:
 
-* thermostat-integrated thermistors
-* single room probes
-* naive averaging
+- thermostat-integrated thermistors
+- single room probes
+- naive averaging
 
 The goal is to create stable, evidence-based environmental state estimation suitable for HVAC orchestration and long-term experimentation.
 
@@ -16,18 +16,18 @@ The goal is to create stable, evidence-based environmental state estimation suit
 
 The system prioritizes:
 
-* stability
-* graceful degradation
-* observability
-* telemetry integrity
-* regression resistance
+- stability
+- graceful degradation
+- observability
+- telemetry integrity
+- regression resistance
 
 The system intentionally avoids:
 
-* blind averaging
-* equal-weight assumptions
-* single-point failure dependence
-* hidden filtering logic
+- blind averaging
+- equal-weight assumptions
+- single-point failure dependence
+- hidden filtering logic
 
 ---
 
@@ -46,13 +46,13 @@ Physical Sensors
 
 All truth sensors implement:
 
-* freshness validation
-* stale sensor rejection
-* availability gating
+- freshness validation
+- stale sensor rejection
+- availability gating
 
 Standard staleness threshold:
 
-* 7200 seconds (2 hours)
+- 7200 seconds (2 hours)
 
 Stale sensors are excluded from weighted calculations.
 
@@ -64,15 +64,15 @@ Human-space sensors are prioritized.
 
 Mini-split internal thermistors are intentionally low-weight because:
 
-* they become thermally biased during operation
-* they do not represent occupied room air accurately
-* they over-report during heating
-* they under-report during cooling
+- they become thermally biased during operation
+- they do not represent occupied room air accurately
+- they over-report during heating
+- they under-report during cooling
 
 Typical Samsung weighting:
 
-* 0.20 temperature
-* 0.25 humidity
+- 0.20 temperature
+- 0.25 humidity
 
 ---
 
@@ -80,16 +80,16 @@ Typical Samsung weighting:
 
 Lincoln's room is the pilot environment for:
 
-* outlier rejection
-* contributor diagnostics
-* sensor rejection telemetry
+- outlier rejection
+- contributor diagnostics
+- sensor rejection telemetry
 
 Features:
 
-* base-mean outlier detection
-* 3°F rejection threshold
-* contributor tracking
-* rejected-sensor diagnostics
+- base-mean outlier detection
+- 3°F rejection threshold
+- contributor tracking
+- rejected-sensor diagnostics
 
 Samsung internal sensors are excluded from outlier detection because their thermal bias is intentional and expected.
 
@@ -101,15 +101,15 @@ Truth sensors feed lowpass-filtered smoothing sensors.
 
 Purpose:
 
-* reduce control jitter
-* reduce compressor short cycling
-* stabilize automation behavior
+- reduce control jitter
+- reduce compressor short cycling
+- stabilize automation behavior
 
 Current filter:
 
-* lowpass
-* time_constant=10
-* precision=2
+- lowpass
+- time_constant=10
+- precision=2
 
 ---
 
@@ -117,11 +117,10 @@ Current filter:
 
 Control wrapper sensors exist because:
 
-* VTherm historically required stable unique_id entities
-* Home Assistant UI management benefits from stable wrappers
-* future orchestration layers may migrate without breaking entity compatibility
+- Home Assistant UI management benefits from stable wrappers
+- future orchestration layers may migrate without breaking entity compatibility
 
-VTherm itself is deprecated, but the wrapper architecture remains useful for compatibility and migration stability.
+The wrapper architecture remains useful for compatibility and migration stability.
 
 ---
 
@@ -129,21 +128,21 @@ VTherm itself is deprecated, but the wrapper architecture remains useful for com
 
 This system is:
 
-* telemetry-first
-* iterative
-* evidence-driven
+- telemetry-first
+- iterative
+- evidence-driven
 
 Changes should:
 
-* preserve observability
-* preserve telemetry continuity
-* preserve regression comparability
+- preserve observability
+- preserve telemetry continuity
+- preserve regression comparability
 
 Avoid:
 
-* silent behavior changes
-* architecture rewrites without evidence
-* premature complexity
+- silent behavior changes
+- architecture rewrites without evidence
+- premature complexity
 
 ---
 
@@ -151,11 +150,11 @@ Avoid:
 
 Critical consumers of truth sensors:
 
-* Main Supervisor
-* Safety Gates
-* Runtime Tracking
-* Telemetry Pipeline
-* Presence Logic
-* HVAC Transition Logging
+- Main Supervisor
+- Safety Gates
+- Runtime Tracking
+- Telemetry Pipeline
+- Presence Logic
+- HVAC Transition Logging
 
 Breaking truth sensors breaks the entire orchestration stack.


### PR DESCRIPTION
🎯 **What:** Removed references to the deprecated VTherm from `truth_sensor_architecture.md`.
💡 **Why:** To improve documentation maintainability by removing outdated and deprecated usage instructions, aligning with the current architecture where VTherm is no longer used but wrapper architecture remains useful for compatibility.
✅ **Verification:** Ran `prettier` to verify formatting and validate file integrity. The python test suite didn't find any tests in the repo to run as this is primarily a HA repo.
✨ **Result:** Improved codebase health without modifying functional logic.

---
*PR created automatically by Jules for task [10179745698523992869](https://jules.google.com/task/10179745698523992869) started by @ManlyRedfish*