### PR TITLE
Refresh stale YAML comments

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -1,6 +1,6 @@
 # =============================================================================
 # MOOSE HOUSE CLIMATE — COMPLETE AUTOMATIONS.YAML
-# Last Updated: April 25, 2026
+# Last Updated: May 6, 2026
 # Architecture: V8.3 — Comfort-First Hotfix with Stack-Effect Mitigation
 # =============================================================================
 #

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,6 +1,6 @@
 # =============================================================================
 # MOOSE HOUSE CLIMATE — COMPLETE CONFIGURATION.YAML
-# Last Updated: April 16, 2026
+# Last Updated: May 6, 2026
 # Architecture: V3.1 — Audited Truth / Smoothed / Control
 # =============================================================================
 #
@@ -20,7 +20,7 @@
 #   7. TRUTH SENSORS — OFFICE (temp, humidity, CO2)
 #   8. TRUTH SENSORS — LAUNDRY (temp, humidity)
 #   9. TRUTH SENSORS — DECK / OUTDOOR (temp, humidity)
-#  10. CONTROL WRAPPERS (smoothed pass-through for VTherm / UI)
+#  10. CONTROL WRAPPERS (smoothed pass-through for UI / supervisor)
 #  11. RUNTIME TRACKING (history_stats for boiler + all heat pumps)
 #  12. SMOOTHED SENSORS (lowpass filter on all truth temps)
 #
@@ -30,7 +30,7 @@
 #   - Outlier rejection (Lincoln pilot, 3°F limit)
 #   - Mini-split internal sensors always low-weight (biased hardware)
 #   - MSR-2 DPS310 sensors removed (both units hardware-failed)
-#   - Smoothed output → control wrapper → VTherm / supervisor
+#   - Smoothed output → control wrapper → V8.3 supervisor / HA UI
 #
 # CHANGELOG:
 #   V3-FIX:   Corrected entity_id slugification for Lincoln's/Lilly's
@@ -840,12 +840,13 @@ template:
           {% endif %}
 
       # =========================================================
-      # SECTION 10: CONTROL WRAPPERS FOR VTHERM / UI
+      # SECTION 10: CONTROL WRAPPERS FOR UI / SUPERVISOR
       # =========================================================
       # ⚠️  DO NOT DELETE — These sensors pass smoothed truth values
-      #     through a template with unique_id so VTherm and the HA UI
-      #     can manage them as distinct entities. Without these, VTherm
-      #     loses its temperature input and control stops working.
+      #     through a template with unique_id so the V8.3 supervisor
+      #     and the HA UI can manage them as distinct entities. Without
+      #     these wrappers, downstream consumers lose their temperature
+      #     input and control stops working.
       #
       # Each wrapper reads from the corresponding smoothed sensor
       # in Section 12 and exposes it with a stable unique_id.
@@ -992,7 +993,7 @@ sensor:
   # =============================================================================
   # ⚠️  DO NOT DELETE — These lowpass filters smooth the raw truth sensors
   #     to prevent control jitter. The control wrappers in Section 10 read
-  #     from these, and VTherm / the supervisor ultimately act on the
+  #     from these, and the V8.3 supervisor ultimately acts on the
   #     smoothed values. Removing these causes noisy truth spikes to
   #     propagate directly into setpoint decisions.
   #


### PR DESCRIPTION
## Problem

Two low-severity hygiene findings from the PR #42 audit (R11 + R12):

1. **`configuration.yaml` Sections 10/12 comments imply VTherm is a live consumer.** PRs #27/#36/#37 cleaned up *deprecated* VTherm references in `automations.yaml`, `AGENTS.md`, and `truth_sensor_architecture.md`, but five comment lines in `configuration.yaml` still describe VTherm as the downstream consumer of the smoothed/control-wrapper pipeline. The actual live consumer is the V8.3 supervisor (Section 2 of `automations.yaml`) plus the HA UI. A new session reading those lines could misidentify the active control authority.

2. **`Last Updated:` headers are stale.** Both `configuration.yaml:3` (April 16, 2026) and `automations.yaml:3` (April 25, 2026) predate the May 5–6 modifications from PRs #34, #35, #38, #39, #40, and #42.

