### PR TITLE
Fix YAML test loader collision

### DIFF
--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -2,6 +2,11 @@ import yaml
 import pytest
 import os
 
+
+class MooseAutomationLoader(yaml.SafeLoader):
+    pass
+
+
 # Home Assistant specific constructors
 def secret_constructor(loader, node):
     return f"SECRET_{node.value}"
@@ -15,17 +20,17 @@ def input_constructor(loader, node):
 def include_dir_merge_list_constructor(loader, node):
     return []
 
-yaml.SafeLoader.add_constructor('!secret', secret_constructor)
-yaml.SafeLoader.add_constructor('!include', include_constructor)
-yaml.SafeLoader.add_constructor('!input', input_constructor)
-yaml.SafeLoader.add_constructor('!include_dir_merge_list', include_dir_merge_list_constructor)
-yaml.SafeLoader.add_constructor('!include_dir_named', include_dir_merge_list_constructor)
+MooseAutomationLoader.add_constructor('!secret', secret_constructor)
+MooseAutomationLoader.add_constructor('!include', include_constructor)
+MooseAutomationLoader.add_constructor('!input', input_constructor)
+MooseAutomationLoader.add_constructor('!include_dir_merge_list', include_dir_merge_list_constructor)
+MooseAutomationLoader.add_constructor('!include_dir_named', include_dir_merge_list_constructor)
 
 @pytest.fixture(scope="module")
 def automations_data():
     file_path = os.path.join(os.path.dirname(__file__), '..', 'automations.yaml')
     with open(file_path, 'r') as f:
-        data = yaml.safe_load(f)
+        data = yaml.load(f, Loader=MooseAutomationLoader)
     return data
 
 

--- a/tests/test_yaml_syntax.py
+++ b/tests/test_yaml_syntax.py
@@ -2,14 +2,19 @@ import pytest
 import yaml
 import os
 
+
+class MooseSyntaxLoader(yaml.SafeLoader):
+    pass
+
+
 def yaml_include(loader, node):
     return node.value
 
 def yaml_secret(loader, node):
     return node.value
 
-yaml.add_constructor('!include', yaml_include, Loader=yaml.SafeLoader)
-yaml.add_constructor('!secret', yaml_secret, Loader=yaml.SafeLoader)
+MooseSyntaxLoader.add_constructor('!include', yaml_include)
+MooseSyntaxLoader.add_constructor('!secret', yaml_secret)
 
 def check_yaml_file(filepath):
     """Parses a YAML file and raises an exception if it's invalid."""
@@ -19,7 +24,7 @@ def check_yaml_file(filepath):
 
     with open(filepath, 'r') as file:
         try:
-            yaml.safe_load(file)
+            yaml.load(file, Loader=MooseSyntaxLoader)
         except Exception as e:
             pytest.fail(f"Invalid YAML in {filepath}:\n{e}")
 


### PR DESCRIPTION
## Problem

`pytest -v` on `main` fails after PR #42:

```
FAILED tests/test_automations.py::test_google_sheets_actions_use_secrets
AssertionError: Automation 'Experiment Data: Export to Google Sheets v5' uses google_sheets without !secret for config_entry
```

Each test file passes when run in isolation, but the full suite fails. This regression was introduced when PR #42 was merged on top of PR #40.

## Cause

Both `tests/test_yaml_syntax.py` (PR #42) and `tests/test_automations.py` (PR #40) registered their `!secret` and `!include` constructors on the **shared global `yaml.SafeLoader`** at module import time:

- PR #40's `test_automations.py` registers a `!secret` constructor that returns `"SECRET_<value>"` and asserts on that prefix.
- PR #42's `test_yaml_syntax.py` registers a `!secret` constructor that returns the bare `node.value`.

Whichever module imports last wins. Pytest collection happens to import `test_yaml_syntax.py` after `test_automations.py`, so the bare-value constructor clobbers the `SECRET_`-prefixed one. When `test_google_sheets_actions_use_secrets` then asserts `config_entry.startswith('SECRET_')` it fails because the value is now `"google_sheets_config_entry"` instead of `"SECRET_google_sheets_config_entry"`.

## Fix

Each test module now uses its own private loader subclass and registers constructors only on that subclass — the global `yaml.SafeLoader` is never mutated, so the two test files cannot collide regardless of import order.

- `tests/test_yaml_syntax.py`: introduces `class MooseSyntaxLoader(yaml.SafeLoader)` and loads via `yaml.load(file, Loader=MooseSyntaxLoader)`.
- `tests/test_automations.py`: introduces `class MooseAutomationLoader(yaml.SafeLoader)` and loads via `yaml.load(f, Loader=MooseAutomationLoader)`. Existing `SECRET_<value>` / `INCLUDE_<value>` / `INPUT_<value>` semantics are preserved.

No other files are touched.

## Test plan

```
$ pytest tests/test_yaml_syntax.py -v
tests/test_yaml_syntax.py::test_configuration_yaml_syntax PASSED         [ 50%]
tests/test_yaml_syntax.py::test_automations_yaml_syntax PASSED           [100%]
============================== 2 passed in 0.20s ===============================

$ pytest tests/test_automations.py -v
tests/test_automations.py::test_automations_is_list PASSED               [ 16%]
tests/test_automations.py::test_automations_have_required_fields PASSED  [ 33%]
tests/test_automations.py::test_automation_ids_are_unique PASSED         [ 50%]
tests/test_automations.py::test_google_sheets_actions_use_secrets PASSED [ 66%]
tests/test_automations.py::test_slugified_entities_check PASSED          [ 83%]
tests/test_automations.py::test_all_automations_have_mode PASSED         [100%]
============================== 6 passed in 0.15s ===============================

$ pytest -v
tests/test_automations.py::test_automations_is_list PASSED               [ 12%]
tests/test_automations.py::test_automations_have_required_fields PASSED  [ 25%]
tests/test_automations.py::test_automation_ids_are_unique PASSED         [ 37%]
tests/test_automations.py::test_google_sheets_actions_use_secrets PASSED [ 50%]
tests/test_automations.py::test_slugified_entities_check PASSED          [ 62%]
tests/test_automations.py::test_all_automations_have_mode PASSED         [ 75%]
tests/test_yaml_syntax.py::test_configuration_yaml_syntax PASSED         [ 87%]
tests/test_yaml_syntax.py::test_automations_yaml_syntax PASSED           [100%]
============================== 8 passed in 0.24s ===============================
```

## Runtime safety statement

**No runtime YAML or Home Assistant behavior changed.** Only `tests/test_yaml_syntax.py` and `tests/test_automations.py` are modified. `configuration.yaml`, `automations.yaml`, helpers, climate entities, supervisor logic (V8.3), safety gates (Section 3), V8.4 LR boost (Section 14), telemetry pipeline (Section 1 / `VTherm_Launch_Data_v5`), and all thresholds (64 / 67 / 77 / 90-min / 60 / 58) are untouched.

https://claude.ai/code/session_01P9inJwNJY94qVd6rq6wTMa

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9inJwNJY94qVd6rq6wTMa)_