### PR TITLE
observability: add Section 14 boost-state telemetry

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -79,18 +79,33 @@
 
 
 # =============================================================================
-# SECTION 1: DATA COLLECTION (V5 Semantic Heritage Schema)
+# SECTION 1: DATA COLLECTION (V5.5 Semantic Heritage Schema + Section 14 obs)
 # =============================================================================
 # ⚠️  DO NOT DELETE — This is the telemetry pipeline to Google Sheets.
 #     Without this, no experiment data is captured.
-#     Worksheet: VTherm_Launch_Data_v5
+#     Worksheet: VTherm_Launch_Data_v5_5
+#
+#     V5.5 NOTE (issue #62, observability-only):
+#       v5.5 is a wide-table interim schema that extends V5 with Section 14
+#       boost-state observability columns (sub-block 14 below). It preserves
+#       the V5 row model and column conventions; v5.5 begins the Section 14
+#       observability era while v5 remains historical and unchanged. The
+#       future event-oriented telemetry work is V6 — this is not V6.
+#
+#     ⚠️  DEPLOYMENT: the live Google Sheets worksheet header row for
+#       VTherm_Launch_Data_v5_5 must include the new sub-block-14 columns
+#       (in the order they appear below) before the first export tick after
+#       this change ships, otherwise rows will be misaligned. The previous
+#       VTherm_Launch_Data_v5 worksheet remains as historical-only evidence
+#       and is no longer written to by this automation.
 # =============================================================================
 
 - id: vtherm_mega_tracker_v5
-  alias: 'Experiment Data: Export to Google Sheets v5'
+  alias: 'Experiment Data: Export to Google Sheets v5.5'
   mode: single
   description: >
-    V5 — Semantic Heritage Schema. Clean headers mapping lineage to entities.
+    V5.5 — Semantic Heritage Schema + Section 14 boost-state observability.
+    Wide-table interim schema. Forward path is V6 (event-oriented).
   trigger:
   - minutes: /15
     trigger: time_pattern
@@ -99,7 +114,7 @@
   - action: google_sheets.append_sheet
     data:
       config_entry: !secret google_sheets_config_entry
-      worksheet: VTherm_Launch_Data_v5
+      worksheet: VTherm_Launch_Data_v5_5
       data:
         # 1. Timestamp / Global Context
         Timestamp: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
@@ -244,6 +259,45 @@
         # 13. Diagnostics
         LR_Truth_Count: "{% set v = states('sensor.living_room_temperature_truth_active_count') %}{{ '' if v in ['unknown', 'unavailable'] else v }}"
         Lincoln_Truth_Count: "{% set v = states('sensor.lincoln_temperature_truth_active_count') %}{{ '' if v in ['unknown', 'unavailable'] else v }}"
