### PR TITLE
docs/tests: cleanup pass after Jules wave (#55-#59)

### DIFF
--- a/docs/2_reference_map.md
+++ b/docs/2_reference_map.md
@@ -21,6 +21,10 @@ hierarchy:
 - **Doc 5 / Runtime Layer** — `5_runtime_layer.md` — what is actually live now.
 - **Doc 6 / Proposals** — `6_proposals.md` — V9 architectural proposals.
 - **Telemetry Confounders** — `telemetry_confounders.md` — analysis guardrail.
+- **Apollo MSR Observability Checklist** — `apollo_msr_observability_checklist.md` — observability-only doctrine and validation checklist for Apollo MSR sensors (proposed; no control-loop promotion).
+- **Operator Annotation Design** — `operator_annotation_design.md` — proposed out-of-band forensic annotation workflow (Status: Proposed).
+- **V6 Telemetry Schema Proposal** — `v6_telemetry_schema_proposal.md` — proposed `VTherm_Launch_Data_v6` schema (planning only; V5 remains active).
+- **V6 Observability Roadmap** — `v6_observability_roadmap.md` — phase order and guardrails for V5 → V6 observability work.
 - **Postmortems** — `postmortems/` — historical incidents.
 
 If a new session needs to know **which sensor feeds which truth calculation,
@@ -75,6 +79,10 @@ For the topology and routing slices Doc 2 is meant to cover, current sources are
 | Sensor exclusions (MSR-2 DPS310 etc.) | `configuration.yaml` Sections 3–9 (live source); summarized in [`5_runtime_layer.md`](5_runtime_layer.md) §7.5 | Live config wins. |
 | Telemetry worksheet / column names | `automations.yaml` Section 1 (`vtherm_mega_tracker_v5`) | Worksheet `VTherm_Launch_Data_v5`. |
 | Operator-suppressed window classification | [`telemetry_confounders.md`](telemetry_confounders.md) | Read before joining columns to behavior. |
+| Apollo MSR observability validation (proposed) | [`apollo_msr_observability_checklist.md`](apollo_msr_observability_checklist.md) | Observability-only; not a control authority. |
+| Operator annotation workflow (proposed) | [`operator_annotation_design.md`](operator_annotation_design.md) | Out-of-band; no HA helpers. Adoption tracked in #50. |
+| V6 telemetry schema (proposed) | [`v6_telemetry_schema_proposal.md`](v6_telemetry_schema_proposal.md) | Planning only. V5 remains active. |
+| V6 observability roadmap (proposed) | [`v6_observability_roadmap.md`](v6_observability_roadmap.md) | Phase order and guardrails. |
 
 ## 5. Conflict rule
 

--- a/docs/apollo_msr_observability_checklist.md
+++ b/docs/apollo_msr_observability_checklist.md
@@ -23,8 +23,8 @@ _Identify and verify all exposed entities for each MSR device. Mark unknowns as 
 
 | Room            | Device          | Presence Entity                          | CO2 Entity           | Temperature Entity                   | Pressure/DPS310 Entity            | Verified? | Notes                                  |
 | :-------------- | :-------------- | :--------------------------------------- | :------------------- | :----------------------------------- | :-------------------------------- | :-------- | :------------------------------------- |
-| Living Room     | Living Room MSR | `binary_sensor.living_room_msr_presence` | [needs verification] | `sensor.living_room_msr_temperature` | `sensor.living_room_msr_pressure` | [ ]       | Example known MSR.                     |
-| Lincoln's Room  | Lincoln MSR     | `binary_sensor.lincoln_msr_presence`     | [needs verification] | `sensor.lincoln_msr_temperature`     | `sensor.lincoln_msr_pressure`     | [ ]       | Do not assume Lincoln MSR exposes CO2. |
+| Living Room     | Living Room MSR | `binary_sensor.living_room_msr_presence` | [needs verification] | `sensor.living_room_msr_temperature` | `sensor.living_room_msr_pressure` | [ ]       | Example known MSR. DPS310 (temperature/pressure) on this MSR-2 unit is part of the documented MSR-2 DPS310 hardware-debt exclusion — observability-only; see `5_runtime_layer.md` §7.5 and `truth_sensor_architecture.md`. |
+| Lincoln's Room  | Lincoln MSR     | `binary_sensor.lincoln_msr_presence`     | [needs verification] | `sensor.lincoln_msr_temperature`     | `sensor.lincoln_msr_pressure`     | [ ]       | Do not assume Lincoln MSR exposes CO2. DPS310 on MSR-2 hardware is observability-only per the global warning below. |
 | [Template Room] | [Device Name]   | `binary_sensor.[name]_presence`          | [needs verification] | `sensor.[name]_temperature`          | `sensor.[name]_pressure`          | [ ]       | Generic Room Template.                 |
 
 ## CO2 Availability Checklist

--- a/docs/telemetry_confounders.md
+++ b/docs/telemetry_confounders.md
@@ -127,11 +127,17 @@ as operator-managed.
    a regression entry) cites Apr 28–May 1 as evidence of Section 2 behavior, that
    doc is wrong and should be corrected against this confounder note.
 
