### PR TITLE
Log Sleep Priority Interlock fires in provenance

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -1763,6 +1763,15 @@
     - platform: state
       entity_id: input_boolean.lr_heating_recovery_boost_active
       id: boost_state
+    # Section 3 Sleep Priority Interlock (SPI) fire observer (issue #88).
+    # Observes the `last_triggered` attribute of `automation.v9_sleep_priority_interlock`
+    # so each SPI fire generates a row in `hvac_provenance_log`. Observability
+    # only — does not gate, change, or interrupt SPI's trigger, condition, or
+    # `climate.set_hvac_mode` action.
+    - platform: state
+      entity_id: automation.v9_sleep_priority_interlock
+      attribute: last_triggered
+      id: spi_last_triggered
   condition:
     # Issue #69: skip when fired manually — manual runs do not provide
     # trigger.from_state / trigger.to_state / trigger.entity_id / trigger.id.
@@ -1779,6 +1788,9 @@
         {% if trigger.id == 'lr_temp_attr' %}
         {% set ov = trigger.from_state.attributes.temperature if trigger.from_state is not none else none %}
         {% set nv = trigger.to_state.attributes.temperature if trigger.to_state is not none else none %}
+        {% elif trigger.id == 'spi_last_triggered' %}
+        {% set ov = trigger.from_state.attributes.last_triggered if trigger.from_state is not none else none %}
+        {% set nv = trigger.to_state.attributes.last_triggered if trigger.to_state is not none else none %}
         {% else %}
         {% set ov = trigger.from_state.state if trigger.from_state is not none else none %}
         {% set nv = trigger.to_state.state if trigger.to_state is not none else none %}
@@ -1786,16 +1798,20 @@
         {{ (ov | string) != (nv | string) }}
   action:
     - variables:
-        attribute_name: "{% if trigger.id == 'lr_temp_attr' %}temperature{% else %}state{% endif %}"
+        attribute_name: "{% if trigger.id == 'lr_temp_attr' %}temperature{% elif trigger.id == 'spi_last_triggered' %}last_triggered{% else %}state{% endif %}"
         old_raw: >-
           {% if trigger.id == 'lr_temp_attr' %}
           {{ trigger.from_state.attributes.temperature if trigger.from_state is not none else '' }}
+          {% elif trigger.id == 'spi_last_triggered' %}
+          {{ trigger.from_state.attributes.last_triggered if trigger.from_state is not none else '' }}
           {% else %}
           {{ trigger.from_state.state if trigger.from_state is not none else '' }}
           {% endif %}
         new_raw: >-
           {% if trigger.id == 'lr_temp_attr' %}
           {{ trigger.to_state.attributes.temperature if trigger.to_state is not none else '' }}
+          {% elif trigger.id == 'spi_last_triggered' %}
+          {{ trigger.to_state.attributes.last_triggered if trigger.to_state is not none else '' }}
           {% else %}
           {{ trigger.to_state.state if trigger.to_state is not none else '' }}
           {% endif %}
@@ -1830,11 +1846,17 @@
           {% else %}unknown
           {% endif %}
         # Best-effort automation candidate hint per design doc §6 — forensic guidance only.
+        # SPI branch is checked before the origin_kind gate because a
+        # `last_triggered` state change on `automation.v9_sleep_priority_interlock`
+        # is itself the evidence the automation fired; defensive labelling here
+        # avoids losing the candidate hint if HA stamps the update with a null
+        # context.
         automation_candidate_v: >-
           {% set ok = (origin_kind_v | trim) %}
           {% set m = now().minute %}
           {% set ts = trigger.to_state.state if trigger.to_state is not none else '' %}
-          {% if ok != 'automation_or_script' %}
+          {% if trigger.id == 'spi_last_triggered' %}v9_sleep_priority_interlock
+          {% elif ok != 'automation_or_script' %}
           {% elif trigger.entity_id == 'timer.manual_hvac_override' and ts == 'active' %}v7_5_waf_manual_override
           {% elif trigger.entity_id == 'input_boolean.lr_heating_recovery_boost_active' and ts == 'on' %}v8_4_lr_heating_recovery_boost_engage
           {% elif trigger.entity_id == 'input_boolean.lr_heating_recovery_boost_active' and ts == 'off' %}v8_4_lr_heating_recovery_boost_release