+
+        # 14. SECTION 14 BOOST OBSERVABILITY (v5.5, issue #62)
+        # Observability-only. No Section 14 control logic / threshold
+        # changes. New columns must be added to the worksheet header row
+        # (in this order) before deployment to avoid row drift. Keeps the
+        # existing V5 blank-on-unknown convention.
+        Section14_Boost_Active: "{% set v = states('input_boolean.lr_heating_recovery_boost_active') %}{{ '' if v in ['unknown', 'unavailable'] else v }}"
+        Section14_Timer_State: "{% set v = states('timer.lr_heating_recovery_boost_max_runtime') %}{{ '' if v in ['unknown', 'unavailable'] else v }}"
+        Section14_Timer_Remaining: >-
+          {% set t = states('timer.lr_heating_recovery_boost_max_runtime') %}
+          {% set finishes = state_attr('timer.lr_heating_recovery_boost_max_runtime', 'finishes_at') %}
+          {% if t == 'active' and finishes not in [none, 'unknown', 'unavailable'] %}
+          {{ ((as_datetime(finishes) - now()).total_seconds()) | int }}
+          {% else %}{% endif %}
+        Section14_Last_Engage_Reason: "{% set v = states('input_text.lr_heating_recovery_boost_last_engage_reason') %}{{ '' if v in ['unknown', 'unavailable'] else v }}"
+        Section14_Last_Release_Reason: "{% set v = states('input_text.lr_heating_recovery_boost_last_release_reason') %}{{ '' if v in ['unknown', 'unavailable'] else v }}"
+        Section14_Last_Engage_At: "{% set v = states('input_datetime.lr_heating_recovery_boost_last_engage_at') %}{{ '' if v in ['unknown', 'unavailable'] else v }}"
+        Section14_Last_Release_At: "{% set v = states('input_datetime.lr_heating_recovery_boost_last_release_at') %}{{ '' if v in ['unknown', 'unavailable'] else v }}"
+        Section14_Engage_Eligible: >-
+          {% set season = states('input_select.hvac_season_mode') %}
+          {% set override = states('timer.manual_hvac_override') %}
+          {% set away = states('input_boolean.away_mode') %}
+          {% set boost = states('input_boolean.lr_heating_recovery_boost_active') %}
+          {% set lr = states('sensor.living_room_temperature_truth') %}
+          {% set lrc = states('climate.living_room_air') %}
+          {% set lr_num = lr | float(none) %}
+          {% if season in ['heating', 'shoulder']
+                and override == 'idle'
+                and away == 'off'
+                and boost == 'off'
+                and lrc not in ['unknown', 'unavailable']
+                and lr_num is not none
+                and lr_num < 64 %}true{% elif season in ['unknown', 'unavailable'] or override in ['unknown', 'unavailable'] or away in ['unknown', 'unavailable'] or boost in ['unknown', 'unavailable'] %}{% else %}false{% endif %}
+        Section14_WAF_Active: >-
+          {% set v = states('timer.manual_hvac_override') %}
+          {% if v in ['unknown', 'unavailable'] %}{% elif v == 'active' %}true{% else %}false{% endif %}
+        Section14_Truth_Available: >-
+          {% set v = states('sensor.living_room_temperature_truth') %}
+          {% if v in ['unknown', 'unavailable'] %}false{% elif v | float(none) is none %}false{% else %}true{% endif %}
 
 
 # =============================================================================
@@ -1476,6 +1530,25 @@
       data:
         temperature: 77
         hvac_mode: heat
+    # -------------------------------------------------------------------------
+    # OBSERVABILITY ONLY (v5.5 / issue #62) — runs AFTER control actions.
+    # Records last engage classification + timestamp into helpers so the
+    # v5.5 telemetry export can classify boost cycles. Does not change any
+    # Section 14 control behavior. Today there is exactly one engage path
+    # (LR truth < 64 °F under heating/shoulder, override idle, away off);
+    # the constant string `truth_below_64` is a stable forward-compatible
+    # classifier and not a threshold value.
+    # -------------------------------------------------------------------------
+    - action: input_text.set_value
+      target:
+        entity_id: input_text.lr_heating_recovery_boost_last_engage_reason
+      data:
+        value: "truth_below_64"
+    - action: input_datetime.set_datetime
+      target:
+        entity_id: input_datetime.lr_heating_recovery_boost_last_engage_at
+      data:
+        timestamp: "{{ now().timestamp() | int }}"
 
 - id: v8_4_lr_heating_recovery_boost_release
   alias: "V8.4: LR Heating Recovery Boost Release"
@@ -1532,3 +1605,71 @@
                 entity_id: climate.living_room_air
               data:
                 hvac_mode: "off"
