### PR TITLE
Mark event telemetry plan as retired

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -1419,7 +1419,14 @@
 #
 #     Note: Section 2 may overwrite the boost on its next 15-minute
 #     supervisor tick. This is an intentional pilot limitation and
-#     should be evaluated with event_journal.csv and Sheets telemetry.
+#     should be evaluated against the live evidence pipeline:
+#       - HA Logbook (Section 11 HVAC Transition Logger)
+#       - VTherm_Launch_Data_v5 (Google Sheets, 15-min snapshot)
+#       - Section 14 traces in HA history
+#     See docs/telemetry_confounders.md for window classification rules
+#     before drawing doctrine conclusions from boost cycles. The original
+#     event_journal.csv sink was retired in PR #34 — see
+#     docs/postmortems/2026-05-02_event_journal_containment.md.
 #
 #     Safety Note: The max-runtime timer uses restore: true so an
 #     active boost does not lose its time boundary during HA restart.

--- a/docs/event_telemetry_plan.md
+++ b/docs/event_telemetry_plan.md
@@ -1,5 +1,43 @@
 # Event Telemetry Plan (V8.3-Compatible, Observability-Only)
 
+> ## ⚠️ STATUS: RETIRED / ARCHIVAL — DO NOT IMPLEMENT
+>
+> **Retired:** 2026-05-05 (PR #34 — full removal).
+>
+> **Why retired:** The Phase 1A implementation in PR #19 failed to register
+> `notify.event_journal` on this Home Assistant build. PRs #22, #23, #24, and
+> #25 each attempted alternative sinks (`notify.send_message`, `shell_command`
+> with `b64encode`, `shell_command` with raw `printf`, restored `notify.file`)
+> and each failed. PR #26 contained the failure by converting `script.log_event`
+> to a no-op and disabling the Section 12 EJ observers. PR #34 then **permanently
+> removed** Section 12, Section 13 (`script.log_event`), and the `script.log_event`
+> calls in Section 14. No part of the architecture described below is present in
+> the live runtime.
+>
+> **Current evidence pipeline (use these instead):**
+> - **HA Logbook** for state transitions and hand-curated narrative.
+> - **`VTherm_Launch_Data_v5`** (Google Sheets, 15-minute snapshot) — the live
+>   `automations.yaml` Section 1 telemetry.
+> - **`docs/telemetry_confounders.md`** for window classification rules
+>   (operator-suppressed vs. clean) before drawing doctrine conclusions.
+> - **`docs/postmortems/2026-05-02_event_journal_containment.md`** §6 for the
+>   live-spike rules any future sink proposal must satisfy.
+> - **Section 11 HVAC Transition Logger** for off ⇄ cool/heat audit trails.
+>
+> **Do not implement this plan.** Do not re-introduce `script.log_event`,
+> `notify.event_journal`, `/config/logs/event_journal.csv`, the Section 12 EJ
+> observers, or the Phase 1A `notify.file` configuration without:
+> 1. A new live-spike issue that satisfies the postmortem §6 rules,
+> 2. Explicit operator approval, and
+> 3. A successful proof of `notify.event_journal` (or replacement sink) writing
+>    a CSV row on the live HA build before any automation is added.
+>
+> The document below is preserved as an archival record of the original Phase 1A
+> design intent. Schema choices, event-type lists, and rollback procedures are
+> historical context, not forward guidance.
+
+---
+
 **Plan Date:** May 1, 2026
 **Document Role:** Verification / Observability / Systems-Architecture proposal
 **Status:** Draft — planning artifact only. No control changes proposed. Safe to merge as documentation.

--- a/docs/v8_4_heating_recovery_boost_plan.md
+++ b/docs/v8_4_heating_recovery_boost_plan.md
@@ -4,6 +4,30 @@
 *Date: 2026-05-02*
 *Status: Design only — no YAML modified*
 