Historical artifacts that **must remain unchanged** were also reviewed:
- Worksheet name `VTherm_Launch_Data_v5` — preserved (renaming would break Sheets continuity).
- Automation id `vtherm_mega_tracker_v5` — preserved (renaming would break HA's automation registry).

## Fix

Comments and headers only. No automation key, trigger, condition, action, id, alias, entity, threshold, mode, template, or value is altered.

`configuration.yaml`:
- `:3` `Last Updated: April 16, 2026` → `Last Updated: May 6, 2026`.
- `:23` Section 10 inventory line: `for VTherm / UI` → `for UI / supervisor`.
- `:33` Design-principles line: `Smoothed output → control wrapper → VTherm / supervisor` → `Smoothed output → control wrapper → V8.3 supervisor / HA UI`.
- `:843–848` Section 10 header block: `CONTROL WRAPPERS FOR VTHERM / UI` → `CONTROL WRAPPERS FOR UI / SUPERVISOR`; body rewritten to `the V8.3 supervisor and the HA UI can manage them as distinct entities` and `downstream consumers lose their temperature input` (no VTherm wording).
- `:995` Section 12 header block: `VTherm / the supervisor ultimately act on` → `the V8.3 supervisor ultimately acts on`.

`automations.yaml`:
- `:3` `Last Updated: April 25, 2026` → `Last Updated: May 6, 2026`.
- `:86, :89, :102` (Worksheet `VTherm_Launch_Data_v5`, automation id `vtherm_mega_tracker_v5`) — **unchanged**.

## Files changed

```
$ git diff --stat
 automations.yaml   |  2 +-
 configuration.yaml | 17 +++++++++--------
 2 files changed, 10 insertions(+), 9 deletions(-)
```

## Comment-only verification

```
$ for f in configuration.yaml automations.yaml; do
    git diff "$f" | grep -E '^[-+]' | grep -v '^[-+][-+][-+]' | grep -vE '^[-+] *#'
  done
(no output — every changed line in both files starts with #)

$ grep -n 'VTherm' configuration.yaml automations.yaml
automations.yaml:86:#     Worksheet: VTherm_Launch_Data_v5
automations.yaml:102:      worksheet: VTherm_Launch_Data_v5
```

Only the legitimate historical worksheet/automation-id references to "VTherm" remain. All "VTherm / supervisor" and "VTherm / UI" wording is gone from `configuration.yaml`.

## Test plan

```
$ pytest tests/test_yaml_syntax.py -v
tests/test_yaml_syntax.py::test_configuration_yaml_syntax PASSED         [ 50%]
tests/test_yaml_syntax.py::test_automations_yaml_syntax PASSED           [100%]
============================== 2 passed in 0.16s ===============================

$ pytest tests/test_automations.py -v
tests/test_automations.py::test_automations_is_list PASSED               [ 16%]
tests/test_automations.py::test_automations_have_required_fields PASSED  [ 33%]
tests/test_automations.py::test_automation_ids_are_unique PASSED         [ 50%]
tests/test_automations.py::test_google_sheets_actions_use_secrets PASSED [ 66%]
tests/test_automations.py::test_slugified_entities_check PASSED          [ 83%]
tests/test_automations.py::test_all_automations_have_mode PASSED         [100%]
============================== 6 passed in 0.14s ===============================
```

8/8 across the two test files in isolation. The full-suite `pytest -v` continues to exhibit the pre-existing PR #40/#42 loader collision tracked by #43; this PR does not change test files and does not change that behavior.

## Runtime safety statement

**No runtime YAML or Home Assistant behavior changed.** Every changed line in both YAML files begins with `#` and is therefore a comment. Section 2 supervisor logic (V8.3), Section 3 safety gates (LR 60°F runaway, Master 58°F floor, 76°F ceiling, SPI, WAF), Section 14 V8.4 LR boost (engage at <64°F, truth_cap ≥67°F, 90-min timer, SP=77°F, restore: true), Section 1 telemetry pipeline (`vtherm_mega_tracker_v5` → `VTherm_Launch_Data_v5`), V3.1 truth-sensor pipeline, smoothed sensors, control wrappers, helper inventory, climate entities, and all thresholds (64 / 67 / 77 / 90-min / 60 / 58 / 76) are unchanged.

https://claude.ai/code/session_01P9inJwNJY94qVd6rq6wTMa

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9inJwNJY94qVd6rq6wTMa)_