--- a/tests/test_provenance_observability.py
+++ b/tests/test_provenance_observability.py
@@ -206,6 +206,68 @@ def test_provenance_logger_includes_bedroom_climate_triggers(provenance_logger):
         "Provenance logger is missing bedroom fan-out trigger ids: "
         f"{missing}"
     )
+
+
+def test_provenance_logger_observes_spi_last_triggered(provenance_logger):
+    """Section 15 (issue #88): observes `automation.v9_sleep_priority_interlock`
+    `last_triggered` so SPI fires generate provenance rows.
+
+    The trigger must be a state platform on the SPI automation entity, scoped
+    to the `last_triggered` attribute, with id `spi_last_triggered`. The
+    classifier branch is verified separately."""
+    triggers = provenance_logger.get("trigger") or []
+
+    matches = [
+        t
+        for t in triggers
+        if isinstance(t, dict)
+        and t.get("platform") == "state"
+        and t.get("entity_id") == "automation.v9_sleep_priority_interlock"
+        and t.get("attribute") == "last_triggered"
+        and t.get("id") == "spi_last_triggered"
+    ]
+
+    assert len(matches) == 1, (
+        "Section 15 must contain exactly one SPI fire observer trigger: "
+        "platform=state, entity_id=automation.v9_sleep_priority_interlock, "
+        "attribute=last_triggered, id=spi_last_triggered (issue #88; see "
+        "docs/5_runtime_layer.md §7.8 and docs/v9_v10_goals.md §2.5). "
+        f"Found {len(matches)} matching trigger(s)."
+    )
+
+
+def test_provenance_classifier_includes_spi(provenance_logger):
+    """Section 15 (issue #88): the automation_candidate classifier emits the
+    string `v9_sleep_priority_interlock` so SPI fires are tagged distinctly
+    from supervisor and Section 14 writes in `hvac_provenance_log`."""
+    action = provenance_logger.get("action") or []
+    classifier_templates = []
+    for item in _iter_action_items(action):
+        if not isinstance(item, dict):
+            continue
+        variables = item.get("variables")
+        if not isinstance(variables, dict):
+            continue
+        candidate_template = variables.get("automation_candidate_v")
+        if isinstance(candidate_template, str):
+            classifier_templates.append(candidate_template)
+
+    assert classifier_templates, (
+        "Section 15 must define an `automation_candidate_v` variable so SPI "
+        "fires can be classified."
+    )
+
+    spi_label = "v9_sleep_priority_interlock"
+    spi_trigger_id = "spi_last_triggered"
+    assert any(
+        spi_label in t and spi_trigger_id in t for t in classifier_templates
+    ), (
+        "automation_candidate_v classifier must label `spi_last_triggered` "
+        f"trigger fires as `{spi_label}` (issue #88). Found templates: "
+        f"{classifier_templates}"
+    )
+
+
 def test_provenance_logger_does_not_mutate_control(provenance_logger):
     """Action block must not call any control-surface service. The logger is
     observability-only — it may not change climate state, helpers, timers,


### PR DESCRIPTION
Closes #88.

## Summary

Adds a Section 15 observer for `automation.v9_sleep_priority_interlock` `last_triggered` so SPI fires generate rows in `hvac_provenance_log` with `automation_candidate = v9_sleep_priority_interlock`. Pure observability — SPI's own behavior is unchanged.

## What this PR does (observability-only)

- Adds a `state` trigger on `automation.v9_sleep_priority_interlock` `attribute: last_triggered` with `id: spi_last_triggered`.
- Extends the existing skip-identical-value condition to compare `attributes.last_triggered` for the SPI trigger (so SPI fires aren't skipped as identical because the automation entity's `state` stays `on`).
- Extends `attribute_name`, `old_raw`, `new_raw` variables with an `spi_last_triggered` branch so the row's `attribute` column reads `last_triggered` and `old_value` / `new_value` capture the timestamp delta.
- Extends `automation_candidate_v` with `v9_sleep_priority_interlock` as the first branch — checked **before** the `origin_kind == 'automation_or_script'` gate, because a `last_triggered` change on the SPI automation is itself the evidence the automation fired. Defensive labelling here avoids losing the candidate hint if HA stamps the update with a null context.
- Adds two tests:
  - `test_provenance_logger_observes_spi_last_triggered` — asserts the new trigger exists with the exact entity_id / attribute / id.
  - `test_provenance_classifier_includes_spi` — asserts `automation_candidate_v` labels `spi_last_triggered` fires as `v9_sleep_priority_interlock`.

## No control behavior changes

- `v9_sleep_priority_interlock` (Section 3) trigger, condition, and `climate.set_hvac_mode` action are byte-for-byte unchanged.
- No manual-override gate added to SPI — its doctrine classification (Position α / β / γ) remains explicitly open per `docs/v9_v10_goals.md` §2.3 and `docs/5_runtime_layer.md` §7.8 (the "Canonical worked example" paragraph). This PR provides the telemetry hook that the doctrine decision needs; it does not pre-empt that decision.
- No SPI authority change.
- No threshold / deadband / helper / `configuration.yaml` / ESPHome change.
- No new worksheet columns. The `hvac_provenance_log` schema is unchanged — the existing `entity_id` and `attribute` columns are room/automation-agnostic.
- No automation reads `hvac_provenance_log`. The forbidden-path discipline from `docs/hvac_provenance_logger_design.md` is preserved.
- No control surface mutation in the Section 15 action body. Existing `test_provenance_logger_does_not_mutate_control` and `test_no_automation_reads_hvac_provenance_log` continue to pass.

## Cross-references

- Issue #88 — observability hook (this PR closes it).
- Issue #87 / PR #95 — SPI doctrine classification (docs-only; ambiguous interlock status). This PR is the telemetry side that feeds future Position selection.
- `docs/5_runtime_layer.md` §7.8 — Manual Override Contract / Canonical ambiguous interlock row.
- `docs/v9_v10_goals.md` §2.3, §2.5, §7 — Manual-Override Discipline, Provenance Completeness, Manual Override Doctrine.
- `docs/comfort_failure_forensics.md` §8.9 — Cross-Room Arbitration / Stack-Effect Conflict signature (was missing a fire-tag; this PR closes that gap).
- `docs/hvac_provenance_logger_design.md` §5, §6 — narrow trigger list and classifier rules being extended.
- `automations.yaml` Section 3 `v9_sleep_priority_interlock` — read-only reference; not modified.
- `automations.yaml` Section 15 `v8_5_hvac_provenance_logger` — observer extension target.

## Tests

- `python -m pytest tests/` — **46 / 46 passing**:
  - 44 pre-existing tests unchanged.
  - 2 new: `test_provenance_logger_observes_spi_last_triggered`, `test_provenance_classifier_includes_spi`.
- Existing forbidden-service test (`test_provenance_logger_does_not_mutate_control`) continues to pass — no new climate/timer/input/notify/shell_command/script.log_event service calls.
- Existing no-read test (`test_no_automation_reads_hvac_provenance_log`) continues to pass — no automation references `hvac_provenance_log` outside the Section 15 write target.

## Out of scope (deliberately)

- Picking an SPI doctrinal position (Position α / β / γ) — that is `docs/5_runtime_layer.md` §7.8 doctrine work, contingent on observed fire data.
- Adding `timer.manual_hvac_override` to SPI — would require Position α to be selected first.
- Fixing the latent `master_temp_attr` / `lincoln_temp_attr` / `lilly_temp_attr` skip-identical-value / `attribute_name` / `old_raw` / `new_raw` handling introduced by the bedroom fan-out (those branches still match the LR-only check). Belongs in a separate scoped PR; this PR only touches the SPI branch.

## Notes on `docs/hvac_provenance_logger_design.md`

The design doc §5 enumerates the "Recommended first observed entities" and explicitly defers fan-out to later passes. This PR is one of those later passes, scoped to a single trigger. A follow-up docs PR can roll the SPI observer into the design doc's narrative if desired — kept out of this PR to preserve the observability-only + tests-only scope.

https://claude.ai/code/session_01AcjicKhg7RnnpUpN9y76Y8

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcjicKhg7RnnpUpN9y76Y8)_