### PR TITLE
supervisor: allow Master cooling escape on shoulder-night

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -483,8 +483,30 @@
                       data:
                         hvac_mode: "{{ 'heat' if lr_temp < (58 if away else 65) else 'off' }}"
                         temperature: "{{ 58 if away else 65 }}"
+                    # ---------------------------------------------------------
+                    # Shoulder-night Master cooling escape (sleep comfort).
+                    # Outdoor temp may influence preferred climate strategy,
+                    # but a bedroom above the sleep cooling threshold must
+                    # still be allowed to cool. Thresholds mirror the
+                    # cooling-season Master sleep band so behavior is
+                    # consistent. Safety floor (58°F) lives in Section 3.
+                    # ---------------------------------------------------------
+                    - variables:
+                        m_sleep_on_at: "{{ 76 if away else 66 }}"
+                        m_sleep_off_at: "{{ 74 if away else 62 }}"
+                        m_sleep_setpoint: "{{ 74 if away else 61 }}"
+                        m_current: "{{ states('climate.master_bedroom_air') }}"
+                    - action: climate.set_temperature
+                      target: { entity_id: climate.master_bedroom_air }
+                      data:
+                        hvac_mode: >-
+                          {% if master_temp > m_sleep_on_at %}cool
+                          {% elif master_temp <= m_sleep_off_at %}off
+                          {% elif m_current == 'cool' %}cool
+                          {% else %}off{% endif %}
+                        temperature: "{{ m_sleep_setpoint }}"
                     - action: climate.set_hvac_mode
-                      target: { entity_id: [climate.master_bedroom_air, climate.lincoln_air, climate.lilly_air, climate.dining_room] }
+                      target: { entity_id: [climate.lincoln_air, climate.lilly_air, climate.dining_room] }
                       data: { hvac_mode: "off" }
               default:
                 - choose:

