### PR TITLE
Add pytest CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run pytest
+        run: pytest -v


### PR DESCRIPTION
## What

Adds `.github/workflows/tests.yml` to run the existing pytest suite on every pull request and on every push to `main`.

```yaml
on:
  pull_request:
  push:
    branches:
      - main
```

The job uses Python 3.12, installs from `requirements.txt`, and runs `pytest -v`.

## Why

PR #42 exposed that local-only tests are not enough: PR #40's secrets test and PR #42's syntax test each pass alone but **collide when `pytest -v` runs the suite together** (shared `yaml.SafeLoader` mutation across modules). Nothing in the repo would have caught this regression on `main` because there is no CI — only a local `pytest.ini` and an `install_deps.sh`. This workflow closes that gap so future PRs cannot silently regress the suite.

This is the minimum viable CI: only the existing tests, only on PR + push-to-main, only on a single Python version. Home Assistant semantic validation (`hass --script check_config`, threshold pinning, helper-reference checks) is intentionally out of scope and tracked for a follow-up.

## Sequencing note

This PR is intentionally narrow and stacks on top of #43 (loader collision fix). Until #43 is merged into `main`, the `pytest -v` step on this PR's merge ref will fail on `test_google_sheets_actions_use_secrets` for the reason documented in #43. After #43 merges, the merge-ref CI on this PR will go green; locally with #43 applied, all 8 tests pass.

## Test plan

- [x] Workflow YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tests.yml'))"`).
- [x] Locally with PR #43 applied: `pytest -v` → 8 passed.
- [ ] On GitHub Actions after #43 merges: `pytest -v` → 8 passed (will be visible on the Actions tab once this PR's merge ref includes #43).

## Runtime safety statement

**No runtime YAML or Home Assistant behavior changed.** Only `.github/workflows/tests.yml` is added. `configuration.yaml`, `automations.yaml`, helpers, climate entities, supervisor logic (V8.3), safety gates (Section 3), V8.4 LR boost (Section 14), telemetry pipeline (Section 1 / `VTherm_Launch_Data_v5`), and all thresholds (64 / 67 / 77 / 90-min / 60 / 58) are untouched.

https://claude.ai/code/session_01P9inJwNJY94qVd6rq6wTMa

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9inJwNJY94qVd6rq6wTMa)_