-## 6. Operator Annotation Practice
+## 6. Operator Annotation Practice (Proposed)
 
-To prevent the same confounder from contaminating future analyses, the operator must utilize the out-of-band forensic workflow.
+To prevent the same confounder from contaminating future analyses, the operator
+should utilize the **proposed** out-of-band forensic workflow once it is adopted.
+The workflow is currently a design proposal, not implemented operational
+procedure.
 
-For the full design and schema of this out-of-band workflow, refer to the [Operator Annotation Design (`docs/operator_annotation_design.md`)](operator_annotation_design.md).
+For the full design and schema of this out-of-band workflow, refer to the
+[Operator Annotation Design (`docs/operator_annotation_design.md`)](operator_annotation_design.md)
+(`Status: Proposed`). Adoption is tracked in issue #50; until that issue closes,
+contaminated windows must continue to be classified behaviorally per §4.
 
 The event journal infrastructure was **retired and removed** after the sink failed
 to register. Do not re-introduce observers or attempt a new event-journal write path

--- a/tests/test_safety_invariants.py
+++ b/tests/test_safety_invariants.py
@@ -69,8 +69,19 @@ def test_master_emergency_cooling_floor_exists(automations_data):
     for auto in automations_data:
         if auto.get('id') == 'v8_2_master_emergency_floor':
             found = True
-            # TODO: Add assertions for the exact 58F threshold once full HA simulation is supported.
-            # Currently conservative, just verifying the automation ID exists.
+
+            # Mirror the LR runaway test: pin the 58F threshold statically.
+            # This static check does not require full HA runtime simulation —
+            # the trigger shape is identical to the LR runaway cutoff.
+            triggers = auto.get('trigger', [])
+            threshold_found = False
+            for trigger in triggers:
+                if trigger.get('platform') == 'numeric_state' and trigger.get('entity_id') == 'sensor.master_bedroom_temperature_truth':
+                    if trigger.get('below') == 58:
+                        threshold_found = True
+                        break
+
+            assert threshold_found, "Master emergency floor automation exists, but 58F threshold trigger is missing or modified."
             break
 
     assert found, "Master emergency cooling floor automation (v8_2_master_emergency_floor) not found in automations.yaml"


### PR DESCRIPTION
- Soften docs/telemetry_confounders.md §6 from "must utilize" to
  "should utilize the proposed out-of-band forensic workflow"; flag
  the section heading as Proposed and reference issue #50, since
  docs/operator_annotation_design.md is Status: Proposed.
- Strengthen tests/test_safety_invariants.py::test_master_emergency_cooling_floor_exists
  to assert the 58F numeric_state trigger on
  sensor.master_bedroom_temperature_truth, mirroring the LR 60F test.
  The static check does not require HA runtime simulation; the prior
  TODO is removed.
- Add the four new Jules planning docs to docs/2_reference_map.md so
  they are discoverable from the canonical Doc 2 index.
- Annotate the Living Room MSR DPS310 row in
  docs/apollo_msr_observability_checklist.md with the MSR-2 hardware-debt
  cross-reference; observability-only doctrine is preserved.

No runtime YAML, automation, ESPHome, script, scene, helper, or climate
template changes. git diff -- '*.yaml' '*.yml' is empty. Issue #49 is
not closed by this PR. pytest tests/ is green (11/11), including the
strengthened 58F assertion.