### PR TITLE
docs: adopt sheet-side operator annotations

### DIFF
--- a/docs/2_reference_map.md
+++ b/docs/2_reference_map.md
@@ -22,7 +22,7 @@ hierarchy:
 - **Doc 6 / Proposals** — `6_proposals.md` — V9 architectural proposals.
 - **Telemetry Confounders** — `telemetry_confounders.md` — analysis guardrail.
 - **Apollo MSR Observability Checklist** — `apollo_msr_observability_checklist.md` — observability-only doctrine and validation checklist for Apollo MSR sensors (proposed; no control-loop promotion).
-- **Operator Annotation Design** — `operator_annotation_design.md` — proposed out-of-band forensic annotation workflow (Status: Proposed).
+- **Operator Annotation Design** — `operator_annotation_design.md` — out-of-band forensic annotation workflow. Status: sheet-side practice **adopted** (worksheet `supervisor_state_log` in the Home Assistant Google Sheet); Form / Apps Script ingest remains proposed.
 - **V6 Telemetry Schema Proposal** — `v6_telemetry_schema_proposal.md` — proposed `VTherm_Launch_Data_v6` schema (planning only; V5 remains active).
 - **V6 Observability Roadmap** — `v6_observability_roadmap.md` — phase order and guardrails for V5 → V6 observability work.
 - **V8.4 LR Boost V5 Evidence Review** — `analysis/v8_4_lr_boost_v5_evidence_review.md` — tab-by-tab forensic review of Section 14 (V8.4) boost cycles in `VTherm_Launch_Data_v5` and prior versioned tabs. Verdict: effectiveness remains unmeasured; #49 close criteria not met.
@@ -81,7 +81,7 @@ For the topology and routing slices Doc 2 is meant to cover, current sources are
 | Telemetry worksheet / column names | `automations.yaml` Section 1 (`vtherm_mega_tracker_v5`) | Worksheet `VTherm_Launch_Data_v5`. |
 | Operator-suppressed window classification | [`telemetry_confounders.md`](telemetry_confounders.md) | Read before joining columns to behavior. |
 | Apollo MSR observability validation (proposed) | [`apollo_msr_observability_checklist.md`](apollo_msr_observability_checklist.md) | Observability-only; not a control authority. |
-| Operator annotation workflow (proposed) | [`operator_annotation_design.md`](operator_annotation_design.md) | Out-of-band; no HA helpers. Adoption tracked in #50. |
+| Operator annotation workflow (sheet-side adopted) | [`operator_annotation_design.md`](operator_annotation_design.md) and [`telemetry_confounders.md`](telemetry_confounders.md) §6 | Live worksheet `supervisor_state_log` in the Home Assistant workbook. Forensic-only; not read by HA. Form / Apps Script ingest still proposed. Adoption / first-row gate tracked in #50. |
 | V6 telemetry schema (proposed) | [`v6_telemetry_schema_proposal.md`](v6_telemetry_schema_proposal.md) | Planning only. V5 remains active. |
 | V6 observability roadmap (proposed) | [`v6_observability_roadmap.md`](v6_observability_roadmap.md) | Phase order and guardrails. |
 | V8.4 LR boost V5 evidence review | [`analysis/v8_4_lr_boost_v5_evidence_review.md`](analysis/v8_4_lr_boost_v5_evidence_review.md) | Forensic review of Section 14 boost cycles in `VTherm_Launch_Data_v5`. Verdict: effectiveness unmeasured; #49 not yet closeable. |

--- a/docs/operator_annotation_design.md
+++ b/docs/operator_annotation_design.md
@@ -1,14 +1,36 @@
 # Operator Annotation Design — Out-of-Band Forensic Workflow
 
-**Doc Date:** 2026-05-06
+**Doc Date:** 2026-05-07
 **Document Role:** Architecture Design Document (Docs-Only)
-**Status:** Proposed
+**Status:** Adopted — sheet-side, manual. Apps Script / Form ingest remain Proposed.
 
 ---
