### PR TITLE
Add truth-entity-registry ghost-failure doc, fixtures, and integrity tests

### DIFF
--- a/docs/truth_entity_registry_ghost_failure.md
+++ b/docs/truth_entity_registry_ghost_failure.md
@@ -1,0 +1,45 @@
+# Truth Entity Registry Ghost Failure (Lincoln/Lilly)
+
+## Failure Signature
+
+This failure is caused by Home Assistant restoring ghost entities into canonical truth IDs while the live template entities are forced to `*_2` IDs.
+
+Observed broken pattern:
+
+- Canonical truth entities (`sensor.lincoln_s_room_temperature_truth`, `sensor.lilly_s_room_temperature_truth`) exist as `restored: true` and `state: unavailable`.
+- Live truth entities appear as `_2` suffixes.
+- Canonical smoothed entities still point at canonical truth IDs, so they become `unknown`.
+- Canonical control wrappers become unavailable because smoothed truth is unavailable.
+
+## Canonical Entity IDs (must remain stable)
+
+- `sensor.lincoln_s_room_temperature_truth`
+- `sensor.lilly_s_room_temperature_truth`
+- `sensor.lincoln_s_room_temperature_smoothed`
+- `sensor.lilly_s_room_temperature_smoothed`
+- `sensor.lincoln_s_room_temperature_control`
+- `sensor.lilly_s_room_temperature_control`
+
+## Test-Harness Coverage Added
+
+`tests/test_truth_entity_registry_integrity.py` now checks exported HA state snapshots for the following invariants:
+
+1. A required canonical truth/smoothed/control entity must not be `restored: true`.
+2. No canonical climate truth entity may have a live `*_2` duplicate.
+3. Smoothed entities must not be unavailable because they are linked to unavailable/restored canonical truth.
+4. If raw room probes are live, canonical truth/smoothed/control must not be unavailable.
+
+Fixtures:
+
+- `tests/fixtures/ha_states_truth_entity_broken.json` (reproduces failure)
+- `tests/fixtures/ha_states_truth_entity_healthy.json` (expected healthy behavior)
+
+## Runtime Repair (outside git)
+
+Home Assistant entity registry cleanup is the runtime fix:
+
+1. Delete restored ghost canonical entities.
+2. Rename live `_2` entities back to canonical IDs.
+3. Verify smoothed/control wrappers recover and Section 2/3 consumers stop seeing unknown truth.
+
+No YAML rewrite to `_2` should be performed; canonical IDs are the long-term contract.

--- a/tests/fixtures/ha_states_truth_entity_broken.json
+++ b/tests/fixtures/ha_states_truth_entity_broken.json
@@ -1,0 +1,22 @@
+[
+  {"entity_id":"sensor.lincoln_s_room_temperature_truth","state":"unavailable","attributes":{"restored":true}},
+  {"entity_id":"sensor.lincoln_s_room_temperature_truth_2","state":"71.2","attributes":{"restored":false}},
+  {"entity_id":"sensor.lincoln_s_room_humidity_truth_2","state":"43.5","attributes":{"restored":false}},
+  {"entity_id":"sensor.lincoln_s_room_temperature_smoothed","state":"unknown","attributes":{"source_entity_id":"sensor.lincoln_s_room_temperature_truth"}},
+  {"entity_id":"sensor.lincoln_s_room_temperature_control","state":"unavailable","attributes":{"restored":false}},
+
+  {"entity_id":"sensor.lilly_s_room_temperature_truth","state":"unavailable","attributes":{"restored":true}},
+  {"entity_id":"sensor.lilly_s_room_temperature_truth_2","state":"70.1","attributes":{"restored":false}},
+  {"entity_id":"sensor.lilly_s_room_humidity_truth_2","state":"45.0","attributes":{"restored":false}},
+  {"entity_id":"sensor.lilly_s_room_temperature_smoothed","state":"unknown","attributes":{"source_entity_id":"sensor.lilly_s_room_temperature_truth"}},
+  {"entity_id":"sensor.lilly_s_room_temperature_control","state":"unavailable","attributes":{"restored":false}},
+
+  {"entity_id":"sensor.lincoln_s_temp_temperature","state":"71.4","attributes":{}},
+  {"entity_id":"sensor.lincoln_s_room_temperature_temperature","state":"71.1","attributes":{}},
+  {"entity_id":"sensor.lincoln_temp_temperature","state":"71.3","attributes":{}},
+  {"entity_id":"sensor.lincoln_air_temperature","state":"71.0","attributes":{}},
+  {"entity_id":"sensor.lilly_temperature","state":"70.0","attributes":{}},
+  {"entity_id":"sensor.lilly_room_temperature_temperature","state":"70.2","attributes":{}},
+  {"entity_id":"sensor.lilly_temp_temperature_2","state":"70.3","attributes":{}},
+  {"entity_id":"sensor.lilly_air_temperature","state":"69.9","attributes":{}}
+]

