### PR TITLE
Fix HA nuisance exporter CSV entity identity and history request mode

### DIFF
--- a/docs/ha_nuisance_export.md
+++ b/docs/ha_nuisance_export.md
@@ -48,6 +48,14 @@ pwsh -File .\tools\export_ha_nuisance_evidence.ps1 \
 - `json`: write JSON history only
 - `csv`: write CSV history only
 
+## History API request mode and row contract
+
+- For `-Format csv` and `-Format both`, history requests intentionally **do not** include `minimal_response`.
+  - This preserves per-row metadata used for joins (`entity_id`, `last_updated`, and context fields).
+- For `-Format json`, the script may use `minimal_response` to reduce payload size for raw archival JSON.
+- `no_attributes` remains enabled in all modes to reduce payload size without dropping join-critical identity/timestamp/context fields.
+- CSV flattening includes an entity-id carry-forward guard so rows derived from minimal-style history points still emit a non-blank `entity_id`.
+
 ## Export scope
 
 The script exports history for:

--- a/tests/test_ha_nuisance_export_script.py
+++ b/tests/test_ha_nuisance_export_script.py
@@ -58,3 +58,18 @@ def test_export_script_has_shade_discovery_and_token_redaction() -> None:
     assert 'cover.*shade*' in script
     assert 'Get-RedactedMessage' in script
     assert '[REDACTED_TOKEN]' in script
+
+
+def test_csv_mode_does_not_force_minimal_response() -> None:
+    script = _script_text()
+
+    assert "$useMinimalResponse = $Format -eq 'json'" in script
+    assert '-UseMinimalResponse $useMinimalResponse' in script
+
+
+def test_flattener_carries_forward_entity_id_for_minimal_rows() -> None:
+    script = _script_text()
+
+    assert '$seriesEntityId = $null' in script
+    assert '$effectiveEntityId' in script
+    assert 'entity_id     = $effectiveEntityId' in script

--- a/tools/export_ha_nuisance_evidence.ps1
+++ b/tools/export_ha_nuisance_evidence.ps1
@@ -51,6 +51,29 @@ function Invoke-HAGet {
     }
 }
 
+function New-HistoryUri {
+    param(
+        [string]$ApiBase,
+        [string]$StartIso,
+        [string]$EndIso,
+        [string[]]$EntityIds,
+        [bool]$UseMinimalResponse
+    )
+
+    $entityParam = [uri]::EscapeDataString(($EntityIds -join ','))
+    $queryParts = @(
+        "end_time=$EndIso",
+        "filter_entity_id=$entityParam",
+        'no_attributes'
+    )
+
+    if ($UseMinimalResponse) {
+        $queryParts += 'minimal_response'
+    }
+
+    return "$ApiBase/api/history/period/$StartIso?" + ($queryParts -join '&')
+}
+
 function Convert-HistoryResponseToRows {
     param(
         [object]$HistoryResponse,
@@ -64,10 +87,23 @@ function Convert-HistoryResponseToRows {
     }
 
     foreach ($entitySeries in $HistoryResponse) {
+        $seriesEntityId = $null
+
         foreach ($statePoint in $entitySeries) {
+            if (-not [string]::IsNullOrWhiteSpace($statePoint.entity_id)) {
+                $seriesEntityId = $statePoint.entity_id
+            }
+
+            $effectiveEntityId = if (-not [string]::IsNullOrWhiteSpace($statePoint.entity_id)) {
+                $statePoint.entity_id
+            }
+            else {
+                $seriesEntityId
+            }
+
             $rows += [pscustomobject]@{
                 category      = $Category
-                entity_id     = $statePoint.entity_id
+                entity_id     = $effectiveEntityId
                 state         = $statePoint.state
                 last_changed  = $statePoint.last_changed
                 last_updated  = $statePoint.last_updated
@@ -95,8 +131,8 @@ function Export-Category {
         [string]$Token
     )
 
-    $entityParam = [uri]::EscapeDataString(($EntityIds -join ','))
-    $historyUri = "$ApiBase/api/history/period/$StartIso?end_time=$EndIso&filter_entity_id=$entityParam&minimal_response&no_attributes"
+    $useMinimalResponse = $Format -eq 'json'
+    $historyUri = New-HistoryUri -ApiBase $ApiBase -StartIso $StartIso -EndIso $EndIso -EntityIds $EntityIds -UseMinimalResponse $useMinimalResponse
 
     $history = Invoke-HAGet -Uri $historyUri -Headers $Headers -Token $Token
 


### PR DESCRIPTION
### Motivation
- Minimal Home Assistant history responses can omit per-row `entity_id` and context fields, which breaks downstream join-by-entity forensic analysis when flattened to CSV. 
- CSV exports must preserve a stable `entity_id` and join-critical metadata while keeping payload size reasonable, so `no_attributes` should be preserved but `minimal_response` must not be forced for CSV. 
- Changes are intended to reduce join-integrity risk while maintaining read-only, low-impact export behavior and documenting the JSON/CSV contracts.

### Description
- Added a `New-HistoryUri` helper to build history request URIs with an explicit `UseMinimalResponse` flag and preserved `no_attributes` for payload reduction. 
- Switched `Export-Category` to set `$useMinimalResponse = $Format -eq 'json'` so `-Format csv` and `-Format both` do not request `minimal_response`. 
- Hardened `Convert-HistoryResponseToRows` to carry forward the parent series `entity_id` into each flattened row (`$seriesEntityId` → `$effectiveEntityId`) so CSV rows never emit a blank `entity_id`. 
- Updated `docs/ha_nuisance_export.md` to document the history API request modes and row contract, and added tests in `tests/test_ha_nuisance_export_script.py` to assert request-mode behavior and the flattener guard.

### Testing
- Ran `pytest -q tests/test_ha_nuisance_export_script.py` and all tests in that file passed (`6 passed`). 
- Tests verify that CSV mode does not force `minimal_response` and that the flattener carries forward `entity_id` so flattened rows include a stable `entity_id`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ca2c3ccc83239653f134031ebdd5)