### PR TITLE
docs/tests: capture final truth-chain registry collision resolution evidence

### DIFF
--- a/docs/truth_entity_registry_ghost_failure.md
+++ b/docs/truth_entity_registry_ghost_failure.md
@@ -43,3 +43,41 @@ Home Assistant entity registry cleanup is the runtime fix:
 3. Verify smoothed/control wrappers recover and Section 2/3 consumers stop seeing unknown truth.
 
 No YAML rewrite to `_2` should be performed; canonical IDs are the long-term contract.
+
+
+## Final confirmed cause
+
+Entity registry drift was caused by a `unique_id` slug mismatch between restored historical entries and current template definitions.
+
+Old restored canonical entries were using apostrophe-stripped `unique_id` values:
+
+- `lincolns_room_temperature_truth_v3`
+- `lillys_room_temperature_truth_v3`
+- `lincolns_room_humidity_truth_v3`
+- `lillys_room_humidity_truth_v3`
+- `lincolns_room_temperature_control_v3`
+- `lillys_room_temperature_control_v3`
+
+Current live template entities used corrected apostrophe-slug `unique_id` values:
+
+- `lincoln_s_room_temperature_truth_v3`
+- `lilly_s_room_temperature_truth_v3`
+- `lincoln_s_room_humidity_truth_v3`
+- `lilly_s_room_humidity_truth_v3`
+- `lincoln_s_room_temperature_control_v3`
+- `lilly_s_room_temperature_control_v3`
+
+Home Assistant treated those as different registry objects. That forced live entities to `*_2` entity IDs while restored ghosts retained the canonical IDs.
+
+## Verified runtime repair
+
+Runtime remediation that was executed in live Home Assistant:
+
+1. Deleted old restored canonical registry entries.
+2. Renamed live `*_2` entries back to canonical entity IDs.
+3. Re-ran the truth-chain verification export.
+
+Verification result after repair:
+
+- `overall_status: PASS`
+- `problems: []`

