### PR TITLE
Add tests enforcing manual HVAC override contract for automations

### DIFF
--- a/tests/test_manual_override_contract.py
+++ b/tests/test_manual_override_contract.py
@@ -1,0 +1,194 @@
+import os
+
+import pytest
+import yaml
+
+
+class MooseManualOverrideLoader(yaml.SafeLoader):
+    pass
+
+
+def _secret(loader, node):
+    return f"SECRET_{node.value}"
+
+
+def _include(loader, node):
+    return f"INCLUDE_{node.value}"
+
+
+def _input(loader, node):
+    return f"INPUT_{node.value}"
+
+
+def _include_dir_merge_list(loader, node):
+    return []
+
+
+MooseManualOverrideLoader.add_constructor("!secret", _secret)
+MooseManualOverrideLoader.add_constructor("!include", _include)
+MooseManualOverrideLoader.add_constructor("!input", _input)
+MooseManualOverrideLoader.add_constructor(
+    "!include_dir_merge_list", _include_dir_merge_list
+)
+MooseManualOverrideLoader.add_constructor(
+    "!include_dir_named", _include_dir_merge_list
+)
+
+
+@pytest.fixture(scope="module")
+def automations_data():
+    file_path = os.path.join(os.path.dirname(__file__), "..", "automations.yaml")
+    with open(file_path, "r") as f:
+        return yaml.load(f, Loader=MooseManualOverrideLoader)
+
+
+def _get_automation(automations_data, automation_id):
+    for auto in automations_data:
+        if auto.get("id") == automation_id:
+            return auto
+    pytest.fail(f"Automation with id '{automation_id}' not found")
+
+
+def _iter_nodes(node):
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _iter_nodes(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_nodes(item)
+
+
+def _has_manual_override_idle_condition(auto):
+    for node in _iter_nodes(auto.get("condition", [])):
+        if (
+            node.get("condition") == "state"
+            and node.get("entity_id") == "timer.manual_hvac_override"
+            and node.get("state") == "idle"
+        ):
+            return True
+    return False
+
+
+def _has_any_manual_override_condition(auto):
+    for node in _iter_nodes(auto.get("condition", [])):
+        if node.get("entity_id") == "timer.manual_hvac_override":
+            return True
+    return False
+
+
+def _assert_respects_manual_override_idle(automations_data, automation_id):
+    auto = _get_automation(automations_data, automation_id)
+    assert _has_manual_override_idle_condition(auto), (
+        f"Manual Override Contract violation for '{automation_id}': expected "
+        "a condition requiring timer.manual_hvac_override == idle. "
+        "See docs/5_runtime_layer.md §7.8 and docs/3_regression_appendix.md §4.15."
+    )
+
+
+def test_supervisor_respects_manual_override(automations_data):
+    _assert_respects_manual_override_idle(automations_data, "v7_5_main_supervisor")
+
+
+def test_ceiling_gates_respect_manual_override(automations_data):
+    _assert_respects_manual_override_idle(automations_data, "v7_5_safety_ceiling_gates")
+
+
+def test_destratification_respects_manual_override(automations_data):
+    _assert_respects_manual_override_idle(
+        automations_data, "v8_comfort_fan_destratification"
+    )
+
+
+def test_samsung_guardrail_respects_manual_override(automations_data):
+    _assert_respects_manual_override_idle(automations_data, "v8_samsung_auto_guardrail")
+
+
+def test_boost_engage_respects_manual_override(automations_data):
+    _assert_respects_manual_override_idle(
+        automations_data, "v8_4_lr_heating_recovery_boost_engage"
+    )
+
+
+def test_boost_release_yields_to_manual_override(automations_data):
+    auto = _get_automation(automations_data, "v8_4_lr_heating_recovery_boost_release")
+
+    waf_trigger_found = any(
+        trigger.get("platform") == "state"
+        and trigger.get("entity_id") == "timer.manual_hvac_override"
+        and trigger.get("to") == "active"
+        and trigger.get("id") == "waf"
+        for trigger in auto.get("trigger", [])
+    )
+    assert waf_trigger_found, (
+        "Manual Override Contract violation: v8_4_lr_heating_recovery_boost_release "
+        "must include WAF trigger (platform: state, entity_id: "
+        "timer.manual_hvac_override, to: active, id: waf). "
+        "See docs/5_runtime_layer.md §7.8 and docs/3_regression_appendix.md §4.16."
+    )
+
+    choose_guard_with_lr_off = False
+    for action_item in auto.get("action", []):
+        if not isinstance(action_item, dict) or "choose" not in action_item:
+            continue
+
+        for branch in action_item.get("choose", []):
+            if not isinstance(branch, dict):
+                continue
+
+            conditions = branch.get("conditions", [])
+            has_contract_guard = any(
+                isinstance(cond, dict)
+                and cond.get("condition") == "not"
+                and isinstance(cond.get("conditions"), list)
+                and any(
+                    isinstance(inner, dict)
+                    and inner.get("condition") == "state"
+                    and inner.get("entity_id") == "timer.manual_hvac_override"
+                    and inner.get("state") == "active"
+                    for inner in cond.get("conditions", [])
+                )
+                for cond in conditions
+            )
+            if not has_contract_guard:
+                continue
+
+            sequence = branch.get("sequence", [])
+            has_lr_off = any(
+                isinstance(step, dict)
+                and (step.get("action") or step.get("service"))
+                == "climate.set_hvac_mode"
+                and (step.get("target") or {}).get("entity_id")
+                == "climate.living_room_air"
+                and (step.get("data") or {}).get("hvac_mode") == "off"
+                for step in sequence
+            )
+            if has_lr_off:
+                choose_guard_with_lr_off = True
+                break
+
+        if choose_guard_with_lr_off:
+            break
+
+    assert choose_guard_with_lr_off, (
+        "Manual Override Contract violation: boost release climate-off path must be in "
+        "a choose branch guarded by `not(state(timer.manual_hvac_override == active))`, "
+        "so manual override (WAF) does not force LR HVAC off. "
+        "See docs/5_runtime_layer.md §7.8 and docs/3_regression_appendix.md §4.15/§4.16."
+    )
+
+
+def test_lr_runaway_does_not_gate_on_override(automations_data):
+    auto = _get_automation(automations_data, "v8_2_lr_runaway_cooling_cutoff")
+    assert not _has_any_manual_override_condition(auto), (
+        "True safety gate v8_2_lr_runaway_cooling_cutoff must not gate on "
+        "timer.manual_hvac_override. See docs/5_runtime_layer.md §7.8."
+    )
+
+
+def test_master_floor_does_not_gate_on_override(automations_data):
+    auto = _get_automation(automations_data, "v8_2_master_emergency_floor")
+    assert not _has_any_manual_override_condition(auto), (
+        "True safety gate v8_2_master_emergency_floor must not gate on "
+        "timer.manual_hvac_override. See docs/5_runtime_layer.md §7.8."
+    )


### PR DESCRIPTION
### Motivation
- Ensure all relevant automations respect the manual HVAC override contract for `timer.manual_hvac_override` to prevent automation actions during user override state.
- Verify that certain safety-critical automations do not gate on the manual override so they always execute when needed.
- Capture specific contract requirements around boost release behavior so manual override (WAF) does not inadvertently force LR HVAC off.

### Description
- Add `tests/test_manual_override_contract.py` which defines a `MooseManualOverrideLoader` to safely load `automations.yaml` while stubbing YAML tags like `!secret`, `!include`, and `!input`.
- Implement helpers to locate automations and traverse nested `trigger`, `condition`, and `action` structures and assert presence or absence of `timer.manual_hvac_override` checks.
- Add tests that assert manual-override-idle gating for automations `v7_5_main_supervisor`, `v7_5_safety_ceiling_gates`, `v8_comfort_fan_destratification`, `v8_samsung_auto_guardrail`, and `v8_4_lr_heating_recovery_boost_engage`, and verify WAF trigger and guarded boost-release-off path for `v8_4_lr_heating_recovery_boost_release`.
- Add tests that assert safety gates `v8_2_lr_runaway_cooling_cutoff` and `v8_2_master_emergency_floor` do not gate on the manual override.

### Testing
- Run `pytest tests/test_manual_override_contract.py` to execute the new contract tests.
- All tests in `tests/test_manual_override_contract.py` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08e0d56124832398fd47f7b7997126)