+    # -------------------------------------------------------------------------
+    # OBSERVABILITY ONLY (v5.5 / issue #62) — runs AFTER control actions.
+    # Maps the release trigger.id to a stable classifier string and persists
+    # it (plus the release timestamp) so the v5.5 telemetry export can
+    # distinguish all five doctrinal terminations: truth_cap, timeout, waf,
+    # season_change, truth_unavailable. The default branch writes
+    # `unknown_release_reason` so this block can never raise on an
+    # unrecognized trigger.id and cannot interrupt the latch flip, timer
+    # cancel, or climate-off actions above. No threshold change. No #49
+    # closure.
+    # -------------------------------------------------------------------------
+    - choose:
+        - conditions:
+            - condition: trigger
+              id: truth_cap
+          sequence:
+            - action: input_text.set_value
+              target:
+                entity_id: input_text.lr_heating_recovery_boost_last_release_reason
+              data:
+                value: "truth_cap"
+        - conditions:
+            - condition: trigger
+              id: timeout
+          sequence:
+            - action: input_text.set_value
+              target:
+                entity_id: input_text.lr_heating_recovery_boost_last_release_reason
+              data:
+                value: "timeout"
+        - conditions:
+            - condition: trigger
+              id: waf
+          sequence:
+            - action: input_text.set_value
+              target:
+                entity_id: input_text.lr_heating_recovery_boost_last_release_reason
+              data:
+                value: "waf"
+        - conditions:
+            - condition: trigger
+              id: season_change
+          sequence:
+            - action: input_text.set_value
+              target:
+                entity_id: input_text.lr_heating_recovery_boost_last_release_reason
+              data:
+                value: "season_change"
+        - conditions:
+            - condition: trigger
+              id: truth_unavailable
+          sequence:
+            - action: input_text.set_value
+              target:
+                entity_id: input_text.lr_heating_recovery_boost_last_release_reason
+              data:
+                value: "truth_unavailable"
+      default:
+        - action: input_text.set_value
+          target:
+            entity_id: input_text.lr_heating_recovery_boost_last_release_reason
+          data:
+            value: "unknown_release_reason"
+    - action: input_datetime.set_datetime
+      target:
+        entity_id: input_datetime.lr_heating_recovery_boost_last_release_at
+      data:
+        timestamp: "{{ now().timestamp() | int }}"

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1066,3 +1066,39 @@ input_boolean:
   lr_heating_recovery_boost_active:
     name: "LR Heating Recovery Active"
     icon: mdi:fire-alert
+
+# =============================================================================
+# SECTION 14 OBSERVABILITY HELPERS (v5.5)
+# =============================================================================
+# ⚠️  Observability-only — issue #62.
+#     These helpers persist last-edge memory of Section 14 engage / release
+#     events so the v5.5 telemetry export can classify boost cycles directly
+#     instead of inferring them from LR_Air_Setpoint=77.
+#     They are written by Section 14's engage/release action blocks AFTER the
+#     control actions complete. They do not gate, change, or interrupt any
+#     Section 14 trigger, condition, climate command, timer call, or latch
+#     flip. No threshold change. No #49 closure.
+# =============================================================================
+input_text:
+  lr_heating_recovery_boost_last_engage_reason:
+    name: "LR Boost Last Engage Reason"
+    icon: mdi:play-circle-outline
+    initial: ""
+    max: 64
+  lr_heating_recovery_boost_last_release_reason:
+    name: "LR Boost Last Release Reason"
+    icon: mdi:stop-circle-outline
+    initial: ""
+    max: 64
+
+input_datetime:
+  lr_heating_recovery_boost_last_engage_at:
+    name: "LR Boost Last Engage At"
+    icon: mdi:clock-start
+    has_date: true
+    has_time: true
+  lr_heating_recovery_boost_last_release_at:
+    name: "LR Boost Last Release At"
+    icon: mdi:clock-end
+    has_date: true
+    has_time: true

--- a/docs/5_runtime_layer.md
+++ b/docs/5_runtime_layer.md
@@ -23,9 +23,9 @@ This file contains the live supervisory climate behavior, safety gates, telemetr
 This file contains per-room truth sensors, staleness rejection, outlier handling, smoothed sensors, runtime tracking, and control wrappers. It explicitly states the design principles of weighted per-room truth, 2-hour staleness rejection, Lincoln outlier rejection, low-weight internal Samsung sensing, and removal of failed MSR-2 DPS310 sensors.
 
 ### 2.3 Active Evidence Source