--- a/tests/fixtures/ha_states_truth_entity_broken.json
+++ b/tests/fixtures/ha_states_truth_entity_broken.json
@@ -1,22 +1,120 @@
 [
-  {"entity_id":"sensor.lincoln_s_room_temperature_truth","state":"unavailable","attributes":{"restored":true}},
-  {"entity_id":"sensor.lincoln_s_room_temperature_truth_2","state":"71.2","attributes":{"restored":false}},
-  {"entity_id":"sensor.lincoln_s_room_humidity_truth_2","state":"43.5","attributes":{"restored":false}},
-  {"entity_id":"sensor.lincoln_s_room_temperature_smoothed","state":"unknown","attributes":{"source_entity_id":"sensor.lincoln_s_room_temperature_truth"}},
-  {"entity_id":"sensor.lincoln_s_room_temperature_control","state":"unavailable","attributes":{"restored":false}},
-
-  {"entity_id":"sensor.lilly_s_room_temperature_truth","state":"unavailable","attributes":{"restored":true}},
-  {"entity_id":"sensor.lilly_s_room_temperature_truth_2","state":"70.1","attributes":{"restored":false}},
-  {"entity_id":"sensor.lilly_s_room_humidity_truth_2","state":"45.0","attributes":{"restored":false}},
-  {"entity_id":"sensor.lilly_s_room_temperature_smoothed","state":"unknown","attributes":{"source_entity_id":"sensor.lilly_s_room_temperature_truth"}},
-  {"entity_id":"sensor.lilly_s_room_temperature_control","state":"unavailable","attributes":{"restored":false}},
-
-  {"entity_id":"sensor.lincoln_s_temp_temperature","state":"71.4","attributes":{}},
-  {"entity_id":"sensor.lincoln_s_room_temperature_temperature","state":"71.1","attributes":{}},
-  {"entity_id":"sensor.lincoln_temp_temperature","state":"71.3","attributes":{}},
-  {"entity_id":"sensor.lincoln_air_temperature","state":"71.0","attributes":{}},
-  {"entity_id":"sensor.lilly_temperature","state":"70.0","attributes":{}},
-  {"entity_id":"sensor.lilly_room_temperature_temperature","state":"70.2","attributes":{}},
-  {"entity_id":"sensor.lilly_temp_temperature_2","state":"70.3","attributes":{}},
-  {"entity_id":"sensor.lilly_air_temperature","state":"69.9","attributes":{}}
+  {
+    "entity_id": "sensor.lincoln_s_room_temperature_truth",
+    "state": "unavailable",
+    "attributes": {
+      "restored": true,
+      "unique_id": "lincolns_room_temperature_truth_v3"
+    }
+  },
+  {
+    "entity_id": "sensor.lincoln_s_room_temperature_truth_2",
+    "state": "71.2",
+    "attributes": {
+      "restored": false,
+      "unique_id": "lincoln_s_room_temperature_truth_v3"
+    }
+  },
+  {
+    "entity_id": "sensor.lincoln_s_room_humidity_truth_2",
+    "state": "43.5",
+    "attributes": {
+      "restored": false,
+      "unique_id": "lincoln_s_room_humidity_truth_v3"
+    }
+  },
+  {
+    "entity_id": "sensor.lincoln_s_room_temperature_smoothed",
+    "state": "unknown",
+    "attributes": {
+      "source_entity_id": "sensor.lincoln_s_room_temperature_truth"
+    }
+  },
+  {
+    "entity_id": "sensor.lincoln_s_room_temperature_control",
+    "state": "unavailable",
+    "attributes": {
+      "restored": false,
+      "unique_id": "lincolns_room_temperature_control_v3"
+    }
+  },
+  {
+    "entity_id": "sensor.lilly_s_room_temperature_truth",
+    "state": "unavailable",
+    "attributes": {
+      "restored": true,
+      "unique_id": "lillys_room_temperature_truth_v3"
+    }
+  },
+  {
+    "entity_id": "sensor.lilly_s_room_temperature_truth_2",
+    "state": "70.1",
+    "attributes": {
+      "restored": false,
+      "unique_id": "lilly_s_room_temperature_truth_v3"
+    }
+  },
+  {
+    "entity_id": "sensor.lilly_s_room_humidity_truth_2",
+    "state": "45.0",
+    "attributes": {
+      "restored": false,
+      "unique_id": "lilly_s_room_humidity_truth_v3"
+    }
+  },
+  {
+    "entity_id": "sensor.lilly_s_room_temperature_smoothed",
+    "state": "unknown",
+    "attributes": {
+      "source_entity_id": "sensor.lilly_s_room_temperature_truth"
+    }
+  },
+  {
+    "entity_id": "sensor.lilly_s_room_temperature_control",
+    "state": "unavailable",
+    "attributes": {
+      "restored": false,
+      "unique_id": "lillys_room_temperature_control_v3"
+    }
+  },
+  {
+    "entity_id": "sensor.lincoln_s_temp_temperature",
+    "state": "71.4",
+    "attributes": {}
+  },
+  {
+    "entity_id": "sensor.lincoln_s_room_temperature_temperature",
+    "state": "71.1",
+    "attributes": {}
+  },
+  {
+    "entity_id": "sensor.lincoln_temp_temperature",
+    "state": "71.3",
+    "attributes": {}
+  },
+  {
+    "entity_id": "sensor.lincoln_air_temperature",
+    "state": "71.0",
+    "attributes": {}
+  },
+  {
+    "entity_id": "sensor.lilly_temperature",
+    "state": "70.0",
+    "attributes": {}
+  },
+  {
+    "entity_id": "sensor.lilly_room_temperature_temperature",
+    "state": "70.2",
+    "attributes": {}
+  },
+  {
+    "entity_id": "sensor.lilly_temp_temperature_2",
+    "state": "70.3",
+    "attributes": {}
+  },
+  {
+    "entity_id": "sensor.lilly_air_temperature",
+    "state": "69.9",
+    "attributes": {}
+  }
 ]