+> ## ⚠️ STATUS NOTE — Section 14 deployed; event-journal integration is RETIRED
+>
+> Section 14 was deployed in PR #21 and is live in `automations.yaml`. **However,
+> all references in this document to `script.log_event`, `notify.event_journal`,
+> the "Phase 1A event journal infrastructure", and `/config/logs/event_journal.csv`
+> are archival.** That sink failed to register on the live HA build (PR #19
+> through PR #25), was contained in PR #26, and was permanently removed in
+> PR #34. The `script.log_event` calls inside Section 14 were also removed in
+> PR #34.
+>
+> Treat §9.1 ("Integration with Phase 1A event journal"), the "log to
+> `event_journal.csv`" steps in §10 / §11, and any "existing Phase 1A event
+> journal infrastructure" prerequisite as **superseded**. Validate Section 14
+> against:
+> - **HA Logbook** (Section 11 HVAC Transition Logger)
+> - **`VTherm_Launch_Data_v5`** (Google Sheets snapshot every 15 min)
+> - **`docs/telemetry_confounders.md`** classification rules
+> - **`docs/postmortems/2026-05-02_event_journal_containment.md`** §9 evidence pipeline
+>
+> Section 14's deploy-status, four observed engages, and the
+> "boost effectiveness still unmeasured" verdict are tracked in
+> `docs/5_runtime_layer.md` §7.4 and `docs/telemetry_confounders.md` §5 — not in
+> this design doc.
+
 ---
 
 ## 1. Problem Statement


### PR DESCRIPTION
## Problem

After PR #34 permanently removed the event-journal infrastructure (Section 12 EJ observers, Section 13 `script.log_event`, Section 14's `script.log_event` calls), three doc/comment surfaces still read as if the journal were live infrastructure:

1. `docs/event_telemetry_plan.md` — the entire 1000+ line Phase 1A plan, with no status banner.
2. `docs/v8_4_heating_recovery_boost_plan.md` — design doc for Section 14, with ~25 references describing "the existing Phase 1A event journal infrastructure", `script.log_event` integration, and "log to `event_journal.csv`" verification steps.
3. `automations.yaml:1422` — a Section 14 comment instructing operators to evaluate the boost "with `event_journal.csv` and Sheets telemetry."

A future session reading any of these in isolation could conclude the event journal is the active observability tool and either (a) re-attempt the failed sink, (b) report against a CSV that no longer exists, or (c) defer Section 14 evaluation pending an artifact that will never appear.

## Fix

Documentation and comments only — no runtime, automation, sensor, helper, threshold, entity, or test logic touched.

1. **`docs/event_telemetry_plan.md`** — adds a top blockquote banner: STATUS RETIRED, why retired (PR #19→#25 sink failures, PR #26 containment, PR #34 removal), the current evidence pipeline (HA Logbook, `VTherm_Launch_Data_v5`, `telemetry_confounders.md`, postmortem §6, Section 11), and an explicit do-not-implement clause requiring (i) a new live-spike issue, (ii) operator approval, and (iii) a successful sink proof on the live build before any automation lands. The original document is preserved unchanged below the banner as archival record.
2. **`docs/v8_4_heating_recovery_boost_plan.md`** — adds a status-note banner at the top noting that Section 14 itself is deployed but every reference inside the doc to `script.log_event`, `notify.event_journal`, "Phase 1A event journal infrastructure", and `/config/logs/event_journal.csv` is **superseded**. Points readers to the live evidence pipeline and to `5_runtime_layer.md §7.4` / `telemetry_confounders.md §5` for the actual deploy status. Body of the doc is unchanged.
3. **`automations.yaml`** — replaces the single stale comment line (Section 14 header) with a comment block listing the live evidence pipeline (HA Logbook + Section 11 logger, `VTherm_Launch_Data_v5`, Section 14 history traces), pointing to `telemetry_confounders.md`, and noting the sink was retired in PR #34. **Comment-only** — no automation key, trigger, condition, action, id, alias, entity, threshold, or mode is altered.

Other event-journal references found in the search:
- `docs/5_runtime_layer.md §7.4` — already says "REMOVED". OK.
- `docs/telemetry_confounders.md §6, §7, §8` — already says "retired and removed". OK.
- `docs/postmortems/2026-05-02_event_journal_containment.md` — postmortem, inherently archival. OK.

## Files changed

```
 automations.yaml                         |  9 +++++++-
 docs/event_telemetry_plan.md             | 38 ++++++++++++++++++++++++++++++++
 docs/v8_4_heating_recovery_boost_plan.md | 24 ++++++++++++++++++++
 3 files changed, 70 insertions(+), 1 deletion(-)
```

The `automations.yaml` diff is comment-only — every changed line begins with `#`:
```
$ git diff automations.yaml | grep -E '^[-+]' | grep -v '^[-+]#' | grep -v '^[-+][-+][-+]'
(no output — all changed lines are comments)
```

## Test plan

```
$ pytest tests/test_yaml_syntax.py -v
tests/test_yaml_syntax.py::test_configuration_yaml_syntax PASSED         [ 50%]
tests/test_yaml_syntax.py::test_automations_yaml_syntax PASSED           [100%]
============================== 2 passed in 0.17s ===============================

$ pytest tests/test_automations.py -v
tests/test_automations.py::test_automations_is_list PASSED               [ 16%]
tests/test_automations.py::test_automations_have_required_fields PASSED  [ 33%]
tests/test_automations.py::test_automation_ids_are_unique PASSED         [ 50%]
tests/test_automations.py::test_google_sheets_actions_use_secrets PASSED [ 66%]
tests/test_automations.py::test_slugified_entities_check PASSED          [ 83%]
tests/test_automations.py::test_all_automations_have_mode PASSED         [100%]
============================== 6 passed in 0.15s ===============================
```

Each test file passes 8/8 in isolation. The full-suite `pytest -v` continues to exhibit the pre-existing PR #40/#42 loader collision tracked by #43; this PR does not change test files and so does not change that behavior.

## Runtime safety statement

**No runtime YAML or Home Assistant behavior changed.** Section 14 still engages on `LR_Temp_Truth < 64°F`, commands `heat@77°F`, releases on `truth_cap ≥ 67°F` / 90-min timeout / WAF / season change / truth_unavailable, and uses `restore: true` on its max-runtime timer. Section 2 supervisor (V8.3), Section 3 safety gates (LR 60°F runaway, Master 58°F floor, 76°F ceiling), Section 1 telemetry pipeline (`VTherm_Launch_Data_v5`), helpers, climate entities, truth sensors, smoothed sensors, and control wrappers are all unchanged. All thresholds (64 / 67 / 77 / 90-min / 60 / 58 / 76) are unchanged.

https://claude.ai/code/session_01P9inJwNJY94qVd6rq6wTMa

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9inJwNJY94qVd6rq6wTMa)_