--- a/tests/fixtures/ha_states_truth_entity_healthy.json
+++ b/tests/fixtures/ha_states_truth_entity_healthy.json
@@ -1,0 +1,18 @@
+[
+  {"entity_id":"sensor.lincoln_s_room_temperature_truth","state":"71.2","attributes":{"restored":false}},
+  {"entity_id":"sensor.lincoln_s_room_temperature_smoothed","state":"71.0","attributes":{"source_entity_id":"sensor.lincoln_s_room_temperature_truth"}},
+  {"entity_id":"sensor.lincoln_s_room_temperature_control","state":"71.0","attributes":{"restored":false}},
+
+  {"entity_id":"sensor.lilly_s_room_temperature_truth","state":"70.1","attributes":{"restored":false}},
+  {"entity_id":"sensor.lilly_s_room_temperature_smoothed","state":"70.0","attributes":{"source_entity_id":"sensor.lilly_s_room_temperature_truth"}},
+  {"entity_id":"sensor.lilly_s_room_temperature_control","state":"70.0","attributes":{"restored":false}},
+
+  {"entity_id":"sensor.lincoln_s_temp_temperature","state":"71.4","attributes":{}},
+  {"entity_id":"sensor.lincoln_s_room_temperature_temperature","state":"71.1","attributes":{}},
+  {"entity_id":"sensor.lincoln_temp_temperature","state":"71.3","attributes":{}},
+  {"entity_id":"sensor.lincoln_air_temperature","state":"71.0","attributes":{}},
+  {"entity_id":"sensor.lilly_temperature","state":"70.0","attributes":{}},
+  {"entity_id":"sensor.lilly_room_temperature_temperature","state":"70.2","attributes":{}},
+  {"entity_id":"sensor.lilly_temp_temperature_2","state":"70.3","attributes":{}},
+  {"entity_id":"sensor.lilly_air_temperature","state":"69.9","attributes":{}}
+]