--- a/tests/fixtures/ha_states_truth_entity_healthy.json
+++ b/tests/fixtures/ha_states_truth_entity_healthy.json
@@ -1,18 +1,88 @@
 [
-  {"entity_id":"sensor.lincoln_s_room_temperature_truth","state":"71.2","attributes":{"restored":false}},
-  {"entity_id":"sensor.lincoln_s_room_temperature_smoothed","state":"71.0","attributes":{"source_entity_id":"sensor.lincoln_s_room_temperature_truth"}},
-  {"entity_id":"sensor.lincoln_s_room_temperature_control","state":"71.0","attributes":{"restored":false}},
-
-  {"entity_id":"sensor.lilly_s_room_temperature_truth","state":"70.1","attributes":{"restored":false}},
-  {"entity_id":"sensor.lilly_s_room_temperature_smoothed","state":"70.0","attributes":{"source_entity_id":"sensor.lilly_s_room_temperature_truth"}},
-  {"entity_id":"sensor.lilly_s_room_temperature_control","state":"70.0","attributes":{"restored":false}},
-
-  {"entity_id":"sensor.lincoln_s_temp_temperature","state":"71.4","attributes":{}},
-  {"entity_id":"sensor.lincoln_s_room_temperature_temperature","state":"71.1","attributes":{}},
-  {"entity_id":"sensor.lincoln_temp_temperature","state":"71.3","attributes":{}},
-  {"entity_id":"sensor.lincoln_air_temperature","state":"71.0","attributes":{}},
-  {"entity_id":"sensor.lilly_temperature","state":"70.0","attributes":{}},
-  {"entity_id":"sensor.lilly_room_temperature_temperature","state":"70.2","attributes":{}},
-  {"entity_id":"sensor.lilly_temp_temperature_2","state":"70.3","attributes":{}},
-  {"entity_id":"sensor.lilly_air_temperature","state":"69.9","attributes":{}}
+  {
+    "entity_id": "sensor.lincoln_s_room_temperature_truth",
+    "state": "71.2",
+    "attributes": {
+      "restored": false,
+      "unique_id": "lincoln_s_room_temperature_truth_v3"
+    }
+  },
+  {
+    "entity_id": "sensor.lincoln_s_room_temperature_smoothed",
+    "state": "71.0",
+    "attributes": {
+      "source_entity_id": "sensor.lincoln_s_room_temperature_truth"
+    }
+  },
+  {
+    "entity_id": "sensor.lincoln_s_room_temperature_control",
+    "state": "71.0",
+    "attributes": {
+      "restored": false,
+      "unique_id": "lincoln_s_room_temperature_control_v3"
+    }
+  },
+  {
+    "entity_id": "sensor.lilly_s_room_temperature_truth",
+    "state": "70.1",
+    "attributes": {
+      "restored": false,
+      "unique_id": "lilly_s_room_temperature_truth_v3"
+    }
+  },
+  {
+    "entity_id": "sensor.lilly_s_room_temperature_smoothed",
+    "state": "70.0",
+    "attributes": {
+      "source_entity_id": "sensor.lilly_s_room_temperature_truth"
+    }
+  },
+  {
+    "entity_id": "sensor.lilly_s_room_temperature_control",
+    "state": "70.0",
+    "attributes": {
+      "restored": false,
+      "unique_id": "lilly_s_room_temperature_control_v3"
+    }
+  },
+  {
+    "entity_id": "sensor.lincoln_s_temp_temperature",
+    "state": "71.4",
+    "attributes": {}
+  },
+  {
+    "entity_id": "sensor.lincoln_s_room_temperature_temperature",
+    "state": "71.1",
+    "attributes": {}
+  },
+  {
+    "entity_id": "sensor.lincoln_temp_temperature",
+    "state": "71.3",
+    "attributes": {}
+  },
+  {
+    "entity_id": "sensor.lincoln_air_temperature",
+    "state": "71.0",
+    "attributes": {}
+  },
+  {
+    "entity_id": "sensor.lilly_temperature",
+    "state": "70.0",
+    "attributes": {}
+  },
+  {
+    "entity_id": "sensor.lilly_room_temperature_temperature",
+    "state": "70.2",
+    "attributes": {}
+  },
+  {
+    "entity_id": "sensor.lilly_temp_temperature_2",
+    "state": "70.3",
+    "attributes": {}
+  },
+  {
+    "entity_id": "sensor.lilly_air_temperature",
+    "state": "69.9",
+    "attributes": {}
+  }
 ]


### PR DESCRIPTION
### Motivation

- Record the final root cause and live remediation steps for the truth-entity registry collision so future operators and tests have authoritative evidence.
- Capture the unique_id mismatch semantics that forced live template entities to `*_2` IDs while restored ghosts retained canonical IDs. 
- Strengthen fixtures so the test-harness can reproduce both the broken and healthy registry states for regression detection.

### Description

- Added a new **Final confirmed cause** section to `docs/truth_entity_registry_ghost_failure.md` describing the apostrophe-stripped vs apostrophe-slug `unique_id` values and how Home Assistant treated them as different registry objects. 
- Added a **Verified runtime repair** section to the same doc that lists the live remediation steps (delete restored ghosts, rename `*_2` back to canonical, rerun verification) and the final verification outcome. 
- Updated `tests/fixtures/ha_states_truth_entity_broken.json` to model the real collision by adding `unique_id` attributes that show old-style restored canonical entries and new-style `unique_id` values on live `*_2` entities. 
- Updated `tests/fixtures/ha_states_truth_entity_healthy.json` to include canonical entities with the corrected new-style `unique_id` values and no `*_2` duplicates. 

### Testing

- Attempted the requested composite command `pytest -q tests/test_truth_chain_yaml_contract.py tests/test_truth_entity_registry_integrity.py tests/test_yaml_syntax.py`, which failed because `tests/test_truth_chain_yaml_contract.py` does not exist in this branch. 
- Ran `pytest -q tests/test_truth_entity_registry_integrity.py tests/test_yaml_syntax.py`, and the suite passed with `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1b07da988323b67f10030607820f)