### PR TITLE
Add v8.5 HVAC provenance logger (issue #66) — observability-only, narrow first pass

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -1673,3 +1673,129 @@
         entity_id: input_datetime.lr_heating_recovery_boost_last_release_at
       data:
         timestamp: "{{ now().timestamp() | int }}"
+
+# =============================================================================
+# SECTION 15: HVAC PROVENANCE LOGGER (V8.5 Observability)
+# =============================================================================
+# Observability-only logger for issue #66.
+# Writes provenance rows to the Google Sheets worksheet `hvac_provenance_log`
+# (a sibling to `supervisor_state_log`). Does NOT mutate any HVAC state,
+# helper, timer, or input. Does NOT read from Google Sheets. Does NOT change
+# Section 2 / Section 3 / Section 14 behavior. The tab is HA-write-only;
+# no automation, condition, template, or supervisor branch may consume rows
+# from `hvac_provenance_log`. Issue #49 remains open; this logger does not
+# satisfy its close criteria.
+#
+# DEPLOYMENT: the live Google Sheets `hvac_provenance_log` worksheet header
+# row must be created in Sheets BEFORE this change ships, in the column
+# order declared in the action body below, otherwise rows will be misaligned.
+# See docs/hvac_provenance_logger_design.md §7 for the full schema.
+# =============================================================================
+
+- id: v8_5_hvac_provenance_logger
+  alias: "V8.5: HVAC Provenance Logger"
+  mode: parallel
+  max: 20
+  trigger:
+    - platform: state
+      entity_id: climate.living_room_air
+      id: lr_state
+    - platform: state
+      entity_id: climate.living_room_air
+      attribute: temperature
+      id: lr_temp_attr
+    - platform: state
+      entity_id: timer.manual_hvac_override
+      id: override_state
+    - platform: state
+      entity_id: input_boolean.lr_heating_recovery_boost_active
+      id: boost_state
+  condition:
+    # Skip identical-value writes (noise control per design §8.2).
+    - condition: template
+      value_template: >-
+        {% if trigger.id == 'lr_temp_attr' %}
+        {% set ov = trigger.from_state.attributes.temperature if trigger.from_state is not none else none %}
+        {% set nv = trigger.to_state.attributes.temperature if trigger.to_state is not none else none %}
+        {% else %}
+        {% set ov = trigger.from_state.state if trigger.from_state is not none else none %}
+        {% set nv = trigger.to_state.state if trigger.to_state is not none else none %}
+        {% endif %}
+        {{ (ov | string) != (nv | string) }}
+  action:
+    - variables:
+        attribute_name: "{% if trigger.id == 'lr_temp_attr' %}temperature{% else %}state{% endif %}"
+        old_raw: >-
+          {% if trigger.id == 'lr_temp_attr' %}
+          {{ trigger.from_state.attributes.temperature if trigger.from_state is not none else '' }}
+          {% else %}
+          {{ trigger.from_state.state if trigger.from_state is not none else '' }}
+          {% endif %}
+        new_raw: >-
+          {% if trigger.id == 'lr_temp_attr' %}
+          {{ trigger.to_state.attributes.temperature if trigger.to_state is not none else '' }}
+          {% else %}
+          {{ trigger.to_state.state if trigger.to_state is not none else '' }}
+          {% endif %}
+        old_value_clean: >-
+          {% set v = (old_raw | string) | trim %}
+          {{ '' if v in ['None', 'unknown', 'unavailable', ''] else v }}
+        new_value_clean: >-
+          {% set v = (new_raw | string) | trim %}
+          {{ '' if v in ['None', 'unknown', 'unavailable', ''] else v }}
+        ctx_user_id: >-
+          {% if trigger.to_state is not none and trigger.to_state.context is not none %}
+          {{ trigger.to_state.context.user_id if trigger.to_state.context.user_id is not none else '' }}
+          {% else %}{% endif %}
+        ctx_parent_id: >-
+          {% if trigger.to_state is not none and trigger.to_state.context is not none %}
+          {{ trigger.to_state.context.parent_id if trigger.to_state.context.parent_id is not none else '' }}
+          {% else %}{% endif %}
+        ctx_id: >-
+          {% if trigger.to_state is not none and trigger.to_state.context is not none %}
+          {{ trigger.to_state.context.id if trigger.to_state.context.id is not none else '' }}
+          {% else %}{% endif %}
+        # Origin classification per design doc §6 (decision order; first match wins).
+        # Cold-start guard: from_state missing/unknown/unavailable maps to system_restore.
+        # The 5-min uptime refinement is approximated by the from_state signal — once HA
+        # has fully restored, entities transition between known states, not from
+        # unknown/unavailable.
+        origin_kind_v: >-
+          {% if trigger.from_state is none or (trigger.from_state is not none and trigger.from_state.state in ['unknown', 'unavailable']) %}system_restore
+          {% elif trigger.to_state is not none and trigger.to_state.context is not none and trigger.to_state.context.user_id is not none %}manual_user
+          {% elif trigger.to_state is not none and trigger.to_state.context is not none and trigger.to_state.context.user_id is none and trigger.to_state.context.parent_id is not none %}automation_or_script
+          {% elif trigger.to_state is not none and trigger.to_state.context is not none and trigger.to_state.context.user_id is none and trigger.to_state.context.parent_id is none and trigger.entity_id == 'climate.living_room_air' %}integration_or_device
+          {% else %}unknown
+          {% endif %}
+        # Best-effort automation candidate hint per design doc §6 — forensic guidance only.
+        automation_candidate_v: >-
+          {% set ok = (origin_kind_v | trim) %}
+          {% set m = now().minute %}
+          {% set ts = trigger.to_state.state if trigger.to_state is not none else '' %}
+          {% if ok != 'automation_or_script' %}
+          {% elif trigger.entity_id == 'timer.manual_hvac_override' and ts == 'active' %}v7_5_waf_manual_override
+          {% elif trigger.entity_id == 'input_boolean.lr_heating_recovery_boost_active' and ts == 'on' %}v8_4_lr_heating_recovery_boost_engage
+          {% elif trigger.entity_id == 'input_boolean.lr_heating_recovery_boost_active' and ts == 'off' %}v8_4_lr_heating_recovery_boost_release
+          {% elif trigger.entity_id == 'climate.living_room_air' and trigger.id == 'lr_temp_attr' and (new_value_clean | string) == '77' %}v8_4_lr_heating_recovery_boost_engage
+          {% elif trigger.entity_id == 'climate.living_room_air' and m in [0, 15, 30, 45] %}v7_5_main_supervisor
+          {% else %}
+          {% endif %}
+        ts_now_v: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"
+    - action: google_sheets.append_sheet
+      data:
+        config_entry: !secret google_sheets_config_entry
+        worksheet: hvac_provenance_log
+        data:
+          event_local: "{{ ts_now_v }}"
+          entity_id: "{{ trigger.entity_id }}"
+          attribute: "{{ attribute_name }}"
+          old_value: "{{ old_value_clean }}"
+          new_value: "{{ new_value_clean }}"
+          origin_kind: "{{ origin_kind_v | trim }}"
+          context_id: "{{ ctx_id | trim }}"
+          context_parent_id: "{{ ctx_parent_id | trim }}"
+          context_user_id: "{{ ctx_user_id | trim }}"
+          automation_candidate: "{{ automation_candidate_v | trim }}"
+          related_issue: "#66"
+          note: ""
+          created_at: "{{ now().strftime('%Y-%m-%d %H:%M:%S') }}"

--- a/docs/hvac_provenance_logger_design.md
+++ b/docs/hvac_provenance_logger_design.md
@@ -1,14 +1,19 @@
-# HVAC Provenance Logger — Planning (Issue #66)
+# HVAC Provenance Logger — Adopted / Implemented (Issue #66)
 
 **Doc Date:** 2026-05-07
-**Document Role:** Planning artifact for issue #66 (automatic operator
-provenance logging for manual HVAC changes).
-**Status:** Planning only. Docs-only. No runtime YAML changes.
-**Scope Lock:** Documentation only. Does not modify `automations.yaml`,
+**Document Role:** Design + acceptance record for issue #66 (automatic
+operator provenance logging for manual HVAC changes).
+**Status:** Adopted / Implemented. Section 15 of `automations.yaml` now
+contains the `v8_5_hvac_provenance_logger` automation that fulfills this
+design. Implementation PR: "Add v8.5 HVAC provenance logger (issue #66) —
+observability-only, narrow first pass".
+**Scope Lock:** The implementation pass added exactly one new section
+(Section 15) to `automations.yaml` and four new tests in
+`tests/test_provenance_observability.py`. It did not modify
 `configuration.yaml`, helpers, ESPHome, thresholds, Section 2 supervisor
