### PR TITLE
Document SPI provenance observability via Section 15 observer

### DIFF
--- a/docs/5_runtime_layer.md
+++ b/docs/5_runtime_layer.md
@@ -191,7 +191,7 @@ The table below classifies every automation in `automations.yaml` that can write
 | `v7_5_safety_ceiling_gates` | 3 | Triggering room (cool 68°F / fan_only) | Yes (`idle` condition) | Comfort policy (76°F is comfort ceiling, not equipment protection) |
 | `v8_2_lr_runaway_cooling_cutoff` | 3 | LR off | No | True safety gate (60°F LR equipment protection) |
 | `v8_2_master_emergency_floor` | 3 | Master off | No | True safety gate (58°F Master equipment protection) |
-| `v9_sleep_priority_interlock` | 3 | LR off when Master cool | No | Canonical ambiguous interlock. Current runtime shape: state triggers (`master→cool`, `LR→heat`), conditions (`master==cool`, `LR==heat`, `LR truth > 60°F`), action (`climate.living_room_air -> off`). No `timer.manual_hvac_override` gate. No dedicated fire telemetry/logbook/provenance tag yet (tracked by #88). Doctrine question remains open: comfort policy, compressor-protection gate, or observability-only candidate. |
+| `v9_sleep_priority_interlock` | 3 | LR off when Master cool | No | Canonical ambiguous interlock. Current runtime shape: state triggers (`master→cool`, `LR→heat`), conditions (`master==cool`, `LR==heat`, `LR truth > 60°F`), action (`climate.living_room_air -> off`). No `timer.manual_hvac_override` gate. SPI fire provenance is now observed via Section 15 `spi_last_triggered` (PR #98): each fire produces a row in `hvac_provenance_log` with `automation_candidate = v9_sleep_priority_interlock`. No dedicated logbook tag yet. Doctrine question remains open: comfort policy, compressor-protection gate, or observability-only candidate. |
 | `v7_5_waf_manual_override` | 3 | Starts `timer.manual_hvac_override` | N/A (it *is* the contract source) | Manual-intent ingest |
 | `v7_5_ghost_assassin` | 4 | Lincoln off at 01:20 (non-heating season) | No | Integration-anomaly gate (Samsung phantom heat suppression). Classification consistency with Section 8 is pending. |
 | `v7_5_auto_season_mode` | 5 | `input_select.hvac_season_mode` only | No (downstream supervisor does) | Mode change (indirect). Override respect is via the supervisor's gate. |
@@ -218,7 +218,7 @@ The table below classifies every automation in `automations.yaml` that can write
 - **Current trigger shape:** state transitions on `climate.master_bedroom_air -> cool` and `climate.living_room_air -> heat`.
 - **Current conditions:** Master must be `cool`, LR must be `heat`, and `sensor.living_room_temperature_truth > 60°F`.
 - **Current action:** force `climate.living_room_air -> off`.
-- **Current omissions:** no `timer.manual_hvac_override` gate; no dedicated SPI fire telemetry/logbook/provenance tag yet. Observability/provenance hook is tracked in #88.
+- **Current omissions:** no `timer.manual_hvac_override` gate. SPI fire provenance is now observed via Section 15 `spi_last_triggered` (PR #98, closing #88): each fire writes a row to `hvac_provenance_log` with `automation_candidate = v9_sleep_priority_interlock`. A dedicated logbook tag for SPI fires does not exist yet.
 - **Doctrine classification question (open):** is SPI (α) comfort policy, (β) compressor/cross-mode protection, or (γ) an observability-only candidate after measurement?
 
 **Candidate positions (no selection yet):**
@@ -233,9 +233,9 @@ The table below classifies every automation in `automations.yaml` that can write
 2. Whether LR heat at fire time was manual or supervisor-driven.
 3. Whether Master cool at fire time was manual or supervisor-driven.
 4. Whether SPI correlates with measurable equipment or comfort benefit.
-5. At least 3 logged SPI fire events after the #88 observability/provenance hook lands.
+5. At least 3 logged SPI fire events from the Section 15 `spi_last_triggered` observer (PR #98, closing #88).
 
-No runtime classification change is selected in this document, and no runtime PR is recommended until #88 telemetry exists.
+No runtime classification change is selected in this document, and no runtime PR is recommended until the accumulated `hvac_provenance_log` rows from the Section 15 `spi_last_triggered` observer (PR #98) provide enough evidence to answer the α/β/γ question above.
 
 **Doctrine notes.**
 

--- a/docs/comfort_failure_forensics.md
+++ b/docs/comfort_failure_forensics.md
@@ -304,7 +304,12 @@ notes across many days may justify a separate envelope investigation.
 
 **Signature.** A cross-mode event (e.g., Master cool while LR heat)
 intersected the window. `v9_sleep_priority_interlock` may have fired
-(LR forced off) without an explicit logbook tag.
+(LR forced off). SPI fires can now be confirmed by looking for an
+`hvac_provenance_log` row tagged
+`automation_candidate = v9_sleep_priority_interlock` (Section 15
+`spi_last_triggered` observer, PR #98). A dedicated logbook tag for SPI
+fires does not exist yet, so for the logbook surface the fire is still
+inferred from the LR mode transition signature.
 
 **Diagnosis.** Either SPI fired correctly on a cross-mode contention,
 or a stack-effect interaction was visible, or a transient

--- a/docs/v9_v10_goals.md
+++ b/docs/v9_v10_goals.md
@@ -70,12 +70,17 @@ runtime change to their override authority.
 
 **Canonical worked example.** Section 3 `v9_sleep_priority_interlock` (SPI)
 is the canonical ambiguous interlock for V9/V10 doctrine work: it currently
-forces LR off on Master-cool/LR-heat contention but has no
-`timer.manual_hvac_override` gate and no dedicated fire provenance tag yet.
-Classification remains explicitly open between Position α (comfort policy),
-Position β (compressor/cross-mode protection), and Position γ
-(observability-only candidate). This decision is blocked on #88 telemetry and
-provenance fan-out; no runtime classification change is selected here.
+forces LR off on Master-cool/LR-heat contention and still has no
+`timer.manual_hvac_override` gate. SPI fire provenance is now visible
+through the Section 15 `spi_last_triggered` observer (PR #98, closing
+#88), which writes a row to `hvac_provenance_log` tagged
+`automation_candidate = v9_sleep_priority_interlock` on each fire; a
+dedicated logbook tag for SPI fires does not exist yet. Classification
+remains explicitly open between Position α (comfort policy), Position β
+(compressor/cross-mode protection), and Position γ (observability-only
+candidate). The decision is now blocked on accumulating enough
+`hvac_provenance_log` evidence — not on landing the provenance hook
+itself — and no runtime classification change is selected here.
 
 ### 2.4 Transition / Latch Clarity
 


### PR DESCRIPTION
## Summary
Updates documentation to reflect the completion of SPI (v9_sleep_priority_interlock) fire provenance observability through a new Section 15 `spi_last_triggered` observer (PR #98). This closes the observability gap tracked in #88 and shifts the blocking criterion for doctrine classification from "landing the provenance hook" to "accumulating sufficient evidence."

## Key Changes

- **v9_v10_goals.md**: Updated the canonical SPI worked example to document that provenance is now visible through the Section 15 `spi_last_triggered` observer, which writes rows to `hvac_provenance_log` tagged with `automation_candidate = v9_sleep_priority_interlock`. Clarified that the doctrine decision is now blocked on evidence accumulation rather than the observability hook itself.

- **5_runtime_layer.md**: 
  - Updated the SPI automation table entry to reference the new Section 15 observer and `hvac_provenance_log` mechanism instead of the #88 tracking issue
  - Updated the detailed SPI section (3.3) to document the provenance observation mechanism and clarify that a dedicated logbook tag does not yet exist
  - Revised the blocking criteria to reference accumulated `hvac_provenance_log` rows from the observer rather than waiting for #88 telemetry

- **comfort_failure_forensics.md**: Updated the SPI signature section to explain how SPI fires can now be confirmed via `hvac_provenance_log` rows and clarified that the logbook surface still infers the fire from mode transition signatures.

## Notable Details

- All references to #88 as a blocking issue have been replaced with references to PR #98 and the Section 15 observer
- Documentation maintains that no runtime classification change is selected yet, pending evidence accumulation
- The three candidate doctrine positions (α/β/γ) remain explicitly open

https://claude.ai/code/session_01ByPVcZ3zBuVrdSGKM3UN5n