### PR TITLE
tests: support shorthand Home Assistant logical conditions in manual override contract checks

### DIFF
--- a/tests/test_manual_override_contract.py
+++ b/tests/test_manual_override_contract.py
@@ -91,6 +91,22 @@ def _condition_tree_requires_manual_override_idle(node):
     condition_type = node.get("condition")
     children = node.get("conditions", [])
 
+    # Home Assistant shorthand logical forms:
+    #   - and: [...]
+    #   - or:  [...]
+    #   - not: [...]
+    # Normalize them to the same behavior as expanded form.
+    if condition_type is None:
+        if "and" in node:
+            condition_type = "and"
+            children = node.get("and", [])
+        elif "or" in node:
+            condition_type = "or"
+            children = node.get("or", [])
+        elif "not" in node:
+            condition_type = "not"
+            children = node.get("not", [])
+
     if condition_type == "and":
         # An AND implies idle if at least one conjunct implies idle.
         return any(_condition_tree_requires_manual_override_idle(item) for item in children)
@@ -316,3 +332,87 @@ def test_regression_valid_and_or_structure_still_passes():
         }
     }
     assert _has_manual_override_idle_condition(auto)
+
+
+def test_regression_shorthand_and_with_manual_override_guard_passes():
+    auto = {
+        "condition": {
+            "and": [
+                {
+                    "condition": "state",
+                    "entity_id": "binary_sensor.some_other_gate",
+                    "state": "on",
+                },
+                {
+                    "condition": "state",
+                    "entity_id": "timer.manual_hvac_override",
+                    "state": "idle",
+                },
+            ]
+        }
+    }
+    assert _has_manual_override_idle_condition(auto)
+
+
+def test_regression_shorthand_or_all_branches_require_override_passes():
+    auto = {
+        "condition": {
+            "or": [
+                {
+                    "condition": "state",
+                    "entity_id": "timer.manual_hvac_override",
+                    "state": "idle",
+                },
+                {
+                    "and": [
+                        {
+                            "condition": "state",
+                            "entity_id": "timer.manual_hvac_override",
+                            "state": "idle",
+                        },
+                        {
+                            "condition": "state",
+                            "entity_id": "sensor.window",
+                            "state": "closed",
+                        },
+                    ]
+                },
+            ]
+        }
+    }
+    assert _has_manual_override_idle_condition(auto)
+
+
+def test_regression_shorthand_or_branch_can_bypass_manual_override():
+    auto = {
+        "condition": {
+            "or": [
+                {
+                    "condition": "state",
+                    "entity_id": "timer.manual_hvac_override",
+                    "state": "idle",
+                },
+                {
+                    "condition": "state",
+                    "entity_id": "binary_sensor.some_other_gate",
+                    "state": "on",
+                },
+            ]
+        }
+    }
+    assert not _has_manual_override_idle_condition(auto)
+
+
+def test_regression_shorthand_not_does_not_prove_manual_override_guard():
+    auto = {
+        "condition": {
+            "not": [
+                {
+                    "condition": "state",
+                    "entity_id": "timer.manual_hvac_override",
+                    "state": "idle",
+                }
+            ]
+        }
+    }
+    assert not _has_manual_override_idle_condition(auto)


### PR DESCRIPTION
### Motivation
- The manual-override condition-tree analyzer in the tests only understood the expanded `condition`/`conditions` logical forms and missed Home Assistant shorthand logical forms like `and:`, `or:`, and `not:` which caused gaps in contract coverage. 
- The change ensures the test analyzer treats shorthand logical conditions exactly like the expanded form so regressions around manual override guards are detected consistently. 

### Description
- Extended `_condition_tree_requires_manual_override_idle` in `tests/test_manual_override_contract.py` to normalize Home Assistant shorthand logical condition forms (`and`, `or`, `not`) to the same `condition`/`conditions` semantics when `condition` is not present. 
- Preserved the conservative semantics: `and` proves idle if any conjunct proves idle, `or` proves idle only if all branches prove idle, and `not` remains conservative and does not prove manual override idle. 
- Added targeted regression tests exercising shorthand forms: shorthand `and` passes when a child requires `timer.manual_hvac_override == idle`, shorthand `or` passes when every branch requires idle and fails when a branch bypasses idle, and shorthand `not` wrapping the idle leaf does not prove the guard. 
- No runtime automation files (`automations.yaml`) were modified; this is tests-only and the analyzer change is limited to the test helper logic. 

### Testing
- Ran the full test suite with `pytest` and the result was `57 passed, 0 failed`. 
- New tests added in `tests/test_manual_override_contract.py` passed and did not change the behavior of existing expanded-form regression tests. 
- The change is limited to test analysis logic and carries a minor regression risk if other rare shorthand nesting variations exist that were not covered by the added tests, but the common shorthand/expanded mixes used in the repo are tested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09cc7af52c83238e3c7eb363628569)