### PR TITLE
Fan out HVAC provenance logging to bedroom climates

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -1737,6 +1737,27 @@
       attribute: temperature
       id: lr_temp_attr
     - platform: state
+      entity_id: climate.master_bedroom_air
+      id: master_state
+    - platform: state
+      entity_id: climate.master_bedroom_air
+      attribute: temperature
+      id: master_temp_attr
+    - platform: state
+      entity_id: climate.lincoln_air
+      id: lincoln_state
+    - platform: state
+      entity_id: climate.lincoln_air
+      attribute: temperature
+      id: lincoln_temp_attr
+    - platform: state
+      entity_id: climate.lilly_air
+      id: lilly_state
+    - platform: state
+      entity_id: climate.lilly_air
+      attribute: temperature
+      id: lilly_temp_attr
+    - platform: state
       entity_id: timer.manual_hvac_override
       id: override_state
     - platform: state

--- a/tests/test_provenance_observability.py
+++ b/tests/test_provenance_observability.py
@@ -185,6 +185,27 @@ def test_provenance_logger_uses_google_sheets_secret(provenance_logger):
     )
 
 
+
+
+def test_provenance_logger_includes_bedroom_climate_triggers(provenance_logger):
+    """Section 15 fan-out: bedroom climate state + setpoint trigger ids exist."""
+    triggers = provenance_logger.get("trigger") or []
+    trigger_ids = {t.get("id") for t in triggers if isinstance(t, dict)}
+
+    expected = {
+        "master_state",
+        "master_temp_attr",
+        "lincoln_state",
+        "lincoln_temp_attr",
+        "lilly_state",
+        "lilly_temp_attr",
+    }
+
+    missing = sorted(expected - trigger_ids)
+    assert not missing, (
+        "Provenance logger is missing bedroom fan-out trigger ids: "
+        f"{missing}"
+    )
 def test_provenance_logger_does_not_mutate_control(provenance_logger):
     """Action block must not call any control-surface service. The logger is
     observability-only — it may not change climate state, helpers, timers,


### PR DESCRIPTION
### Motivation
- Closes #85: broaden the provenance surface so bedroom climate changes are captured for forensic analysis.
- Provide observability parity with the Living Room provenance pattern without altering control logic or thresholds.

### Description
- Extend the `v8_5_hvac_provenance_logger` automation triggers to include both `state` and `temperature` attribute changes for `climate.master_bedroom_air`, `climate.lincoln_air`, and `climate.lilly_air` (mirror of the Living Room pattern). 
- Add a focused test `test_provenance_logger_includes_bedroom_climate_triggers` to `tests/test_provenance_observability.py` that asserts the six new trigger ids (`master_state`, `master_temp_attr`, `lincoln_state`, `lincoln_temp_attr`, `lilly_state`, `lilly_temp_attr`) exist. 
- Preserve all provenance guardrails: the logger still writes only to the `hvac_provenance_log` worksheet and does not call any forbidden control services, read the worksheet, or change any helpers/thresholds/behavior. 

### Testing
- Ran `python -m pytest tests/` and all tests passed (`40 passed`).
- The updated provenance tests (including the new bedroom trigger assertions) succeeded and the existing observability acceptance criteria remain enforced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08fb87b1a08323abe5b4038ed278a2)