### PR TITLE
Fix heating recovery boost automation to skip manual triggers

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -1711,6 +1711,15 @@
       entity_id: input_boolean.lr_heating_recovery_boost_active
       id: boost_state
   condition:
+    # Issue #69: skip when fired manually — manual runs do not provide
+    # trigger.from_state / trigger.to_state / trigger.entity_id / trigger.id.
+    - condition: template
+      value_template: >-
+        {{ trigger is defined
+           and trigger.from_state is defined
+           and trigger.to_state is defined
+           and trigger.entity_id is defined
+           and trigger.id is defined }}
     # Skip identical-value writes (noise control per design §8.2).
     - condition: template
       value_template: >-


### PR DESCRIPTION
## Summary
Added a condition to the heating recovery boost automation to prevent execution when triggered manually, which don't provide the expected trigger state variables.

## Key Changes
- Added a template condition that validates the presence of required trigger attributes (`from_state`, `to_state`, `entity_id`, and `id`) before proceeding with automation logic
- This prevents errors and unintended behavior when the automation is manually invoked, as manual triggers lack these state-related attributes

## Implementation Details
The new condition checks that the `trigger` object and all its required state properties are defined before allowing the automation to continue. This acts as a guard clause that ensures only state-change triggers (which provide these attributes) will execute the automation logic, while manual triggers will be safely skipped.

This addresses Issue #69 and aligns with the automation's design intent to respond to entity state changes rather than manual invocations.

https://claude.ai/code/session_01XmHzivgjCYfFcSFmwFbgbJ