--- a/tests/test_supervisor_shoulder_night.py
+++ b/tests/test_supervisor_shoulder_night.py
@@ -1,0 +1,177 @@
+import os
+
+import pytest
+import yaml
+
+
+class MooseSupervisorLoader(yaml.SafeLoader):
+    pass
+
+
+def _yaml_include(loader, node):
+    return f"INCLUDE_{node.value}"
+
+
+def _yaml_secret(loader, node):
+    return f"SECRET_{node.value}"
+
+
+def _yaml_input(loader, node):
+    return f"INPUT_{node.value}"
+
+
+def _yaml_include_list(loader, node):
+    return []
+
+
+MooseSupervisorLoader.add_constructor("!include", _yaml_include)
+MooseSupervisorLoader.add_constructor("!secret", _yaml_secret)
+MooseSupervisorLoader.add_constructor("!input", _yaml_input)
+MooseSupervisorLoader.add_constructor("!include_dir_merge_list", _yaml_include_list)
+MooseSupervisorLoader.add_constructor("!include_dir_named", _yaml_include_list)
+
+
+SUPERVISOR_ID = "v7_5_main_supervisor"
+
+
+@pytest.fixture(scope="module")
+def supervisor():
+    path = os.path.join(os.path.dirname(__file__), "..", "automations.yaml")
+    with open(path, "r") as fh:
+        data = yaml.load(fh, Loader=MooseSupervisorLoader)
+    auto = next((a for a in data if a.get("id") == SUPERVISOR_ID), None)
+    assert auto is not None, f"{SUPERVISOR_ID} automation must exist"
+    return auto
+
+
+def _outer_choose(supervisor):
+    for step in supervisor.get("action", []):
+        if isinstance(step, dict) and "choose" in step:
+            return step["choose"]
+    pytest.fail("Could not find the season choose block in v7_5_main_supervisor")
+
+
+def _shoulder_branch(supervisor):
+    for branch in _outer_choose(supervisor):
+        for cond in branch.get("conditions", []):
+            template = cond.get("value_template", "")
+            if "season == 'shoulder'" in template:
+                return branch
+    pytest.fail("Could not find the shoulder-season branch")
+
+
+def _shoulder_night_sequence(supervisor):
+    shoulder = _shoulder_branch(supervisor)
+    for step in shoulder.get("sequence", []):
+        if isinstance(step, dict) and "choose" in step:
+            for sub in step["choose"]:
+                conds = sub.get("conditions", [])
+                if any("is_night" in c.get("value_template", "") for c in conds):
+                    return sub.get("sequence", [])
+    pytest.fail("Could not find the shoulder-night sub-branch")
+
+
+def _bulk_off_targets(sequence):
+    for step in sequence:
+        if (
+            isinstance(step, dict)
+            and (step.get("action") or step.get("service")) == "climate.set_hvac_mode"
+            and step.get("data", {}).get("hvac_mode") in ("off", False)
+        ):
+            entity_id = step.get("target", {}).get("entity_id")
+            if isinstance(entity_id, str):
+                return [entity_id]
+            return list(entity_id or [])
+    pytest.fail("Shoulder-night sub-branch has no bulk set_hvac_mode off step")
+
+
+def _master_cooling_step(sequence):
+    for step in sequence:
+        if not isinstance(step, dict):
+            continue
+        if (step.get("action") or step.get("service")) != "climate.set_temperature":
+            continue
+        target = step.get("target", {}).get("entity_id")
+        targets = [target] if isinstance(target, str) else list(target or [])
+        if "climate.master_bedroom_air" in targets:
+            return step
+    return None
+
+
+def test_shoulder_night_master_cooling_escape_step_exists(supervisor):
+    sequence = _shoulder_night_sequence(supervisor)
+    step = _master_cooling_step(sequence)
+    assert step is not None, (
+        "Shoulder-night sub-branch must contain a climate.set_temperature step "
+        "targeting climate.master_bedroom_air (sleep-comfort escape)."
+    )
+
+    hvac_template = step.get("data", {}).get("hvac_mode", "")
+    for token in ("cool", "off", "master_temp"):
+        assert token in hvac_template, (
+            f"Master cooling escape hvac_mode template must reference '{token}' "
+            f"in the same step (single-action-dict invariant). Template was: "
+            f"{hvac_template!r}"
+        )
+
+
+def test_shoulder_night_bulk_off_excludes_master(supervisor):
+    targets = _bulk_off_targets(_shoulder_night_sequence(supervisor))
+    assert "climate.master_bedroom_air" not in targets, (
+        "Shoulder-night bulk-off list must not include climate.master_bedroom_air; "
+        "master cooling escape owns that entity in this sub-branch."
+    )
+
+
+def test_shoulder_night_bulk_off_still_covers_lincoln_lilly_dining(supervisor):
+    targets = _bulk_off_targets(_shoulder_night_sequence(supervisor))
+    for entity_id in ("climate.lincoln_air", "climate.lilly_air", "climate.dining_room"):
+        assert entity_id in targets, (
+            f"Shoulder-night bulk-off list must still include {entity_id}; "
+            f"only master_bedroom_air is intentionally excluded."
+        )
+
+
+def test_shoulder_night_lr_heating_preserved(supervisor):
+    sequence = _shoulder_night_sequence(supervisor)
+    lr_step = next(
+        (
+            s
+            for s in sequence
+            if isinstance(s, dict)
+            and (s.get("action") or s.get("service")) == "climate.set_temperature"
+            and s.get("target", {}).get("entity_id") == "climate.living_room_air"
+        ),
+        None,
+    )
+    assert lr_step is not None, "Shoulder-night LR set_temperature step must exist"
+
+    data = lr_step.get("data", {})
+    assert "lr_temp < (58 if away else 65)" in data.get("hvac_mode", ""), (
+        "Shoulder-night LR heat/off decision must still gate on "
+        "lr_temp < (58 if away else 65)."
+    )
+    assert data.get("temperature") == "{{ 58 if away else 65 }}", (
+        "Shoulder-night LR commanded temperature must still be 58/65."
+    )
+
+
+def test_shoulder_night_master_setpoint_below_off_threshold(supervisor):
+    sequence = _shoulder_night_sequence(supervisor)
+    step = _master_cooling_step(sequence)
+    assert step is not None
+
+    variable_steps = [
+        s for s in sequence if isinstance(s, dict) and isinstance(s.get("variables"), dict)
+    ]
+    merged = {}
+    for vs in variable_steps:
+        merged.update(vs["variables"])
+
+    on_at = merged.get("m_sleep_on_at", "")
+    off_at = merged.get("m_sleep_off_at", "")
+    setpoint = merged.get("m_sleep_setpoint", "")
+
+    assert "if away else 66" in on_at, f"m_sleep_on_at template unexpected: {on_at!r}"
+    assert "if away else 62" in off_at, f"m_sleep_off_at template unexpected: {off_at!r}"
+    assert "if away else 61" in setpoint, f"m_sleep_setpoint template unexpected: {setpoint!r}"


### PR DESCRIPTION
## Summary

