### PR TITLE
Provenance: handle bedroom temperature-attribute triggers uniformly

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -1785,7 +1785,8 @@
     # Skip identical-value writes (noise control per design §8.2).
     - condition: template
       value_template: >-
-        {% if trigger.id == 'lr_temp_attr' %}
+        {% set temp_attr_ids = ['lr_temp_attr', 'master_temp_attr', 'lincoln_temp_attr', 'lilly_temp_attr'] %}
+        {% if trigger.id in temp_attr_ids %}
         {% set ov = trigger.from_state.attributes.temperature if trigger.from_state is not none else none %}
         {% set nv = trigger.to_state.attributes.temperature if trigger.to_state is not none else none %}
         {% elif trigger.id == 'spi_last_triggered' %}
@@ -1798,9 +1799,10 @@
         {{ (ov | string) != (nv | string) }}
   action:
     - variables:
-        attribute_name: "{% if trigger.id == 'lr_temp_attr' %}temperature{% elif trigger.id == 'spi_last_triggered' %}last_triggered{% else %}state{% endif %}"
+        temperature_attr_trigger_ids: ['lr_temp_attr', 'master_temp_attr', 'lincoln_temp_attr', 'lilly_temp_attr']
+        attribute_name: "{% if trigger.id in temperature_attr_trigger_ids %}temperature{% elif trigger.id == 'spi_last_triggered' %}last_triggered{% else %}state{% endif %}"
         old_raw: >-
-          {% if trigger.id == 'lr_temp_attr' %}
+          {% if trigger.id in temperature_attr_trigger_ids %}
           {{ trigger.from_state.attributes.temperature if trigger.from_state is not none else '' }}
           {% elif trigger.id == 'spi_last_triggered' %}
           {{ trigger.from_state.attributes.last_triggered if trigger.from_state is not none else '' }}
@@ -1808,7 +1810,7 @@
           {{ trigger.from_state.state if trigger.from_state is not none else '' }}
           {% endif %}
         new_raw: >-
-          {% if trigger.id == 'lr_temp_attr' %}
+          {% if trigger.id in temperature_attr_trigger_ids %}
           {{ trigger.to_state.attributes.temperature if trigger.to_state is not none else '' }}
           {% elif trigger.id == 'spi_last_triggered' %}
           {{ trigger.to_state.attributes.last_triggered if trigger.to_state is not none else '' }}

--- a/tests/test_provenance_observability.py
+++ b/tests/test_provenance_observability.py
@@ -149,6 +149,32 @@ def _service_of(item):
     return item.get("action") or item.get("service")
 
 
+def _provenance_variable_templates(provenance_logger):
+    templates = {}
+    action = provenance_logger.get("action") or []
+    for item in _iter_action_items(action):
+        if not isinstance(item, dict):
+            continue
+        variables = item.get("variables")
+        if not isinstance(variables, dict):
+            continue
+        for key, value in variables.items():
+            if isinstance(value, str):
+                templates[key] = value
+    return templates
+
+
+def _provenance_variables_dict(provenance_logger):
+    action = provenance_logger.get("action") or []
+    for item in _iter_action_items(action):
+        if not isinstance(item, dict):
+            continue
+        variables = item.get("variables")
+        if isinstance(variables, dict):
+            return variables
+    return {}
+
+
 def test_provenance_logger_exists(provenance_logger):
     """Automation `v8_5_hvac_provenance_logger` exists with mode=parallel, max=20."""
     assert provenance_logger.get("id") == PROVENANCE_ID