-**Source:** VTherm_Launch_Data_v5
-**Current telemetry/export schema:** V5 — Semantic Heritage Schema
-The live telemetry pipeline is defined in `automations.yaml` as a 15-minute export to Google Sheets under the worksheet `VTherm_Launch_Data_v5`, with room/metric/role/transport-aware naming.
+**Source:** VTherm_Launch_Data_v5_5
+**Current telemetry/export schema:** V5.5 — Semantic Heritage Schema + Section 14 boost-state observability
+The live telemetry pipeline is defined in `automations.yaml` as a 15-minute export to Google Sheets under the worksheet `VTherm_Launch_Data_v5_5`, with room/metric/role/transport-aware naming. V5.5 is a wide-table interim schema that extends V5 with Section 14 boost-state observability columns (issue #62); it preserves the V5 row model and column conventions. V5 (`VTherm_Launch_Data_v5`) remains historical and is no longer written to. V6 (event-oriented) remains future work — see `docs/v6_telemetry_schema_proposal.md` and `docs/v6_observability_roadmap.md`.
 
 ### 2.4 Active Surface-State Sources
 - Live Home Assistant state
@@ -68,11 +68,18 @@ This layer should not become a full YAML dump. It is a runtime map, not a code m
 **Current truth file:** `configuration.yaml`
 **Current posture:** Audited, trimmed, smoothed truth architecture.
 
-### 5.3 Active Telemetry Layer (V5 Semantic Heritage Schema)
-**Current telemetry version:** V5
+### 5.3 Active Telemetry Layer (V5.5 Semantic Heritage Schema + Section 14 boost obs)
+**Current telemetry version:** V5.5
 **Current export destination:** Google Sheets
-**Current worksheet:** `VTherm_Launch_Data_v5`
-**Current schema style:** Semantic Heritage naming, mapping room + metric + role + transport into export headers.
+**Current worksheet:** `VTherm_Launch_Data_v5_5`
+**Current schema style:** Semantic Heritage naming, mapping room + metric + role + transport into export headers, plus Section 14 boost-state observability columns.
+
+**V5 vs V5.5 vs V6 boundary:**
+- V5 (`VTherm_Launch_Data_v5`) — historical and unchanged. No longer written to. Referenced by `docs/analysis/v8_4_lr_boost_v5_evidence_review.md`.
+- V5.5 (`VTherm_Launch_Data_v5_5`) — begins the Section 14 observability era. Wide-table interim schema. Adds the §14 sub-block columns from `automations.yaml` Section 1: `Section14_Boost_Active`, `Section14_Timer_State`, `Section14_Timer_Remaining`, `Section14_Last_Engage_Reason`, `Section14_Last_Release_Reason`, `Section14_Last_Engage_At`, `Section14_Last_Release_At`, `Section14_Engage_Eligible`, `Section14_WAF_Active`, `Section14_Truth_Available`. No control or threshold change.
+- V6 — future event-oriented telemetry work. Out of scope here.
+
+**⚠️  Worksheet header row:** the live Google Sheets `VTherm_Launch_Data_v5_5` worksheet header must include the new sub-block-14 columns in the same order they appear in `automations.yaml` Section 1 before the first export tick after this change ships, otherwise rows will be misaligned. This is an out-of-band manual step.
 
 ## 6. Live Runtime Components
 
@@ -118,7 +125,11 @@ The runtime depends on several helpers. The live automations file explicitly lis
 - `input_boolean.away_mode`
 - `input_boolean.lr_heating_recovery_boost_active` (Section 14 V8.4 LR boost latch)
 - `timer.lr_heating_recovery_boost_max_runtime` (Section 14 V8.4 LR boost timeout, `restore: true`)
-*(These helpers are not just UI artifacts. They are part of the live control path and must exist for runtime behavior to function properly.)*
+- `input_text.lr_heating_recovery_boost_last_engage_reason` (Section 14 v5.5 observability — last engage classifier; written by engage action block; observability-only, no control authority)
+- `input_text.lr_heating_recovery_boost_last_release_reason` (Section 14 v5.5 observability — one of `truth_cap` / `timeout` / `waf` / `season_change` / `truth_unavailable` / `unknown_release_reason`; written by release action block; observability-only, no control authority)
+- `input_datetime.lr_heating_recovery_boost_last_engage_at` (Section 14 v5.5 observability — engage timestamp; observability-only)
+- `input_datetime.lr_heating_recovery_boost_last_release_at` (Section 14 v5.5 observability — release timestamp; observability-only)
+*(These helpers are not just UI artifacts. They are part of the live control path and must exist for runtime behavior to function properly. The four v5.5 observability helpers are written from Section 14 action blocks AFTER the existing control actions complete; they do not gate, change, or interrupt any Section 14 trigger, condition, climate command, timer call, or latch flip.)*
 
 ### 6.6 Evidence / Runtime Observation Components
 The runtime evidence layer includes:
@@ -197,8 +208,8 @@ When checking a runtime claim, use this order:
 The runtime layer should always preserve, at minimum:
 - Active control version: V8.3
 - Active truth version: V3.1
-- Active telemetry version: V5
-- Telemetry worksheet: VTherm_Launch_Data_v5
+- Active telemetry version: V5.5
+- Telemetry worksheet: VTherm_Launch_Data_v5_5
 - Key helper dependencies
 - Key climate entities
 - Key room truth entities

--- a/docs/analysis/v8_4_lr_boost_v5_evidence_review.md
+++ b/docs/analysis/v8_4_lr_boost_v5_evidence_review.md
@@ -280,3 +280,48 @@ Issue #49 remains open. This review does not propose to close it.
 - `docs/v6_telemetry_schema_proposal.md`, `docs/v6_observability_roadmap.md` —
   where any future telemetry-column additions to support boost-state recording
   would be discussed (this review does not advance either).
+
+## 13. Addendum (issue #62 / v5.5 schema)
+
+This addendum was added after the issue #62 implementation PR. The body of
+this review (§1 through §12) describes the state of evidence at the time
+of the original 2026-05-07 analysis and is **left unchanged**. The §6
+finding that no Section 14 boost-state columns existed in the workbook was
+correct as of that date and applies to the historical `VTherm_Launch_Data_v5`
+tab in perpetuity.
+
+**What changed:**
+- Issue #62 added Section 14 boost-state observability columns going
+  forward, in a new wide-table interim schema `VTherm_Launch_Data_v5_5`.
+  The original `VTherm_Launch_Data_v5` tab remains historical and is no
+  longer written to.
+- The new columns (`Section14_Boost_Active`, `Section14_Timer_State`,
+  `Section14_Timer_Remaining`, `Section14_Last_Engage_Reason`,
+  `Section14_Last_Release_Reason`, `Section14_Last_Engage_At`,
+  `Section14_Last_Release_At`, `Section14_Engage_Eligible`,
+  `Section14_WAF_Active`, `Section14_Truth_Available`) are populated by
+  the same 15-minute export plus by Section 14 action-block writes to
+  four new helpers (two `input_text`, two `input_datetime`).
+- Section 14 control logic, triggers, conditions, thresholds (64 °F engage,
+  67 °F truth_cap, 77 °F demand setpoint, 90-minute timer), and climate /
+  timer / latch effects were **not** changed. The new helpers are written
+  AFTER the existing control actions complete.
+
+**What does not change:**
+- Historical rows in `VTherm_Launch_Data_v5` (and prior tabs) remain
+  inferential for Section 14 cycle classification — they still rely on
+  the `LR_Air_Setpoint = 77` proxy described in §6.
+- The four cycles enumerated in §5 (2026-05-03 04:45, 2026-05-03 11:45,
+  2026-05-04 10:00, 2026-05-04 13:30) cannot be retroactively classified
+  by release cause from current evidence.
+- The verdict in §9 — **effectiveness remains unmeasured** — is unchanged
+  by this addendum. v5.5 starts collecting the data needed for a future
+  measurement; it does not retroactively supply that measurement.
+- The verdict in §10 — **#49 close criteria not met** — is unchanged.
+  Issue #49 remains open. v5.5 enables the future evidence pipeline that
+  could eventually satisfy the #49 criteria; this addendum does not.
+
+**Forward path:** with v5.5 active, future Section 14 cycles will record
+their engage cause, release cause, and timestamps directly. Once ≥3 clean
+cycles per the #49 criteria accumulate, an effectiveness verdict can be
+written using direct boost-state telemetry rather than setpoint inference.


### PR DESCRIPTION
## Observability-only

Implements issue #62. Adds Section 14 (V8.4 LR Heating Recovery Boost) boost-state observability fields so future LR boost cycles can be classified directly instead of inferred from the `LR_Air_Setpoint = 77` proxy. **No Section 14 control behavior, threshold, or doctrine change.** Issue #49 remains open and is **not** closed by this PR.

## Schema bump: v5 → v5.5

The telemetry export worksheet name moves from `VTherm_Launch_Data_v5` to `VTherm_Launch_Data_v5_5`.

- v5 (`VTherm_Launch_Data_v5`) — historical and unchanged. No longer written to.
- **v5.5** (`VTherm_Launch_Data_v5_5`) — begins the Section 14 observability era. Wide-table interim schema. Preserves the V5 row model and column conventions; adds a new sub-block 14 of Section 14 boost-state columns.
- v6 — future event-oriented telemetry work. Out of scope here. Not started.

## New helpers (`configuration.yaml`)

`input_text:`
- `lr_heating_recovery_boost_last_engage_reason`
- `lr_heating_recovery_boost_last_release_reason`

`input_datetime:`
- `lr_heating_recovery_boost_last_engage_at`
- `lr_heating_recovery_boost_last_release_at`

These helpers persist last-edge memory of Section 14 engage / release events. They are written by Section 14's engage and release action blocks **after** the existing control actions complete. They do not gate, change, or interrupt any Section 14 trigger, condition, climate command, timer call, or latch flip. They are observability-only and have no control authority.

## New telemetry columns (`automations.yaml` Section 1, sub-block 14)

10 columns appended after the §13 Diagnostics sub-block, in this exact order:

1. `Section14_Boost_Active` — state of `input_boolean.lr_heating_recovery_boost_active`
2. `Section14_Timer_State` — state of `timer.lr_heating_recovery_boost_max_runtime`
3. `Section14_Timer_Remaining` — seconds until `finishes_at` while timer is active; blank otherwise
4. `Section14_Last_Engage_Reason` — value of the engage-reason `input_text` (today: `truth_below_64`)
5. `Section14_Last_Release_Reason` — one of `truth_cap` / `timeout` / `waf` / `season_change` / `truth_unavailable` / `unknown_release_reason`
6. `Section14_Last_Engage_At` — value of the engage-timestamp `input_datetime`
7. `Section14_Last_Release_At` — value of the release-timestamp `input_datetime`
8. `Section14_Engage_Eligible` — `true` / `false` / blank from current engage conditions evaluated at write tick
9. `Section14_WAF_Active` — `true` / `false` / blank from `timer.manual_hvac_override`
10. `Section14_Truth_Available` — `true` / `false` from numeric availability of `sensor.living_room_temperature_truth`

Existing V5 columns are preserved unchanged. None were renamed or removed.

## Section 14 control logic / thresholds — unchanged

| Item | Status |
|---|---|
| Engage trigger (LR truth `< 64 °F`) | unchanged |
| Engage conditions (heating/shoulder, override idle, away off, latch off, climate available, truth numeric) | unchanged |
| 64 °F engage threshold | unchanged |
| 67 °F truth_cap (release at `> 66.99`) | unchanged |
| 77 °F demand setpoint | unchanged |
| `hvac_mode: heat` engage command | unchanged |
| 90-minute (`01:30:00`) max-runtime timer | unchanged |
| `restore: true` on timer | unchanged |
| Release triggers (5 IDs: `truth_cap`, `timeout`, `waf`, `season_change`, `truth_unavailable`) | unchanged |
| Latch on/off semantics | unchanged |
| Release climate-off command and override-idle gating | unchanged |
| Section 2 supervisor | untouched |
| Section 3 safety gates | untouched |
| Truth-sensor logic | untouched |
| MSR / Apollo control status | untouched (still observability-only, not promoted) |
| Apps Script | not implemented |
| V6 event-oriented telemetry | not implemented |

The engage-action observability writes (`input_text.set_value`, `input_datetime.set_datetime`) are appended **after** the existing `input_boolean.turn_on` / `timer.start` / `climate.set_temperature` actions. The release-action `choose:` over `trigger.id` (with a `default:` branch writing `unknown_release_reason`) is appended **after** the existing latch off / timer cancel / climate off actions and is unable to raise on an unrecognized trigger.

## Issue #49 — remains open

Issue #49 is **not** closed by this PR. v5.5 starts collecting the data needed for a future cycle-classification effort; it does not retroactively classify the four already-recorded May 2026 cycles, and it does not constitute an effectiveness verdict. Once ≥3 clean cycles per the #49 acceptance criteria accumulate under v5.5, an effectiveness verdict can be written using direct boost-state telemetry rather than setpoint inference. Until then, no doc may state V8.4 boost is "proven" / "validated" / "working" / "effective" without the evidence-pending caveat and a pointer back to #49.

## ⚠️  Worksheet header row — out-of-band manual step required before deploy

The live Google Sheets `VTherm_Launch_Data_v5_5` worksheet **must** have its header row populated with the 10 new Section 14 columns, in the same order they appear in `automations.yaml` Section 1 sub-block 14, **before** the first export tick after this change ships. Otherwise rows will be misaligned and silently corrupt the new tab.

The previous `VTherm_Launch_Data_v5` worksheet is no longer written to and remains as historical evidence (referenced from `docs/analysis/v8_4_lr_boost_v5_evidence_review.md`).

## Test results

```
$ python -m pytest tests/ -v
============================= test session starts ==============================
collected 11 items

tests/test_automations.py::test_automations_is_list PASSED               [  9%]
tests/test_automations.py::test_automations_have_required_fields PASSED  [ 18%]
tests/test_automations.py::test_automation_ids_are_unique PASSED         [ 27%]
tests/test_automations.py::test_google_sheets_actions_use_secrets PASSED [ 36%]
tests/test_automations.py::test_slugified_entities_check PASSED          [ 45%]
tests/test_automations.py::test_all_automations_have_mode PASSED         [ 54%]
tests/test_safety_invariants.py::test_lr_runaway_cooling_cutoff_exists PASSED [ 63%]
tests/test_safety_invariants.py::test_master_emergency_cooling_floor_exists PASSED [ 72%]
tests/test_safety_invariants.py::test_cooling_not_permitted_below_safety_floor PASSED [ 81%]
tests/test_yaml_syntax.py::test_configuration_yaml_syntax PASSED         [ 90%]
tests/test_yaml_syntax.py::test_automations_yaml_syntax PASSED           [100%]

============================== 11 passed in 0.42s ==============================
```

11/11 pass. YAML syntax for both files is valid. Safety invariants (LR 60 °F runaway cutoff, Master 58 °F emergency floor) intact. No new behavior tests were added — this PR is observability-only and has no behavior change to test beyond schema presence.

## Files changed

- `configuration.yaml` — new `input_text:` and `input_datetime:` blocks (4 helpers)
- `automations.yaml` — Section 1: worksheet name + new sub-block 14 (10 columns); Section 14: engage and release action-block trailing observability writes
- `docs/5_runtime_layer.md` — §2.3, §5.3, §6.5, §11 updated for v5.5 and the four new helpers
- `docs/analysis/v8_4_lr_boost_v5_evidence_review.md` — §13 addendum noting v5.5 columns going forward, with §1–§12 left unchanged

No ESPHome YAML, no other YAML, no other docs changed.

## Runtime safety statement

This PR is **observability-only**. It does not change Section 14 control behavior. It does not tune any threshold (64 °F engage, 67 °F truth_cap, 77 °F demand setpoint, 90-minute timer remain unchanged). It does not modify Section 2, Section 3, Section 11, or any other automation block. It does not modify truth-sensor logic, smoothing parameters, or control wrappers. It does not promote MSR / Apollo data into the control loop. It does not implement V6 routing or Apps Script. It does not claim V8.4 LR boost is effective. It does not close #49.

The only Section 14 edits are trailing `input_text.set_value` and `input_datetime.set_datetime` actions appended **after** the existing control actions in each automation, plus a `choose:` over `trigger.id` (with a safe `default:` branch) on the release path. These cannot interrupt or alter the existing control sequence.

cc #62 #49

https://claude.ai/code/session_01Jm9AwuTsR4mkkymHtHbHuW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jm9AwuTsR4mkkymHtHbHuW)_