+
+## 0. Adopted vs. proposed at a glance
+
+| Component                                                       | Status     |
+| --------------------------------------------------------------- | ---------- |
+| Sheet-side annotation surface (`supervisor_state_log`)          | **Adopted** |
+| Workbook: existing **Home Assistant** Google Sheet               | **Adopted** |
+| Manual operator entry into the worksheet                        | **Adopted** |
+| Forensic-only join from annotations to V5/V5.5 telemetry windows | **Adopted** |
+| Google Form ingest path                                         | Proposed (not implemented) |
+| Apps Script validation / formatting                             | Proposed (not implemented) |
+| Home Assistant helper, automation, webhook, or event-bus path   | **Forbidden** |
+
+The current implementation is the **manual sheet-side practice**. There is **no
+Apps Script in production**, **no Google Form in production**, and **no Home
+Assistant integration of any kind** consuming annotation data. The Form/Apps
+Script sections below remain in this document as a forward-looking design
+sketch only; they are not deployed.
 
 ## 1. Purpose
 
 This document outlines the design for an out-of-band forensic annotation workflow for Moose House telemetry. Its primary goal is to provide a structured method for operators to log external confounders—such as manual overrides, maintenance, or environmental anomalies—that impact telemetry but are invisible to the Home Assistant (HA) state engine.
+
+The currently adopted workflow is the **manual sheet-side practice** described
+in §4.0 below. The Form / Apps Script flow described in §4.1–§4.4 remains
+proposed and is **not implemented**.
 
 ## 2. Why Annotations Must Remain Forensic-Only
 
@@ -27,20 +49,60 @@ The Home Assistant instance at Moose House is designed for orchestration, not fr
 3. **No State Pollution:** Creating `input_text` or `input_boolean` helpers inside HA invites the temptation to use them in automations. Removing them entirely removes the temptation.
 4. **Resilience:** If the HA instance reboots or crashes, the forensic logs must remain accessible and intact.
 
-## 4. Proposed Google Sheets / Apps Script Workflow
+## 4. Workflow
 
-The proposed workflow utilizes Google Forms/Sheets as a decoupled, out-of-band system.
+### 4.0 Adopted: manual sheet-side annotation (live)
 
-### 4.1 Logical Workflow
+The live operator workflow is:
+
+1. **Worksheet:** `supervisor_state_log`, inside the existing **Home Assistant**
+   Google Sheets workbook (the same workbook that holds
+   `VTherm_Launch_Data_v5` and `VTherm_Launch_Data_v5_5`).
+2. **Entry method:** the operator types a row directly into the worksheet.
+3. **Header row (minimum):** `start_local`, `end_local`, `kind`, `note`,
+   `created_at`. Additional columns (e.g., `operator_id`) are tolerated and
+   should not break analysis.
+4. **Recommended `kind` values:** `supervisor_disabled`,
+   `manual_setpoint_nudge`, `waf_observed`, `boost_observed`, `away_window`,
+   `truth_unavailable`, `stale_setpoint_artifact`, `hardware_maintenance`,
+   `sensor_relocation`, `comfort_complaint`, `other`. See
+   `docs/telemetry_confounders.md` §6.3 for the canonical list.
+5. **Consumers:** **none in Home Assistant.** Annotations are read only by
+   downstream forensic analysis (humans, notebooks, future BigQuery /
+   pandas joins).
+6. **Join semantics:** an annotation applies to any 15-minute V5/V5.5
+   telemetry row whose timestamp overlaps `[start_local, end_local]`. Point
+   annotations (no `end_local`) snap to the nearest telemetry row plus
+   adjacent rows as needed. See `docs/telemetry_confounders.md` §6.4.
+
+The manual sheet-side practice is **the** practice today. The richer
+Form/Apps Script flow described below is a future design and is not
+implemented.
+
+### 4.1 Proposed Google Sheets / Apps Script Workflow (not implemented)
+
+The following is a forward-looking design for a richer ingest path. It is
+**not deployed** and must not be assumed to exist. The proposed workflow
+utilizes Google Forms/Sheets as a decoupled, out-of-band system.
+
+### 4.1.1 Logical Workflow (proposed)
 
 1. **Submission:** An operator encounters a confounder (e.g., opened a window) and submits a Google Form from their mobile device or workstation.
 2. **Ingestion:** The Google Form directly populates a new row in a dedicated "Annotations" sheet within the telemetry Google Workbook.
 3. **Validation (Apps Script):** A Google Apps Script triggers on form submission. It performs basic validation (e.g., ensuring `Start_Time` is before `End_Time`) and standardizes formatting.
 4. **Storage:** The validated annotation rests in the Google Sheet, entirely isolated from Home Assistant.
 
