### PR TITLE
Add Doc 2 reference map entry point

### DIFF
--- a/docs/2_reference_map.md
+++ b/docs/2_reference_map.md
@@ -1,0 +1,95 @@
+# Doc 2 / Moose House Climate Reference Map
+
+**Canon Date:** 2026-05-06
+**Document Role:** Reference Map — canonical routing entry point.
+**Status:** Index. Update when topology, sensor naming, source precedence, or entity routing materially changes.
+
+---
+
+## 1. Purpose
+
+This is the canonical Doc 2 entry point referenced from `1_startup_canon.md`
+(§9 Document Routing, §6 hardware-debt notes, §10 Startup Handoff Rule).
+
+Doc 2 is the **routing and topology layer** of the Moose House documentation
+hierarchy:
+
+- **Doc 1 / Startup Canon** — `1_startup_canon.md` — what to believe.
+- **Doc 2 / Reference Map** — *this document* — where to look.
+- **Doc 3 / Regression Appendix** — `3_regression_appendix.md` — what not to reinvent.
+- **Doc 4 / Operations Sheet** — `4_operations_sheet.md` — whether current doctrine is working.
+- **Doc 5 / Runtime Layer** — `5_runtime_layer.md` — what is actually live now.
+- **Doc 6 / Proposals** — `6_proposals.md` — V9 architectural proposals.
+- **Telemetry Confounders** — `telemetry_confounders.md` — analysis guardrail.
+- **Postmortems** — `postmortems/` — historical incidents.
+
+If a new session needs to know **which sensor feeds which truth calculation,
+which entity is downstream of which, or where a given concept's source-of-truth
+lives**, Doc 2 is the routing layer that answers that.
+
+## 2. What belongs in Doc 2
+
+- Static topology (rooms, sensors, mini-split heads, Nest dining/boiler).
+- Sensor naming truth and aliases.
+- Source precedence per room (BT primary / ST + Matter fallbacks / Samsung internal low-weight / MSR-2 DPS310 excluded).
+- Entity-id routing (truth → smoothed → control wrapper → supervisor consumer).
+- Helper inventory and what writes/reads each helper.
+- Worksheet and column-name mapping for `VTherm_Launch_Data_v5`.
+
+What does **not** belong in Doc 2:
+- Doctrine and active control posture (Doc 1).
+- Runtime-layer implementation boundaries (Doc 5).
+- Deferred/retired approaches (Doc 3).
+- Performance verdicts (Doc 4).
+- Architectural proposals (Doc 6).
+- Telemetry classification rules (`telemetry_confounders.md`).
+
+## 3. Current detailed truth-sensor architecture
+
+The detailed truth-sensor architecture currently lives at the repository root in
+[`../truth_sensor_architecture.md`](../truth_sensor_architecture.md). That
+document covers:
+
+- The truth-sensor pipeline: physical sensors → truth → smoothed → control wrappers → supervisor → telemetry.
+- Sensor-freshness policy (2-hour staleness rejection).
+- Weighting philosophy (human-space sensors prioritized; Samsung internal kept low-weight).
+- Lincoln pilot architecture (outlier rejection, contributor diagnostics).
+- Smoothed-sensor lowpass filter parameters (`time_constant=10`, `precision=2`).
+- Control-wrapper rationale.
+- Critical consumers of truth sensors.
+
+That file is the authoritative source for the truth-sensor part of Doc 2 until
+or unless it is migrated into `docs/`. **This PR does not move it.** A future
+PR may relocate it as `docs/2a_truth_sensor_architecture.md` (or fold its
+content directly into this file) — the move is deferred to keep this PR narrow.
+
+## 4. Pointers (interim, until topology content lands here)
+
+For the topology and routing slices Doc 2 is meant to cover, current sources are:
+
+| Topic | Authoritative source today | Notes |
+|---|---|---|
+| Truth-sensor pipeline / weighting / freshness | [`../truth_sensor_architecture.md`](../truth_sensor_architecture.md) | Detailed architecture. |
+| Live truth/control/telemetry versions | [`5_runtime_layer.md`](5_runtime_layer.md) §5, §6 | V8.3 control, V3.1 truth, V5 telemetry. |
+| Helper inventory (live) | [`5_runtime_layer.md`](5_runtime_layer.md) §6.5 + `automations.yaml` header | Helpers required for runtime. |
+| Sensor exclusions (MSR-2 DPS310 etc.) | `configuration.yaml` Sections 3–9 (live source); summarized in [`5_runtime_layer.md`](5_runtime_layer.md) §7.5 | Live config wins. |
+| Telemetry worksheet / column names | `automations.yaml` Section 1 (`vtherm_mega_tracker_v5`) | Worksheet `VTherm_Launch_Data_v5`. |
+| Operator-suppressed window classification | [`telemetry_confounders.md`](telemetry_confounders.md) | Read before joining columns to behavior. |
+
+## 5. Conflict rule
+
+If Doc 2 (this file) and the detailed source it routes to disagree, **the
+detailed source wins** for routing accuracy and Doc 2 should be updated. If Doc
+2 and live YAML disagree, **YAML wins** for runtime truth — re-route Doc 2.
+
+## 6. Maintenance rule
+
+Update Doc 2 when:
+
+- A sensor is added to or removed from a room's truth calculation.
+- An entity is renamed (e.g., the Lilly/Lincoln slug fix in PR #35/#39).
+- A helper is added, removed, or repurposed.
+- A worksheet column is added, removed, or renamed.
+- The Reference Map's authoritative-source link list (§4) needs a new row.
+
+Do not update Doc 2 merely to improve prose. Doc 2 is an index, not a narrative.


### PR DESCRIPTION
## Problem

Doc 1 / Startup Canon (`docs/1_startup_canon.md`) routes new sessions to "Doc 2 / Reference Map" in five places:

```
$ grep -nE "(Doc 2|Reference Map)" docs/1_startup_canon.md
8:This document is for startup context only. It is not the full topology map (Doc 2)...
59:...ST + Matter fallbacks are actively carrying the truth calculations (see Doc 2 / Reference Map).
80:Doc 2 / Moose House Climate Reference Map
93:For room-by-room topology and source precedence, use Doc 2 / Reference Map.
100:Use Doc 2 (Reference Map) for routing and topology, not this document.
```

…but no `docs/2_*.md` exists. `truth_sensor_architecture.md` lives at the **repo root** and only partially fills the role. A new session following Doc 1's instructions hits a dead pointer (R10 in the PR #42 audit).

## Fix

Adds `docs/2_reference_map.md` as a **lightweight canonical routing/index document**, not a rewrite of the truth-sensor architecture.

The new file:

1. Declares itself the canonical Doc 2 entry point and lists the full doc hierarchy (Doc 1 → Doc 6 + telemetry confounders + postmortems).
2. Defines what belongs in Doc 2 (topology, sensor naming truth, source precedence, entity-id routing, helper inventory, V5 worksheet/column mapping) vs. what does not (doctrine, runtime boundaries, retired approaches, performance verdicts, proposals, classification rules).
3. Cross-links to the existing detailed truth-sensor architecture at `../truth_sensor_architecture.md` and explicitly notes that file is **not moved by this PR**. A future PR may relocate or fold it; this one keeps the move out of scope to stay narrow.
4. Provides an interim authoritative-source pointer table (truth pipeline → root file; live versions → Doc 5 §5/§6; helper inventory → Doc 5 §6.5 + automations.yaml header; sensor exclusions → configuration.yaml + Doc 5 §7.5; telemetry worksheet → automations.yaml Section 1; window classification → telemetry_confounders.md).
5. States the conflict rule (detailed source wins for routing accuracy; live YAML wins for runtime truth) and the maintenance rule (update on entity rename / sensor add/remove / helper change / column change — not for prose).

`docs/1_startup_canon.md` is **not edited**: its references to Doc 2 are textual ("Doc 2 / Reference Map"), not Markdown hyperlinks. With `docs/2_reference_map.md` now present, those textual pointers resolve. No wording change is needed to fix the dead-pointer condition.

## Files changed

```
$ git diff --stat
 docs/2_reference_map.md | 95 +++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 95 insertions(+)
```

A single new doc file. No edits to `truth_sensor_architecture.md`, no edits to Doc 1, no edits to runtime YAML, no edits to tests, no edits to GitHub Actions.

## Test plan

```
$ pytest tests/test_yaml_syntax.py tests/test_automations.py -v
============================== 8 passed in 0.25s ===============================

$ pytest -v
========================= 1 failed, 7 passed in 0.26s ==========================
FAILED tests/test_automations.py::test_google_sheets_actions_use_secrets
```

The full-suite failure is the **pre-existing** PR #40/#42 loader collision tracked by #43 — unchanged by this PR (no test file touched, no YAML touched). Each test file still passes alone (8/8 across the two).

## Runtime safety statement

**No runtime YAML or Home Assistant behavior changed.** Only `docs/2_reference_map.md` is added (new file). `configuration.yaml`, `automations.yaml`, helpers, climate entities, supervisor logic (V8.3), safety gates (Section 3), V8.4 LR boost (Section 14), telemetry pipeline (Section 1 / `VTherm_Launch_Data_v5`), and all thresholds (64 / 67 / 77 / 90-min / 60 / 58 / 76) are untouched.

https://claude.ai/code/session_01P9inJwNJY94qVd6rq6wTMa

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9inJwNJY94qVd6rq6wTMa)_