This is a narrow runtime comfort fix for shoulder-night Master bedroom cooling suppression. Outdoor temperature may influence preferred climate strategy, but it must not veto sleep comfort when Master truth is above the existing sleep cooling threshold. Safety floors remain unchanged.

## What changed

Inside `v7_5_main_supervisor` → Section 2 → `season == 'shoulder'` → `is_night` sub-branch:

- **Preserved** the existing Living Room `set_temperature` step that decides `heat` vs `off` from `lr_temp < (58 if away else 65)` and commands setpoint 58/65.
- **Added** a Master cooling escape immediately after the LR step. It reuses the cooling-season Master sleep band so the system behaves consistently across seasons:
  - `m_sleep_on_at`: `{{ 76 if away else 66 }}`
  - `m_sleep_off_at`: `{{ 74 if away else 62 }}`
  - `m_sleep_setpoint`: `{{ 74 if away else 61 }}`
  - Mode logic: `cool` if `master_temp > on_at`, `off` if `master_temp ≤ off_at`, preserve current state otherwise.
- **Removed only** `climate.master_bedroom_air` from the shoulder-night bulk `climate.set_hvac_mode: off` target list. `climate.lincoln_air`, `climate.lilly_air`, and `climate.dining_room` remain in the bulk-off list.

## What is explicitly NOT changed

- Section 3 safety floors: `v8_2_lr_runaway_cooling_cutoff` (LR 60°F) and `v8_2_master_emergency_floor` (Master 58°F).
- `v7_5_safety_ceiling_gates` (76°F).
- `v7_5_waf_manual_override` and the `timer.manual_hvac_override: idle` gate at the top of the supervisor — manual override still locks this new escape path out just like the rest of the supervisor.
- `v9_sleep_priority_interlock` — unchanged. With Master now allowed to enter `cool` during shoulder-night, the interlock can fire to turn LR off when LR is heating and LR truth > 60°F. That is the intended sleep-priority behavior.
- All automation IDs, MSR observability boundaries (`tests/test_msr_observability_boundary.py`), and Sections 4, 5, 6, 8, 14 are untouched.
- Lincoln, Lilly, and Dining shoulder-night behavior — unchanged (bulk-off). Lincoln and Lilly are deliberately deferred for a later patch because they have presence-debounced couplings (`binary_sensor.lincoln_presence_debounced_v3`, fan destratification, ghost-assassin) that need to be considered as a unit.

## Tests

New file: `tests/test_supervisor_shoulder_night.py` — five static-YAML assertions:

1. `test_shoulder_night_master_cooling_escape_step_exists` — verifies a single `climate.set_temperature` step targets `climate.master_bedroom_air` and its `hvac_mode` template contains `cool`, `off`, and `master_temp` in the same step (single-action-dict invariant).
2. `test_shoulder_night_bulk_off_excludes_master` — verifies the bulk `set_hvac_mode: off` no longer targets master.
3. `test_shoulder_night_bulk_off_still_covers_lincoln_lilly_dining` — verifies the remaining three are still in the bulk-off list.
4. `test_shoulder_night_lr_heating_preserved` — verifies the LR step still gates on `lr_temp < (58 if away else 65)` with setpoint 58/65.
5. `test_shoulder_night_master_setpoint_below_off_threshold` — pins the three sleep-band literals so a future edit can't silently drift them.

No HA runtime simulation. No new dependencies.

## Verification

```
$ python -m pytest -q
...............................                                          [100%]
31 passed in 1.00s
```

Pre-change suite: 26 tests. Post-change: 31 tests (5 new). All existing safety, MSR, provenance, automations, and yaml-syntax tests continue to pass.

## Rollback

Single commit. `git revert` and push. The supervisor's `/15` cadence means recovery is one tick after the revert merges.

## Test plan

- [ ] CI pytest job green on this PR.
- [ ] Watch first shoulder-season night after merge: confirm Master enters `cool` if truth > 66°F and goes back to `off` once truth ≤ 62°F.
- [ ] Confirm Lincoln, Lilly, Dining remain off through shoulder-night (no regression).
- [ ] Confirm `v9_sleep_priority_interlock` correctly turns LR off if LR is heating while Master is cooling and LR truth > 60°F.
- [ ] Confirm `v8_2_master_emergency_floor` still arms (no fire expected — it's an equipment-protection floor).

https://claude.ai/code/session_019hnH8zac9pTSaQYrzMnWsr

---
_Generated by [Claude Code](https://claude.ai/code/session_019hnH8zac9pTSaQYrzMnWsr)_