### PR TITLE
Fix MSR observability safety allow-list for LR runaway cutoff ID rename

### DIFF
--- a/tests/test_msr_observability_boundary.py
+++ b/tests/test_msr_observability_boundary.py
@@ -98,7 +98,7 @@ LINCOLN_FAN_EXCEPTION_ALLOWED_HVAC_MODES = {"fan_only", "off"}
 
 # Safety automations and the main supervisor must remain MSR-free.
 SAFETY_AUTOMATION_IDS = {
-    "v8_2_runaway_cooling_cutoff_lr",   # 60°F LR runaway cooling cutoff
+    "v8_2_lr_runaway_cooling_cutoff",   # 60°F LR runaway cooling cutoff
     "v8_2_master_emergency_floor",      # 58°F Master emergency cooling floor
     "v7_5_safety_ceiling_gates",        # 76°F all-season ceiling
 }


### PR DESCRIPTION
### Motivation
- Align the MSR observability safety allow-list with the automation ID rename so the LR runaway cooling cutoff remains checked by the MSR boundary test. 

### Description
- Update `SAFETY_AUTOMATION_IDS` in `tests/test_msr_observability_boundary.py` to replace `"v8_2_runaway_cooling_cutoff_lr"` with `"v8_2_lr_runaway_cooling_cutoff"` without changing runtime YAML or doctrine. 

### Testing
- Ran `pytest -q tests/test_safety_invariants.py tests/test_msr_observability_boundary.py` (12 passed) and `pytest -q tests/test_yaml_syntax.py tests/test_automations.py` (9 passed), and confirmed the LR runaway cutoff is still covered by the `SAFETY_AUTOMATION_IDS` entry; changed file: `tests/test_msr_observability_boundary.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061752b3e08323a76173b081597e2a)