-### 4.2 Annotation Schema
+> Reminder: §4.1.1–§4.1.4 describe a *proposed* future ingest path. The
+> currently live workflow is the manual sheet-side practice in §4.0.
+> The live worksheet is `supervisor_state_log` and uses the schema in
+> `docs/telemetry_confounders.md` §6.2 (`start_local`, `end_local`, `kind`,
+> `note`, `created_at`), not the PascalCase schema below.
 
-The following fields must be captured for each annotation:
+### 4.1.2 Annotation Schema (proposed; not currently in use)
+
+The following fields would be captured for each annotation if the Form / Apps
+Script ingest path were ever built. The currently adopted live schema is the
+five-field snake_case schema in `docs/telemetry_confounders.md` §6.2.
 
 | Field          | Type     | Description                                                                       |
 | -------------- | -------- | --------------------------------------------------------------------------------- |
@@ -51,9 +113,10 @@ The following fields must be captured for each annotation:
 | End_Time       | DateTime | Exact time the event concluded (can be left null if ongoing, though discouraged). |
 | Forensic_Notes | Text     | Free-form explanation of the event and its context.                               |
 
-### 4.3 Allowed Event_Kind Values
+### 4.1.3 Allowed Event_Kind Values (proposed)
 
-To ensure consistent filtering during analysis, `Event_Kind` should be restricted via a dropdown to the following values:
+To ensure consistent filtering during analysis, `Event_Kind` should be restricted via a dropdown to the following values. The live `kind` column today uses
+the snake_case set in `docs/telemetry_confounders.md` §6.3.
 
 | Event_Kind                | Usage Context                                                                    |
 | ------------------------- | -------------------------------------------------------------------------------- |
@@ -66,9 +129,9 @@ To ensure consistent filtering during analysis, `Event_Kind` should be restricte
 | Comfort Complaint         | WAF-driven adjustment or reported discomfort without immediate manual action.    |
 | Other                     | Unforeseen confounders; requires detailed `Forensic_Notes`.                      |
 
-### 4.4 Conceptual Apps Script Flow
+### 4.1.4 Conceptual Apps Script Flow (proposed; not deployed)
 
