### PR TITLE
Fix sensor slugification

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1018,6 +1018,7 @@ sensor:
 
   - platform: filter
     name: "Lincoln's Room Temperature Smoothed"
+    unique_id: lincoln_s_room_temperature_smoothed
     entity_id: sensor.lincoln_s_room_temperature_truth
     filters:
       - filter: lowpass
@@ -1026,6 +1027,7 @@ sensor:
 
   - platform: filter
     name: "Lilly's Room Temperature Smoothed"
+    unique_id: lilly_s_room_temperature_smoothed
     entity_id: sensor.lilly_s_room_temperature_truth
     filters:
       - filter: lowpass


### PR DESCRIPTION
Ensured the `lilly_s_room` and `lincoln_s_room` formats are maintained for the filter platform sensors by defining `unique_id` explicitly in `configuration.yaml`.

---
*PR created automatically by Jules for task [6846810663375335050](https://jules.google.com/task/6846810663375335050) started by @ManlyRedfish*