@@ -205,6 +231,87 @@ def test_provenance_logger_includes_bedroom_climate_triggers(provenance_logger):
     assert not missing, (
         "Provenance logger is missing bedroom fan-out trigger ids: "
         f"{missing}"
+    )
+
+
+def test_temperature_attribute_triggers_use_temperature_provenance(
+    provenance_logger,
+):
+    """All climate setpoint attr triggers must be treated as `temperature`
+    attribute provenance, including bedroom heads and LR legacy behavior."""
+    templates = _provenance_variable_templates(provenance_logger)
+    variables = _provenance_variables_dict(provenance_logger)
+
+    for key in ("attribute_name", "old_raw", "new_raw"):
+        assert key in templates, f"Expected provenance variable template: {key}"
+    assert "temperature_attr_trigger_ids" in variables, (
+        "Expected provenance variable: temperature_attr_trigger_ids"
+    )
+
+    ids_template = variables["temperature_attr_trigger_ids"]
+    for trigger_id in (
+        "lr_temp_attr",
+        "master_temp_attr",
+        "lincoln_temp_attr",
+        "lilly_temp_attr",
+    ):
+        assert trigger_id in ids_template, (
+            f"{trigger_id} must be included in temperature_attr_trigger_ids."
+        )
+
+    assert "trigger.id in temperature_attr_trigger_ids" in templates["old_raw"], (
+        "old_raw must branch on temperature_attr_trigger_ids."
+    )
+    assert "trigger.id in temperature_attr_trigger_ids" in templates["new_raw"], (
+        "new_raw must branch on temperature_attr_trigger_ids."
+    )
+    assert "trigger.id in temperature_attr_trigger_ids" in templates["attribute_name"], (
+        "attribute_name must branch on temperature_attr_trigger_ids."
+    )
+    assert "attributes.temperature" in templates["old_raw"], (
+        "old_raw must use trigger.from_state.attributes.temperature for "
+        "temperature-attribute triggers."
+    )
+    assert "attributes.temperature" in templates["new_raw"], (
+        "new_raw must use trigger.to_state.attributes.temperature for "
+        "temperature-attribute triggers."
+    )
+    assert "temperature" in templates["attribute_name"], (
+        "attribute_name template must emit 'temperature' for setpoint attribute "
+        "triggers."
+    )
+
+
+def test_skip_identical_uses_temperature_attribute_for_all_climate_setpoint_triggers(
+    provenance_logger,
+):
+    """Dedupe/skip-identical logic must compare temperature attributes (not
+    climate state strings) for all setpoint attr trigger ids."""
+    conditions = provenance_logger.get("condition") or []
+    templates = [
+        c.get("value_template")
+        for c in conditions
+        if isinstance(c, dict) and isinstance(c.get("value_template"), str)
+    ]
+    dedupe = next((t for t in templates if "ov" in t and "nv" in t), "")
+    assert dedupe, "Could not locate skip-identical/dedupe value_template."
+
+    for trigger_id in (
+        "lr_temp_attr",
+        "master_temp_attr",
+        "lincoln_temp_attr",
+        "lilly_temp_attr",
+    ):
+        assert trigger_id in dedupe, (
+            f"Dedupe template must include {trigger_id} in temperature-attr branch."
+        )
+
+    assert "attributes.temperature" in dedupe, (
+        "Dedupe template must compare trigger.*.attributes.temperature for "
+        "climate setpoint attr triggers."
+    )
+    assert "from_state.state" in dedupe and "to_state.state" in dedupe, (
+        "Dedupe template must retain state fallback for non-attribute triggers."
     )
 
 


### PR DESCRIPTION
### Motivation

- Fix a provenance gap where only `lr_temp_attr` was treated as an attribute-change trigger while the bedroom setpoint attribute triggers (`master_temp_attr`, `lincoln_temp_attr`, `lilly_temp_attr`) were added elsewhere but still special-cased as state changes in Section 15; this caused incorrect provenance values and dedupe behavior for setpoint-only updates.
- Ensure setpoint attribute changes are logged as the climate `temperature` attribute (old/new come from `trigger.from_state.attributes.temperature` / `trigger.to_state.attributes.temperature`) and that skip-identical/dedupe logic compares those attribute values so setpoint-only updates are not mistakenly filtered out.
- Preserve existing LR behavior while generalizing to avoid duplicated one-off branches and reduce future regression risk in provenance classification.

### Description

- Generalized the Section 15 provenance classifier to recognize all temperature-attribute trigger IDs by introducing a shared list variable (`['lr_temp_attr','master_temp_attr','lincoln_temp_attr','lilly_temp_attr']`) and using it in both the skip-identical condition and the action variable templates. The condition now compares `trigger.*.attributes.temperature` for those triggers instead of `trigger.*.state`.
- Updated the action `variables` templates to branch on the shared `temperature_attr_trigger_ids` for `attribute_name`, `old_raw`, and `new_raw` so the provenance row labels these events as `temperature` and sources old/new from the attribute values rather than the entity state string. This preserves the legacy LR branch while removing duplicated logic for each bedroom head.
- Modified and extended `tests/test_provenance_observability.py` to (a) extract provenance variable templates/variables, (b) assert the temperature-attribute trigger ids are present in the shared list, (c) verify `old_raw`/`new_raw`/`attribute_name` use `attributes.temperature`, and (d) verify the dedupe condition compares the attribute values for all climate setpoint attribute triggers.

### Testing

- Ran the full test suite with `pytest -q`; result: `51 passed in 1.91s`.
- Added/updated tests in `tests/test_provenance_observability.py`: `test_temperature_attribute_triggers_use_temperature_provenance` and `test_skip_identical_uses_temperature_attribute_for_all_climate_setpoint_triggers`, and they pass as part of the suite.
- Tests exercise the new shared trigger-id branching and the dedupe/value extraction templates; no test failures observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c6c2b9388323925bcebf50901077)