-behavior, Section 3 safety gates, or Section 14 boost behavior. Does not
-promote any annotation/provenance data into a control loop input. Does not
-touch issue #49.
+behavior, Section 3 safety gates, or Section 14 boost behavior. It did not
+promote any annotation/provenance data into a control loop input. Issue #49
+remains open.
 
 ---
 

--- a/docs/operator_annotation_design.md
+++ b/docs/operator_annotation_design.md
@@ -79,6 +79,39 @@ The manual sheet-side practice is **the** practice today. The richer
 Form/Apps Script flow described below is a future design and is not
 implemented.
 
+#### `supervisor_state_log` vs. `hvac_provenance_log`
+
+`supervisor_state_log` is the **human narrative annotation** surface. Rows
+are typed by the operator after the fact and use the schema in
+`docs/telemetry_confounders.md` §6.2 (`start_local`, `end_local`, `kind`,
+`note`, `created_at`). `kind` is the operator's claim about what was
+happening (e.g., `manual_setpoint_nudge`, `waf_observed`,
+`supervisor_disabled`). The worksheet is appended to manually and is
+forensic-only.
+
+`hvac_provenance_log` is the **machine-generated provenance** surface
+adopted in #66. It is appended to automatically by the V8.5 provenance
+logger (`automations.yaml` Section 15, `id: v8_5_hvac_provenance_logger`)
+on every state/setpoint change to the four observed entities listed in
+`docs/hvac_provenance_logger_design.md` §5. Rows use the schema in §7 of
+that doc and carry an `origin_kind` derived from
+`trigger.to_state.context` (`manual_user`, `automation_or_script`,
+`integration_or_device`, `system_restore`, `unknown`). The worksheet is
+also forensic-only, but it is **HA-write-only**: no automation, condition,
+template, supervisor branch, or safety gate may consume rows from it.
+
+The two tabs are sibling surfaces in the same workbook, joinable by time
+and entity but never mixed:
+
+- `supervisor_state_log` — interval-shaped, human author-of-record, low
+  row count, written by the operator, never written by HA.
+- `hvac_provenance_log` — event-shaped, machine-classified, ≤ ~50 rows/day
+  in steady state, written exclusively by the V8.5 provenance logger,
+  never read by HA.
+
+The forbidden-path list in §6 applies to both tabs: neither may become a
+control-loop input.
+
 ### 4.1 Proposed Google Sheets / Apps Script Workflow (not implemented)
 
 The following is a forward-looking design for a richer ingest path. It is