-_Note: The following is conceptual pseudocode to illustrate the validation step, not deployable production code._
+_Note: The following is conceptual pseudocode to illustrate the validation step, not deployable production code. **No Apps Script is currently deployed.**_
 
 ```javascript
 // NON-PRODUCTION PSEUDOCODE
@@ -97,17 +160,33 @@ function onFormSubmit(e) {
 
 ## 5. Joining Annotations to Telemetry Windows
 
-Current V5-style analysis commonly uses 15-minute windows (e.g., :00, :15, :30, :45), while future V6 event telemetry may support more granular joins.
+Current V5/V5.5 analysis uses 15-minute windows (`:00`, `:15`, `:30`, `:45`).
+Future V6 event telemetry may support more granular joins.
 
-Annotations are recorded with exact `Start_Time` and `End_Time`. During analysis (typically in pandas, BigQuery, or a secondary Apps Script process):
+Live annotations carry `start_local`, `end_local`, and `created_at`. During analysis (humans, notebooks, future BigQuery / pandas):
 
-- Analysis scripts will perform a timeline overlap or "snap" to join the continuous annotation period against the discrete telemetry windows.
-- Any 15-minute telemetry window that intersects the `[Start_Time, End_Time]` interval of an annotation is flagged with that annotation's `Event_Kind` and `Forensic_Notes`.
-- This allows analysts to filter out contaminated windows (e.g., dropping all rows where `Event_Kind == 'Manual Override'`) without altering the original V5 data structure.
+- Perform a timeline overlap or "snap" to join the annotation interval against
+  the discrete telemetry windows.
+- Any 15-minute telemetry row whose timestamp intersects
+  `[start_local, end_local]` is flagged with that annotation's `kind` and
+  `note`.
+- Point annotations (no `end_local`) snap to the nearest telemetry row, plus
+  adjacent rows if the analyst's evaluation window plausibly extends into
+  them.
+- For #49 V8.4 LR boost clean-cycle evaluation, any overlapping operator
+  annotation must be reviewed before classifying a cycle as `clean_auto`.
+- Annotations let analysts filter out contaminated windows (e.g., drop rows
+  where `kind == 'manual_setpoint_nudge'`) without altering V5/V5.5 data.
+
+> The proposed Form / Apps Script ingest in §4.1 uses PascalCase
+> (`Start_Time`, `End_Time`, `Event_Kind`, `Forensic_Notes`). Until that path
+> is built, **the live schema is the snake_case schema in
+> `docs/telemetry_confounders.md` §6.2** and analysts should treat that as
+> authoritative.
 
 ## 6. Forbidden Paths
 
-To protect the architecture, the following actions are explicitly forbidden regarding this annotation workflow:
+To protect the architecture, the following actions are explicitly forbidden regarding this annotation workflow — under both the adopted sheet-side practice and any future ingest path:
 
 - **NO Home Assistant Helpers:** Do not create `input_text`, `input_boolean`, or any other helper entities in HA to track annotations.
 - **NO Webhooks:** Do not expose webhooks in HA to receive annotation payloads.
@@ -115,3 +194,10 @@ To protect the architecture, the following actions are explicitly forbidden rega
 - **NO Runtime YAML Changes:** `configuration.yaml`, `automations.yaml`, and other runtime files must remain untouched by this design.
 - **NO State Machine Triggers:** Annotations must never trigger, pause, or alter Home Assistant state machines.
 - **NO Event Bus Routing:** Do not route annotations through the HA event bus. They must remain entirely out-of-band.
+- **NO Control-Loop Inputs:** Annotations are forensic labels only. They must
+  never be consumed by Section 2 supervisor logic, Section 3 safety gates,
+  Section 14 LR boost, or any other control surface.
+- **NO Apps Script in production:** Until and unless the Form / Apps Script
+  path in §4.1 is explicitly approved and reviewed, no Apps Script bound to
+  this workbook may write back into HA, mutate telemetry rows, or call any
+  HA-facing endpoint.

--- a/docs/telemetry_confounders.md
+++ b/docs/telemetry_confounders.md
@@ -1,9 +1,10 @@
 # Telemetry Confounders — Operator-Suppressed Supervisor Windows
 
-**Doc Date:** 2026-05-04
+**Doc Date:** 2026-05-07
 **Document Role:** Telemetry Analysis Guardrail
 **Status:** Living. Update when a new confounder pattern is identified or when the
-operator annotation practice changes.
+operator annotation practice changes. Operator annotation practice was moved
+from *Proposed* to *Adopted (sheet-side)* on 2026-05-07; see §6.
 **Scope:** Documentation only. Does not change runtime YAML, thresholds, safety gates,
 or telemetry schema.
 
@@ -127,21 +128,86 @@ as operator-managed.
    a regression entry) cites Apr 28–May 1 as evidence of Section 2 behavior, that
    doc is wrong and should be corrected against this confounder note.
 
-## 6. Operator Annotation Practice (Proposed)
+## 6. Operator Annotation Practice (Adopted — Sheet-Side)
 
-To prevent the same confounder from contaminating future analyses, the operator
-should utilize the **proposed** out-of-band forensic workflow once it is adopted.
-The workflow is currently a design proposal, not implemented operational
-procedure.
+The adopted operator annotation surface is a manual sheet-side workflow. The
+worksheet `supervisor_state_log` lives in the existing **Home Assistant** Google
+Sheets workbook alongside `VTherm_Launch_Data_v5` / `VTherm_Launch_Data_v5_5`.
+Adoption of this practice is tracked in issue #50.
 
-For the full design and schema of this out-of-band workflow, refer to the
-[Operator Annotation Design (`docs/operator_annotation_design.md`)](operator_annotation_design.md)
-(`Status: Proposed`). Adoption is tracked in issue #50; until that issue closes,
-contaminated windows must continue to be classified behaviorally per §4.
+### 6.1 Hard properties
 
-The event journal infrastructure was **retired and removed** after the sink failed
-to register. Do not re-introduce observers or attempt a new event-journal write path
-on the strength of this annotation need without a proven HA-compatible sink.
+- The worksheet is **forensic-only**. It exists to let analysts join human/operator
+  context to telemetry windows after the fact.
+- **Home Assistant does not read this sheet.** No automation, helper, template,
+  webhook, Apps Script, or supervisor logic consumes annotation rows.
+- **Annotations must never trigger automations or change HVAC behavior.** They
+  are a labeling surface, not a control input.
+- No HA helper, no Apps Script, no webhook, no event-bus path is implemented.
+  The worksheet is updated by the operator manually.
+- The retired event-journal sink remains retired. Annotations live in Sheets,
+  not in the HA event bus.
+
+### 6.2 Schema
+
+The header row of `supervisor_state_log` carries (at minimum) these fields:
+
+| Field        | Meaning                                                      |
+| ------------ | ------------------------------------------------------------ |
+| `start_local` | Local start time of the operator/context event.              |
+| `end_local`   | Local end time, if known. May be empty for point annotations. |
+| `kind`        | Event category (see §6.3).                                   |
+| `note`        | Human-readable context.                                      |
+| `created_at`  | When the annotation row was created.                         |
+
+If the operator extends the schema (e.g., `operator_id`, `source`), additional
+columns are tolerated downstream and are not breaking. Analysts should ignore
+unknown columns and never assume a column is mandatory beyond the five above.
+
+### 6.3 Recommended `kind` values
+
+To keep filtering tractable across analyses, the recommended dropdown values
+are:
+
+- `supervisor_disabled` — `automation.v7_5_main_supervisor` was off.
+- `manual_setpoint_nudge` — operator set a non-doctrinal setpoint by hand.
+- `waf_observed` — comfort intervention by household member.
+- `boost_observed` — Section 14 LR boost engagement window observed.
+- `away_window` — household away; thermal load atypical.
+- `truth_unavailable` — truth sensor or contributors went unavailable.
+- `stale_setpoint_artifact` — stale setpoint left over from prior state.
+- `hardware_maintenance` — battery swap, filter clean, network outage.
+- `sensor_relocation` — physical move of a Netatmo / room probe.
+- `comfort_complaint` — reported discomfort without immediate manual action.
+- `other` — anything else; require detail in `note`.
+
+### 6.4 Join guidance for V5/V5.5 telemetry
+
+- Current `VTherm_Launch_Data_v5` / `VTherm_Launch_Data_v5_5` rows land at
+  15-minute boundaries (`:00`, `:15`, `:30`, `:45`).
+- An annotation **applies to any telemetry row whose timestamp overlaps the
+  `[start_local, end_local]` window**.
+- If only `start_local` is known (point annotation), join the annotation to the
+  nearest 15-minute telemetry row, plus adjacent rows if the analyst's
+  evaluation window plausibly extends into them.
+- For #49 V8.4 LR boost clean-cycle evaluation, **any overlapping operator
+  annotation must be reviewed before classifying a cycle as `clean_auto`**.
+  An overlapping `manual_setpoint_nudge`, `waf_observed`,
+  `supervisor_disabled`, `truth_unavailable`, or `stale_setpoint_artifact`
+  generally disqualifies a cycle from a clean-window verdict.
+
+### 6.5 Forbidden paths (carried forward from `operator_annotation_design.md`)
+
+- No `input_text` / `input_boolean` / sensor / template helper for annotations.
+- No webhook ingest from outside HA.
+- No automation that triggers on, or reacts to, annotation data.
+- No Apps Script that writes back into HA or alters telemetry rows.
+- No event-bus routing of annotation payloads.
+- No annotation can become a control-loop input for Section 2, Section 3, or
+  Section 14.
+
+For the architecture rationale and the full forbidden-path list, see
+[Operator Annotation Design (`docs/operator_annotation_design.md`)](operator_annotation_design.md).
 
 ## 7. Hard constraints carried forward
 


### PR DESCRIPTION
## Summary

- Verified the existing **Home Assistant** Google Sheets workbook (id `1URlWLkBYHYzuRcTvB32jPs_Fvs2bdDFn2L-sW3y10w8`, owner `ericmanly@gmail.com`, last modified 2026-05-07) and adopted the sheet-side annotation practice in docs.
- Updated `docs/telemetry_confounders.md` §6 from "Proposed" operator annotation practice to "Adopted — Sheet-Side", pointing at the worksheet `supervisor_state_log`.
- Updated `docs/operator_annotation_design.md` status from "Proposed" to "Adopted — sheet-side, manual"; Form / Apps Script ingest stays Proposed and is explicitly marked not-implemented.
- Updated `docs/2_reference_map.md` status descriptors so future sessions can find the adopted practice.
- Clarified that annotations are **forensic-only** and never part of Home Assistant control logic — no helper, automation, webhook, Apps Script, or event-bus path is added or implied.
- Added the five-field snake_case schema (`start_local`, `end_local`, `kind`, `note`, `created_at`), the recommended `kind` enum, and join guidance for aligning annotations to V5/V5.5 15-minute telemetry windows (and to #49 clean-cycle evaluation).

## Runtime safety

- Docs-only.
- No `automations.yaml` changes.
- No `configuration.yaml` changes.
- No ESPHome changes.
- No scripts / scenes / helper / template / climate-template changes.
- No HA helper annotation path added.
- No Apps Script implemented.
- No webhook implemented.
- No annotation data is read by Home Assistant.
- No HVAC control behavior changed.
- No V8.4 / Section 14 behavior changed; #49 effectiveness is **not** claimed.

## Sheet verification

- **Workbook name:** `Home Assistant` (Google Sheets)
- **Workbook ID:** `1URlWLkBYHYzuRcTvB32jPs_Fvs2bdDFn2L-sW3y10w8`
- **Worksheet name (per issue #50 / per task):** `supervisor_state_log`
- **Header fields found via Drive MCP `read_file_content`:** **inconclusive.** The Drive read returned ~110 KB of content out of a ~494 KB workbook (≈22%). Within the visible window, six rendered table sections were detected, all of them telemetry tabs (`VTherm_Launch_Data_v5_5`, `VTherm_Launch_Data_v5`, and four older `Outdoor_Temp`-style schemas). The `supervisor_state_log` tab was not within the rendered slice, and Drive `fullText` searches for `supervisor_state_log`, `start_local`, `manual_setpoint_nudge`, `waf_observed`, and `boost_observed` returned zero hits.
- **First data row exists?** **Cannot confirm directly** from this PR session. The expected header fields (`start_local`, `end_local`, `kind`, `note`, `created_at`) and any first row do not appear in the indexed/visible portion of the workbook this session can read.
- The task description states the operator has already created the tab, so the PR adopts the practice in docs accordingly. Independent confirmation of the tab and its first row is left to the operator.

## Issue status

Per issue #50's stated close criteria — "first row has been written to a `supervisor_state_log` … worksheet **and** `docs/telemetry_confounders.md` §6 has been updated to point to that worksheet" — the doc half is satisfied by this PR, but I cannot independently verify the first-row half from this session.

**Recommendation:** keep #50 open until the first annotation row is observable. This PR satisfies the documentation half of the close criteria; #50 should remain open pending verification of (or operator confirmation of) the first data row in `supervisor_state_log`.

## Test plan

- [x] `python -m pytest tests/` — 11 passed in 0.35s (test_automations.py, test_safety_invariants.py, test_yaml_syntax.py).
- [x] `git diff origin/main -- '*.yaml' '*.yml'` — empty (no YAML touched by this PR).
- [x] Confirmed no edits to `automations.yaml`, `configuration.yaml`, ESPHome, scripts, scenes, helpers, climate templates, or any runtime surface.

https://claude.ai/code/session_01MjMXiAE5ER1wVsYddGQGfW

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjMXiAE5ER1wVsYddGQGfW)_