### PR TITLE
Tune cooling setpoints for stronger actuator demand

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -364,7 +364,11 @@
         #   temp ≤ off_at → off  (disengage)
         #   in between    → hold current state (deadband via HVAC mode)
         #
-        # The Samsung setpoint does the fine-grained work.
+        # Truth thresholds define comfort ON/OFF behavior (hysteresis).
+        # The commanded Samsung setpoint is actuator-demand, not comfort truth.
+        # Cooling setpoints are intentionally below OFF thresholds so units pull
+        # down decisively and reach truth-based shutdown instead of weak
+        # near-threshold long-run behavior.
         # The supervisor just decides ON vs OFF with hysteresis.
         # Safety backstops live in Section 3 (runaway cutoff, emergency
         # floor, ceiling gates). They operate independently of this logic.
@@ -380,14 +384,14 @@
 
             # ---------------------------------------------------------
             # MASTER BEDROOM
-            # 6pm-6am: Sleep mode (63°F set / off ≤62 / on >66)
-            # 6am-6pm: Normal    (68°F set / off ≤68 / on >72)
+            # 6pm-6am: Sleep mode (61°F set / off ≤62 / on >66)
+            # 6am-6pm: Normal    (66°F set / off ≤68 / on >72)
             # Away:    Relaxed   (74°F set / off ≤74 / on >76)
             # Runaway floor at 58°F lives in Section 3 (independent).
             # ---------------------------------------------------------
             - variables:
                 is_master_sleep: "{{ now().hour >= 18 or now().hour < 6 }}"
-                m_setpoint: "{{ 74 if away else (63 if is_master_sleep else 68) }}"
+                m_setpoint: "{{ 74 if away else (61 if is_master_sleep else 66) }}"
                 m_off_at: "{{ 74 if away else (62 if is_master_sleep else 68) }}"
                 m_on_at: "{{ 76 if away else (66 if is_master_sleep else 72) }}"
                 m_current: "{{ states('climate.master_bedroom_air') }}"
@@ -403,11 +407,11 @@
 
             # ---------------------------------------------------------
             # LINCOLN'S ROOM
-            # All hours: 68°F set / off ≤68 / on >72
+            # All hours: 66°F set / off ≤68 / on >72
             # Away:      74°F set / off ≤74 / on >76
             # ---------------------------------------------------------
             - variables:
-                l_setpoint: "{{ 74 if away else 68 }}"
+                l_setpoint: "{{ 74 if away else 66 }}"
                 l_off_at: "{{ 74 if away else 68 }}"
                 l_on_at: "{{ 76 if away else 72 }}"
                 l_current: "{{ states('climate.lincoln_air') }}"
@@ -423,11 +427,11 @@
 
             # ---------------------------------------------------------
             # LILLY'S ROOM
-            # All hours: 68°F set / off ≤68 / on >72
+            # All hours: 66°F set / off ≤68 / on >72
             # Away:      74°F set / off ≤74 / on >76
             # ---------------------------------------------------------
             - variables:
-                ly_setpoint: "{{ 74 if away else 68 }}"
+                ly_setpoint: "{{ 74 if away else 66 }}"
                 ly_off_at: "{{ 74 if away else 68 }}"
                 ly_on_at: "{{ 76 if away else 72 }}"
                 ly_current: "{{ states('climate.lilly_air') }}"
@@ -442,13 +446,13 @@
                 temperature: "{{ ly_setpoint }}"
 
             # ---------------------------------------------------------
-            # LIVING ROOM (V8.2: around-the-clock 68/72)
-            # All hours: 68°F set / off ≤68 / on >72
+            # LIVING ROOM (V8.2: around-the-clock 68/72 truth thresholds)
+            # All hours: 66°F set / off ≤68 / on >72
             # Away:      74°F set / off ≤74 / on >76
             # Runaway cutoff at 60°F lives in Section 3 (independent).
             # ---------------------------------------------------------
             - variables:
-                lr_setpoint: "{{ 74 if away else 68 }}"
+                lr_setpoint: "{{ 74 if away else 66 }}"
                 lr_off_at: "{{ 74 if away else 68 }}"
                 lr_on_at: "{{ 76 if away else 72 }}"
                 lr_current: "{{ states('climate.living_room_air') }}"