--- a/docs/telemetry_confounders.md
+++ b/docs/telemetry_confounders.md
@@ -209,6 +209,29 @@ are:
 For the architecture rationale and the full forbidden-path list, see
 [Operator Annotation Design (`docs/operator_annotation_design.md`)](operator_annotation_design.md).
 
+### 6.6 Cross-reference: `hvac_provenance_log` (machine provenance, sibling tab)
+
+`supervisor_state_log` is the human narrative annotation surface. Its
+machine sibling is `hvac_provenance_log`, written automatically by the
+V8.5 provenance logger (`automations.yaml` Section 15,
+`id: v8_5_hvac_provenance_logger`, adopted under issue #66). The
+provenance log tags each tracked HVAC state/setpoint change with an
+`origin_kind` (`manual_user`, `automation_or_script`,
+`integration_or_device`, `system_restore`, `unknown`) derived from
+`trigger.to_state.context`. See
+[`docs/hvac_provenance_logger_design.md`](hvac_provenance_logger_design.md)
+for the schema and classification rules, and
+[`docs/operator_annotation_design.md`](operator_annotation_design.md) §4.0
+for the side-by-side comparison with `supervisor_state_log`.
+
+The two tabs share the same forbidden-path discipline as §6.5: the
+provenance tab is **HA-write-only** and may never be read back into a
+control surface (Section 2, Section 3, Section 14, truth-sensor math, or
+any other control loop). For #49 clean-cycle classification, an analyst
+may consult both tabs — `supervisor_state_log` for human-claimed context
+and `hvac_provenance_log` for HA-classified context — but neither row set
+becomes runtime input.
+
 ## 7. Hard constraints carried forward
 
 This document does not change:

--- a/tests/test_provenance_observability.py
+++ b/tests/test_provenance_observability.py
@@ -1,0 +1,240 @@
+"""
+Tests for the V8.5 HVAC Provenance Logger (issue #66).
+
+The provenance logger is a narrow, observability-only automation that
+appends rows to the Google Sheets worksheet `hvac_provenance_log` so
+operators / analysts can classify whether each tracked HVAC change looks
+manual, automation-driven, integration-driven, restore-driven, or unknown.
+
+These tests guard the design contract:
+  1. The automation exists with the documented id / mode / max.
+  2. It writes via google_sheets.append_sheet using the existing
+     `!secret google_sheets_config_entry`, targeting `hvac_provenance_log`.
+  3. The action body never mutates control surfaces (no climate.set_*,
+     no timer.*, no input_*.*, no notify.*, no shell_command.*,
+     no script.log_event).
+  4. No automation reads from `hvac_provenance_log`. The tab is
+     HA-write-only; only the provenance logger's append_sheet target may
+     reference its name.
+
+See docs/hvac_provenance_logger_design.md §10 for the full acceptance
+criteria.
+"""
+
+import os
+import re
+
+import yaml
+import pytest
+
+
+class MooseProvenanceLoader(yaml.SafeLoader):
+    pass
+
+
+def _secret(loader, node):
+    return f"SECRET_{node.value}"
+
+
+def _include(loader, node):
+    return f"INCLUDE_{node.value}"
+
+
+def _input(loader, node):
+    return f"INPUT_{node.value}"
+
+
+def _include_dir_merge_list(loader, node):
+    return []
+
+
+MooseProvenanceLoader.add_constructor("!secret", _secret)
+MooseProvenanceLoader.add_constructor("!include", _include)
+MooseProvenanceLoader.add_constructor("!input", _input)
+MooseProvenanceLoader.add_constructor(
+    "!include_dir_merge_list", _include_dir_merge_list
+)
+MooseProvenanceLoader.add_constructor(
+    "!include_dir_named", _include_dir_merge_list
+)
+
+
+PROVENANCE_ID = "v8_5_hvac_provenance_logger"
+PROVENANCE_WORKSHEET = "hvac_provenance_log"
+
+# Service calls forbidden in the provenance logger's action body. These map
+# 1:1 to docs/hvac_provenance_logger_design.md §10 acceptance criterion 4.
+FORBIDDEN_SERVICES = {
+    "climate.set_temperature",
+    "climate.set_hvac_mode",
+    "timer.start",
+    "timer.cancel",
+    "timer.finish",
+    "input_boolean.turn_on",
+    "input_boolean.turn_off",
+    "input_text.set_value",
+    "input_datetime.set_datetime",
+    "script.log_event",
+}
+
+# Domain-prefix forbids: any service in these domains is rejected.
+FORBIDDEN_DOMAINS = ("notify.", "shell_command.")
+
+
+@pytest.fixture(scope="module")
+def automations_data():
+    file_path = os.path.join(os.path.dirname(__file__), "..", "automations.yaml")
+    with open(file_path, "r") as f:
+        return yaml.load(f, Loader=MooseProvenanceLoader)
+
+
+@pytest.fixture(scope="module")
+def provenance_logger(automations_data):
+    for auto in automations_data:
+        if auto.get("id") == PROVENANCE_ID:
+            return auto
+    pytest.fail(
+        f"Provenance logger automation with id '{PROVENANCE_ID}' not found"
+    )
+
+
+@pytest.fixture(scope="module")
+def automations_yaml_text():
+    file_path = os.path.join(os.path.dirname(__file__), "..", "automations.yaml")
+    with open(file_path, "r") as f:
+        return f.read()
+
+
+def _iter_action_items(action):
+    """Yield every action dict in a possibly-nested action sequence."""
+    if action is None:
+        return
+    if isinstance(action, dict):
+        action = [action]
+    for item in action:
+        if not isinstance(item, dict):
+            continue
+        yield item
+        for nested_key in (
+            "choose",
+            "if",
+            "repeat",
+            "parallel",
+            "default",
+            "then",
+            "else",
+            "sequence",
+        ):
+            nested = item.get(nested_key)
+            if nested is None:
+                continue
+            if nested_key == "choose" and isinstance(nested, list):
+                for choice in nested:
+                    if isinstance(choice, dict):
+                        for sub in _iter_action_items(choice.get("sequence")):
+                            yield sub
+                continue
+            if isinstance(nested, list):
+                for sub in _iter_action_items(nested):
+                    yield sub
+            elif isinstance(nested, dict):
+                for sub in _iter_action_items([nested]):
+                    yield sub
+
+
+def _service_of(item):
+    """Return the service identifier of an action item, or None."""
+    if not isinstance(item, dict):
+        return None
+    return item.get("action") or item.get("service")
+
+
+def test_provenance_logger_exists(provenance_logger):
+    """Automation `v8_5_hvac_provenance_logger` exists with mode=parallel, max=20."""
+    assert provenance_logger.get("id") == PROVENANCE_ID
+    assert provenance_logger.get("mode") == "parallel", (
+        "Provenance logger must declare mode: parallel"
+    )
+    assert provenance_logger.get("max") == 20, (
+        "Provenance logger must declare max: 20"
+    )
+
+
+def test_provenance_logger_uses_google_sheets_secret(provenance_logger):
+    """Logger uses google_sheets.append_sheet with !secret config_entry and the
+    `hvac_provenance_log` worksheet."""
+    sheet_calls = []
+    for item in _iter_action_items(provenance_logger.get("action")):
+        if _service_of(item) == "google_sheets.append_sheet":
+            sheet_calls.append(item)
+
+    assert len(sheet_calls) == 1, (
+        "Provenance logger must contain exactly one google_sheets.append_sheet "
+        f"call (found {len(sheet_calls)})"
+    )
+
+    data = sheet_calls[0].get("data", {}) or {}
+    config_entry = data.get("config_entry")
+    assert config_entry == "SECRET_google_sheets_config_entry", (
+        "Provenance logger must reuse !secret google_sheets_config_entry "
+        f"(found: {config_entry!r})"
+    )
+    assert data.get("worksheet") == PROVENANCE_WORKSHEET, (
+        "Provenance logger must target worksheet 'hvac_provenance_log' "
+        f"(found: {data.get('worksheet')!r})"
+    )
+
+
+def test_provenance_logger_does_not_mutate_control(provenance_logger):
+    """Action block must not call any control-surface service. The logger is
+    observability-only — it may not change climate state, helpers, timers,
+    notify users, run shell commands, or revive script.log_event."""
+    offenders = []
+    for item in _iter_action_items(provenance_logger.get("action")):
+        svc = _service_of(item)
+        if svc is None:
+            continue
+        if svc in FORBIDDEN_SERVICES:
+            offenders.append(svc)
+        elif any(svc.startswith(prefix) for prefix in FORBIDDEN_DOMAINS):
+            offenders.append(svc)
+
+    assert not offenders, (
+        "Provenance logger action body contains forbidden control-surface "
+        f"service calls: {sorted(set(offenders))}. The logger must remain "
+        "observability-only (see docs/hvac_provenance_logger_design.md §10)."
+    )
+
+
+def test_no_automation_reads_hvac_provenance_log(
+    automations_data, automations_yaml_text
+):
+    """No automation may reference `hvac_provenance_log` except the provenance
+    logger's google_sheets.append_sheet write target. Anything else implies
+    HA is reading from (or otherwise consuming) the forensic tab."""
+    # Coarse text guard: the worksheet name should appear only in the logger
+    # automation block — once as the worksheet target, optionally repeated
+    # in section header comments. Any reference outside that block is
+    # disallowed.
+    occurrences = [
+        m.start()
+        for m in re.finditer(
+            re.escape(PROVENANCE_WORKSHEET), automations_yaml_text
+        )
+    ]
+    assert occurrences, (
+        f"Expected at least one mention of '{PROVENANCE_WORKSHEET}' in "
+        "automations.yaml (the logger's worksheet target)."
+    )
+
+    # Structural guard: walk every other automation and assert nothing in its
+    # triggers, conditions, or actions references the worksheet name.
+    for auto in automations_data:
+        if auto.get("id") == PROVENANCE_ID:
+            continue
+        rendered = yaml.safe_dump(auto, default_flow_style=False)
+        assert PROVENANCE_WORKSHEET not in rendered, (
+            f"Automation '{auto.get('id')}' references "
+            f"'{PROVENANCE_WORKSHEET}'. The provenance tab must remain "
+            "HA-write-only — no other automation may read or mention it."
+        )


### PR DESCRIPTION
## Observability-only

This PR adds a single new observability-only Home Assistant automation that writes HVAC provenance rows to a sibling Google Sheets worksheet. **No HVAC control surface mutation. No new helpers. No change to existing automations. No new sinks. The provenance worksheet is HA-write-only and is never read back by Home Assistant.**

## What changed

| File | Change |
| ---- | ------ |
| `automations.yaml` | Adds **Section 15** (the only new content) with one new automation: `v8_5_hvac_provenance_logger`. |
| `tests/test_provenance_observability.py` | New file — four guard tests for the new automation. |
| `docs/hvac_provenance_logger_design.md` | Status flipped Planning → Adopted / Implemented. |
| `docs/operator_annotation_design.md` | Adds a paragraph distinguishing `supervisor_state_log` (human narrative annotation) from `hvac_provenance_log` (machine-generated provenance). |
| `docs/telemetry_confounders.md` | Adds §6.6 cross-reference to `hvac_provenance_log`. |

`configuration.yaml`, ESPHome YAML, scripts, scenes, helpers, truth-sensor templates, climate templates, and all thresholds are **byte-for-byte unchanged**.

## New automation id

- `v8_5_hvac_provenance_logger`
- alias: `V8.5: HVAC Provenance Logger`
- mode: `parallel`, max: `20`

## Triggers (exactly four observation points, narrow first pass)

1. `climate.living_room_air` — state changes (id: `lr_state`).
2. `climate.living_room_air` — `attribute: temperature` changes (id: `lr_temp_attr`).
3. `timer.manual_hvac_override` — state changes (id: `override_state`).
4. `input_boolean.lr_heating_recovery_boost_active` — state changes (id: `boost_state`).

Master / Lincoln / Lilly climates, `hvac_action`, `fan_mode`, season/away/night toggles, and all MSR sensors are explicitly **out of scope** for this first pass (per `docs/hvac_provenance_logger_design.md` §5).

## Output worksheet

- Workbook: existing **Home Assistant** Google Sheets workbook (same workbook as `VTherm_Launch_Data_v5_5` and `supervisor_state_log`).
- Tab: **`hvac_provenance_log`** (new sibling tab — operator must create the header row in Sheets before merge; if not yet done, see "Pre-merge precondition" below).
- Auth: reuses `!secret google_sheets_config_entry` (same as Section 1's v5.5 tracker). No new sinks added.

Row schema: `event_local`, `entity_id`, `attribute`, `old_value`, `new_value`, `origin_kind`, `context_id`, `context_parent_id`, `context_user_id`, `automation_candidate`, `related_issue`, `note`, `created_at`.

## Origin classification (decision order; first match wins)

1. `system_restore` — `from_state is none`/`unknown`/`unavailable` (cold-start guard; suppresses misclassifying restore traffic as `manual_user`).
2. `manual_user` — `to_state.context.user_id is not none` (UI / API / mobile).
3. `automation_or_script` — `user_id is none` and `parent_id is not none` (Section 2 / 3 / 14 paths).
4. `integration_or_device` — both ids `none` and the entity is `climate.living_room_air` (Samsung integration cloud pushes).
5. `unknown` — defensive default; rare; a labelled "did not classify" row.

`automation_candidate` is best-effort forensic guidance only (`v7_5_main_supervisor`, `v8_4_lr_heating_recovery_boost_engage`, `v8_4_lr_heating_recovery_boost_release`, `v7_5_waf_manual_override`, or blank). It is not authoritative and never feeds control logic.

## Runtime safety

- Action body contains **exactly one** `google_sheets.append_sheet` call. No other service calls.
- `climate.set_temperature`, `climate.set_hvac_mode`, `timer.start`, `timer.cancel`, `timer.finish`, `input_boolean.turn_on`, `input_boolean.turn_off`, `input_text.set_value`, `input_datetime.set_datetime`, `notify.*`, `shell_command.*`, and `script.log_event` are all forbidden in the action block — and a new test enforces that.
- The provenance log is **HA-write-only**: no automation, condition, template, or supervisor branch consumes rows from `hvac_provenance_log`. A new test enforces that no other automation references the worksheet name.
- Reuses the existing proven `google_sheets.append_sheet` sink — no `notify.file`, `shell_command`, or revival of `script.log_event` (per `docs/postmortems/2026-05-02_event_journal_containment.md`).
- No new helpers. No `configuration.yaml` change. No threshold tuning. No fan-out across other rooms in the first pass.
- Identical-value writes are skipped via a top-level condition (noise control).

## Sections 2, 3, 14 confirmation

- **Section 2** (`v7_5_main_supervisor`): unchanged. Verified by `git diff origin/main -- automations.yaml` showing one hunk at line 1673 (end of file) only.
- **Section 3** safety gates (`v9_sleep_priority_interlock`, `v8_2_runaway_cooling_cutoff_lr`, `v8_2_master_emergency_floor`, `v7_5_waf_manual_override`, ceiling gate): unchanged.
- **Section 14** boost (`v8_4_lr_heating_recovery_boost_engage`, `v8_4_lr_heating_recovery_boost_release`): unchanged.

## configuration.yaml confirmation

`git diff origin/main -- configuration.yaml` is empty. No helpers added, no timers added, no input_text/boolean/datetime added.

## Tests

New file `tests/test_provenance_observability.py`:

1. `test_provenance_logger_exists` — confirms id `v8_5_hvac_provenance_logger`, `mode: parallel`, `max: 20`.
2. `test_provenance_logger_uses_google_sheets_secret` — confirms `google_sheets.append_sheet` with `config_entry: !secret google_sheets_config_entry` and `worksheet: hvac_provenance_log`.
3. `test_provenance_logger_does_not_mutate_control` — confirms zero forbidden service calls in the action block.
4. `test_no_automation_reads_hvac_provenance_log` — confirms no other automation references the `hvac_provenance_log` worksheet.

## Test results

```
$ python -m pytest tests/
...............                                                          [100%]
15 passed in 0.63s
```

11 pre-existing tests + 4 new tests, all green.

## Diff summary

```
$ git diff origin/main -- configuration.yaml
(empty)

$ git diff origin/main -- automations.yaml
@@ -1673,3 +1673,129 @@        # one hunk only — Section 15 appended
 (124 lines added, 0 removed)
```

## Pre-merge precondition (Google Sheet)

The operator must create the `hvac_provenance_log` worksheet in the existing Home Assistant Google Sheets workbook with the column header row in the order specified above (`event_local`, `entity_id`, `attribute`, `old_value`, `new_value`, `origin_kind`, `context_id`, `context_parent_id`, `context_user_id`, `automation_candidate`, `related_issue`, `note`, `created_at`) **before** this PR merges. Otherwise the first row written by the logger will be misaligned. This precondition is also called out in the Section 15 header comment in the YAML.

If the worksheet has not yet been created, do not merge.

## Issue #49 remains open

This logger improves cycle-classification inputs for #49 (V8.4 LR boost clean-cycle close criteria) but does **not** satisfy its close criteria. **#49 stays open.**

## References

- Issue #66 (originating request).
- `docs/hvac_provenance_logger_design.md` §10 (acceptance criteria).
- `docs/operator_annotation_design.md` §4.0 (sibling-tab distinction).
- `docs/telemetry_confounders.md` §6.6 (cross-reference).
- `docs/postmortems/2026-05-02_event_journal_containment.md` (sink discipline honored).

https://claude.ai/code/session_01Ahxo6CdRcuH8fSwCjgHfG1


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ahxo6CdRcuH8fSwCjgHfG1)_