--- a/tests/test_truth_entity_registry_integrity.py
+++ b/tests/test_truth_entity_registry_integrity.py
@@ -1,0 +1,121 @@
+import json
+from pathlib import Path
+
+CANONICAL_TRUTH = {
+    "sensor.lincoln_s_room_temperature_truth",
+    "sensor.lilly_s_room_temperature_truth",
+}
+
+CANONICAL_HUMIDITY_TRUTH = {
+    "sensor.lincoln_s_room_humidity_truth",
+    "sensor.lilly_s_room_humidity_truth",
+}
+CANONICAL_SMOOTHED = {
+    "sensor.lincoln_s_room_temperature_smoothed": "sensor.lincoln_s_room_temperature_truth",
+    "sensor.lilly_s_room_temperature_smoothed": "sensor.lilly_s_room_temperature_truth",
+}
+CANONICAL_CONTROL = {
+    "sensor.lincoln_s_room_temperature_control",
+    "sensor.lilly_s_room_temperature_control",
+}
+CANONICAL_REQUIRED = CANONICAL_TRUTH | set(CANONICAL_SMOOTHED) | CANONICAL_CONTROL
+
+RAW_ROOM_PROBES = {
+    "sensor.lincoln_s_temp_temperature",
+    "sensor.lincoln_s_room_temperature_temperature",
+    "sensor.lincoln_temp_temperature",
+    "sensor.lincoln_air_temperature",
+    "sensor.lilly_temperature",
+    "sensor.lilly_room_temperature_temperature",
+    "sensor.lilly_temp_temperature_2",
+    "sensor.lilly_air_temperature",
+}
+
+UNAVAILABLE_STATES = {"unknown", "unavailable"}
+
+
+def _load_states(fixture_name: str) -> list[dict]:
+    path = Path("tests/fixtures") / fixture_name
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _map_states(states: list[dict]) -> dict[str, dict]:
+    return {item["entity_id"]: item for item in states}
+
+
+def _is_unavailable(item: dict | None) -> bool:
+    if item is None:
+        return True
+    return str(item.get("state", "")).lower() in UNAVAILABLE_STATES
+
+
+def _is_restored(item: dict | None) -> bool:
+    if item is None:
+        return False
+    attrs = item.get("attributes", {}) or {}
+    return bool(attrs.get("restored", False))
+
+
+def _is_live_numeric(item: dict | None) -> bool:
+    if item is None:
+        return False
+    value = str(item.get("state", "")).lower()
+    if value in UNAVAILABLE_STATES:
+        return False
+    try:
+        float(value)
+        return True
+    except ValueError:
+        return False
+
+
+def _validate_truth_entity_integrity(states: list[dict]) -> list[str]:
+    by_entity = _map_states(states)
+    issues: list[str] = []
+
+    for entity_id in sorted(CANONICAL_REQUIRED):
+        state = by_entity.get(entity_id)
+        if _is_restored(state):
+            issues.append(f"canonical entity restored:true: {entity_id}")
+
+    for truth_entity in sorted(CANONICAL_TRUTH | CANONICAL_HUMIDITY_TRUTH):
+        duplicate_id = f"{truth_entity}_2"
+        if duplicate_id in by_entity:
+            issues.append(f"unexpected suffixed truth entity exists: {duplicate_id}")
+
+    for smoothed_entity, expected_source in sorted(CANONICAL_SMOOTHED.items()):
+        smoothed = by_entity.get(smoothed_entity)
+        source = by_entity.get(expected_source)
+        source_id = ((smoothed or {}).get("attributes", {}) or {}).get("source_entity_id")
+
+        if source_id and source_id != expected_source:
+            issues.append(
+                f"smoothed source mismatch: {smoothed_entity} points to {source_id}, expected {expected_source}"
+            )
+
+        if _is_unavailable(smoothed) and (_is_unavailable(source) or _is_restored(source)):
+            issues.append(
+                f"smoothed unavailable from unavailable/restored source: {smoothed_entity} <- {expected_source}"
+            )
+
+    any_live_raw = any(_is_live_numeric(by_entity.get(probe)) for probe in RAW_ROOM_PROBES)
+    any_canonical_down = any(_is_unavailable(by_entity.get(e)) for e in CANONICAL_REQUIRED)
+    if any_live_raw and any_canonical_down:
+        issues.append("raw room probe live while canonical truth/smoothed/control is unavailable")
+
+    return issues
+
+
+def test_broken_fixture_flags_truth_entity_registry_failure_modes() -> None:
+    issues = _validate_truth_entity_integrity(_load_states("ha_states_truth_entity_broken.json"))
+
+    assert issues, "Expected broken fixture to produce integrity violations"
+    assert any("canonical entity restored:true" in issue for issue in issues)
+    assert any("unexpected suffixed truth entity exists" in issue for issue in issues)
+    assert any("smoothed unavailable from unavailable/restored source" in issue for issue in issues)
+    assert any("raw room probe live while canonical truth/smoothed/control is unavailable" in issue for issue in issues)
+
+
+def test_healthy_fixture_passes_truth_entity_registry_integrity_checks() -> None:
+    issues = _validate_truth_entity_integrity(_load_states("ha_states_truth_entity_healthy.json"))
+    assert issues == []


### PR DESCRIPTION
### Motivation

- Detect and prevent a Home Assistant failure mode where restored ghost canonical entities are present while live template entities are created with `_2` suffixes, causing smoothed/control entities to become unknown or unavailable.

### Description

- Add a diagnostic doc `docs/truth_entity_registry_ghost_failure.md` that describes the failure signature, canonical IDs, runtime repair steps, and test-harness coverage.
- Add two HA state fixtures `tests/fixtures/ha_states_truth_entity_broken.json` and `tests/fixtures/ha_states_truth_entity_healthy.json` representing broken and healthy snapshots respectively.
- Add `tests/test_truth_entity_registry_integrity.py` which implements `_validate_truth_entity_integrity` and unit tests that check for restored canonical entities, unexpected `_2` duplicates, smoothed/source mismatches and smoothed unavailability, and live raw probes while canonical truth/smoothed/control are down.

### Testing

- Ran the new unit tests with `pytest tests/test_truth_entity_registry_integrity.py`, which executed the two tests in the file and reported success (both tests passed).
- The tests exercise the broken and healthy fixtures and assert that the broken fixture produces the expected integrity violation messages and that the healthy fixture yields no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a11b6c2448323922313125188b8a1)