--- a/tests/test_section2_cooling_setpoint_doctrine.py
+++ b/tests/test_section2_cooling_setpoint_doctrine.py
@@ -1,0 +1,92 @@
+import os
+import yaml
+
+
+class MooseAutomationLoader(yaml.SafeLoader):
+    pass
+
+
+def secret_constructor(loader, node):
+    return f"SECRET_{node.value}"
+
+
+def include_constructor(loader, node):
+    return f"INCLUDE_{node.value}"
+
+
+def input_constructor(loader, node):
+    return f"INPUT_{node.value}"
+
+
+def include_dir_merge_list_constructor(loader, node):
+    return []
+
+
+MooseAutomationLoader.add_constructor('!secret', secret_constructor)
+MooseAutomationLoader.add_constructor('!include', include_constructor)
+MooseAutomationLoader.add_constructor('!input', input_constructor)
+MooseAutomationLoader.add_constructor('!include_dir_merge_list', include_dir_merge_list_constructor)
+MooseAutomationLoader.add_constructor('!include_dir_named', include_dir_merge_list_constructor)
+
+
+def _load_main_supervisor_actions():
+    file_path = os.path.join(os.path.dirname(__file__), '..', 'automations.yaml')
+    with open(file_path, 'r') as f:
+        data = yaml.load(f, Loader=MooseAutomationLoader)
+
+    supervisor = next(
+        (a for a in data if a.get('id') == 'v7_5_main_supervisor'),
+        None,
+    )
+    assert supervisor is not None, "Main supervisor automation v7_5_main_supervisor not found"
+
+    actions = supervisor.get('action', [])
+    assert isinstance(actions, list), "Main supervisor actions must be a list"
+    return actions
+
+
+def _extract_cooling_variable_templates(actions):
+    templates = {}
+    for item in actions:
+        if isinstance(item, dict) and 'choose' in item:
+            for choice in item.get('choose', []):
+                sequence = choice.get('sequence', [])
+                for step in sequence:
+                    if isinstance(step, dict) and 'variables' in step:
+                        for k, v in step['variables'].items():
+                            if k in {
+                                'm_setpoint', 'm_off_at', 'm_on_at',
+                                'l_setpoint', 'l_off_at', 'l_on_at',
+                                'ly_setpoint', 'ly_off_at', 'ly_on_at',
+                                'lr_setpoint', 'lr_off_at', 'lr_on_at',
+                            }:
+                                templates[k] = v
+            break
+
+    missing = {
+        'm_setpoint', 'm_off_at', 'm_on_at',
+        'l_setpoint', 'l_off_at', 'l_on_at',
+        'ly_setpoint', 'ly_off_at', 'ly_on_at',
+        'lr_setpoint', 'lr_off_at', 'lr_on_at',
+    } - templates.keys()
+    assert not missing, f"Missing expected Section 2 cooling variable templates: {sorted(missing)}"
+    return templates
+
+
+def test_section2_cooling_setpoint_and_threshold_doctrine():
+    templates = _extract_cooling_variable_templates(_load_main_supervisor_actions())
+
+    assert templates['m_setpoint'] == "{{ 74 if away else (61 if is_master_sleep else 66) }}"
+    assert templates['l_setpoint'] == "{{ 74 if away else 66 }}"
+    assert templates['ly_setpoint'] == "{{ 74 if away else 66 }}"
+    assert templates['lr_setpoint'] == "{{ 74 if away else 66 }}"
+
+    assert templates['m_off_at'] == "{{ 74 if away else (62 if is_master_sleep else 68) }}"
+    assert templates['m_on_at'] == "{{ 76 if away else (66 if is_master_sleep else 72) }}"
+
+    assert templates['l_off_at'] == "{{ 74 if away else 68 }}"
+    assert templates['l_on_at'] == "{{ 76 if away else 72 }}"
+    assert templates['ly_off_at'] == "{{ 74 if away else 68 }}"
+    assert templates['ly_on_at'] == "{{ 76 if away else 72 }}"
+    assert templates['lr_off_at'] == "{{ 74 if away else 68 }}"
+    assert templates['lr_on_at'] == "{{ 76 if away else 72 }}"


### PR DESCRIPTION
### Motivation
- Prevent Samsung mini-splits from loafing or running weakly near the comfort OFF threshold by increasing actuator demand while keeping truth sensors as the authority for ON/OFF decisions. 
- Keep existing truth-based `*_on_at`/`*_off_at` thresholds, safety floors, and all Section 3 safety gates unchanged. 

### Description
- Clarified Section 2 Branch 1 comments to document that truth thresholds define comfort ON/OFF behavior and the commanded Samsung setpoint is actuator-demand intended to be below the OFF threshold. 
- Lowered occupied cooling commanded setpoints in Section 2 Branch 1 only: `m_setpoint` changed to `"{{ 74 if away else (61 if is_master_sleep else 66) }}``, `l_setpoint`/`ly_setpoint`/`lr_setpoint` changed to `"{{ 74 if away else 66 }}``, and left every `*_off_at` and `*_on_at` template unchanged. 
- Did not modify any safety gates, away-mode behavior, shoulder-season logic, WAF/manual override, or telemetry schema, and preserved comments and architecture around Section 2. 
- Added a static doctrine test `tests/test_section2_cooling_setpoint_doctrine.py` that asserts the new setpoints and that ON/OFF/away thresholds remain unchanged. 

### Testing
- Ran `pytest -q tests/test_yaml_syntax.py tests/test_automations.py tests/test_safety_invariants.py tests/test_section2_cooling_setpoint_doctrine.py`. 
- Result: all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061fd05ecc8323b8e64d8da014cb40)