### PR TITLE
🧪 Add redaction tests for HA nuisance evidence export

### DIFF
--- a/tools/export_ha_nuisance_evidence.Tests.ps1
+++ b/tools/export_ha_nuisance_evidence.Tests.ps1
@@ -1,0 +1,40 @@
+Describe "Get-RedactedMessage" {
+    BeforeAll {
+        . "$PSScriptRoot/export_ha_nuisance_evidence.ps1"
+    }
+
+    It "redacts an access token from a message" {
+        Get-RedactedMessage -Message "Bearer abc123 failed" -Token "abc123" |
+            Should -Be "Bearer [REDACTED_TOKEN] failed"
+    }
+
+    It "redacts every occurrence of the token" {
+        Get-RedactedMessage -Message "abc123 then abc123" -Token "abc123" |
+            Should -Be "[REDACTED_TOKEN] then [REDACTED_TOKEN]"
+    }
+
+    It "returns the original message when token is empty" {
+        Get-RedactedMessage -Message "nothing changes" -Token "" |
+            Should -Be "nothing changes"
+    }
+
+    It "returns the original message when message is empty" {
+        Get-RedactedMessage -Message "" -Token "abc123" |
+            Should -Be ""
+    }
+
+    It "returns null when message is null" {
+        Get-RedactedMessage -Message $null -Token "abc123" |
+            Should -BeNullOrEmpty
+    }
+
+    It "leaves message unchanged when token is not present" {
+        Get-RedactedMessage -Message "safe message" -Token "abc123" |
+            Should -Be "safe message"
+    }
+
+    It "treats token text literally rather than as regex" {
+        Get-RedactedMessage -Message "token a.b[c] leaked" -Token "a.b[c]" |
+            Should -Be "token [REDACTED_TOKEN] leaked"
+    }
+}

--- a/tools/export_ha_nuisance_evidence.ps1
+++ b/tools/export_ha_nuisance_evidence.ps1
@@ -1,23 +1,14 @@
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $true)]
     [string]$BaseUrl,
-
-    [Parameter(Mandatory = $true)]
     [string]$AccessToken,
-
-    [Parameter(Mandatory = $true)]
     [datetime]$StartDate,
-
-    [Parameter(Mandatory = $true)]
     [datetime]$EndDate,
-
-    [Parameter(Mandatory = $true)]
     [string]$OutputFolder,
-
     [ValidateSet('json', 'csv', 'both')]
     [string]$Format = 'both'
 )
+
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
@@ -148,70 +139,92 @@ function Export-Category {
     }
 }
 
-$normalizedBase = $BaseUrl.TrimEnd('/')
-$apiBase = $normalizedBase
-
-if ($StartDate -ge $EndDate) {
-    throw 'StartDate must be earlier than EndDate.'
-}
-
-$headers = @{ Authorization = "Bearer $AccessToken" }
-
-$startUtc = $StartDate.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-$endUtc = $EndDate.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-
-New-Item -ItemType Directory -Path $OutputFolder -Force | Out-Null
-
-$automationEntities = @(
-    'automation.v8_3_hvac_transition_log',
-    'automation.v8_samsung_auto_guardrail',
-    'automation.v7_5_ghost_assassin',
-    'automation.v9_sleep_priority_interlock'
-)
-
-$climateEntities = @(
-    'climate.living_room_air',
-    'climate.master_bedroom_air',
-    'climate.lincoln_air',
-    'climate.lilly_air'
-)
-
-$timerEntities = @(
-    'timer.lr_compressor_cooldown',
-    'timer.master_compressor_cooldown',
-    'timer.lincoln_compressor_cooldown',
-    'timer.lilly_compressor_cooldown'
-)
-
-$stateUri = "$apiBase/api/states"
-$allStates = Invoke-HAGet -Uri $stateUri -Headers $headers -Token $AccessToken
-$shadeEntities = @($allStates | Where-Object { $_.entity_id -like 'cover.*shade*' } | ForEach-Object { $_.entity_id })
-
-$manifest = [pscustomobject]@{
-    generated_utc = (Get-Date).ToUniversalTime().ToString('o')
-    start_utc = $startUtc
-    end_utc = $endUtc
-    base_url = $normalizedBase
-    categories = [pscustomobject]@{
-        climates = $climateEntities
-        automations = $automationEntities
-        timers = $timerEntities
-        shades = $shadeEntities
-    }
-    notes = @(
-        'Read-only API usage: GET /api/states, GET /api/history/period, GET /api/logbook',
-        'No POST/PUT/PATCH/DELETE requests are used by this script.'
+function Invoke-HaNuisanceEvidenceExport {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BaseUrl,
+        [Parameter(Mandatory = $true)]
+        [string]$AccessToken,
+        [Parameter(Mandatory = $true)]
+        [datetime]$StartDate,
+        [Parameter(Mandatory = $true)]
+        [datetime]$EndDate,
+        [Parameter(Mandatory = $true)]
+        [string]$OutputFolder,
+        [ValidateSet('json', 'csv', 'both')]
+        [string]$Format = 'both'
     )
+
+    $normalizedBase = $BaseUrl.TrimEnd('/')
+    $apiBase = $normalizedBase
+
+    if ($StartDate -ge $EndDate) {
+        throw 'StartDate must be earlier than EndDate.'
+    }
+
+    $headers = @{ Authorization = "Bearer $AccessToken" }
+
+    $startUtc = $StartDate.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    $endUtc = $EndDate.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+
+    New-Item -ItemType Directory -Path $OutputFolder -Force | Out-Null
+
+    $automationEntities = @(
+        'automation.v8_3_hvac_transition_log',
+        'automation.v8_samsung_auto_guardrail',
+        'automation.v7_5_ghost_assassin',
+        'automation.v9_sleep_priority_interlock'
+    )
+
+    $climateEntities = @(
+        'climate.living_room_air',
+        'climate.master_bedroom_air',
+        'climate.lincoln_air',
+        'climate.lilly_air'
+    )
+
+    $timerEntities = @(
+        'timer.lr_compressor_cooldown',
+        'timer.master_compressor_cooldown',
+        'timer.lincoln_compressor_cooldown',
+        'timer.lilly_compressor_cooldown'
+    )
+
+    $stateUri = "$apiBase/api/states"
+    $allStates = Invoke-HAGet -Uri $stateUri -Headers $headers -Token $AccessToken
+    $shadeEntities = @($allStates | Where-Object { $_.entity_id -like 'cover.*shade*' } | ForEach-Object { $_.entity_id })
+
+    $manifest = [pscustomobject]@{
+        generated_utc = (Get-Date).ToUniversalTime().ToString('o')
+        start_utc = $startUtc
+        end_utc = $endUtc
+        base_url = $normalizedBase
+        categories = [pscustomobject]@{
+            climates = $climateEntities
+            automations = $automationEntities
+            timers = $timerEntities
+            shades = $shadeEntities
+        }
+        notes = @(
+            'Read-only API usage: GET /api/states, GET /api/history/period, GET /api/logbook',
+            'No POST/PUT/PATCH/DELETE requests are used by this script.'
+        )
+    }
+    $manifest | ConvertTo-Json -Depth 10 | Out-File -FilePath (Join-Path $OutputFolder 'ha_export_manifest.json') -Encoding utf8
+
+    Export-Category -Category 'climates' -EntityIds $climateEntities -StartIso $startUtc -EndIso $endUtc -ApiBase $apiBase -Headers $headers -OutputFolder $OutputFolder -Format $Format -Token $AccessToken
+    Export-Category -Category 'automations' -EntityIds $automationEntities -StartIso $startUtc -EndIso $endUtc -ApiBase $apiBase -Headers $headers -OutputFolder $OutputFolder -Format $Format -Token $AccessToken
+    Export-Category -Category 'timers' -EntityIds $timerEntities -StartIso $startUtc -EndIso $endUtc -ApiBase $apiBase -Headers $headers -OutputFolder $OutputFolder -Format $Format -Token $AccessToken
+
+    $logbookUri = "$apiBase/api/logbook/$startUtc?end_time=$endUtc"
+    $logbook = Invoke-HAGet -Uri $logbookUri -Headers $headers -Token $AccessToken
+    $logbook | ConvertTo-Json -Depth 20 | Out-File -FilePath (Join-Path $OutputFolder 'ha_logbook.json') -Encoding utf8
+
+    Write-Host "Export complete. Output folder: $OutputFolder"
+    Write-Host "Shade entities discovered: $($shadeEntities.Count)"
 }
-$manifest | ConvertTo-Json -Depth 10 | Out-File -FilePath (Join-Path $OutputFolder 'ha_export_manifest.json') -Encoding utf8
 
-Export-Category -Category 'climates' -EntityIds $climateEntities -StartIso $startUtc -EndIso $endUtc -ApiBase $apiBase -Headers $headers -OutputFolder $OutputFolder -Format $Format -Token $AccessToken
-Export-Category -Category 'automations' -EntityIds $automationEntities -StartIso $startUtc -EndIso $endUtc -ApiBase $apiBase -Headers $headers -OutputFolder $OutputFolder -Format $Format -Token $AccessToken
-Export-Category -Category 'timers' -EntityIds $timerEntities -StartIso $startUtc -EndIso $endUtc -ApiBase $apiBase -Headers $headers -OutputFolder $OutputFolder -Format $Format -Token $AccessToken
-
-$logbookUri = "$apiBase/api/logbook/$startUtc?end_time=$endUtc"
-$logbook = Invoke-HAGet -Uri $logbookUri -Headers $headers -Token $AccessToken
-$logbook | ConvertTo-Json -Depth 20 | Out-File -FilePath (Join-Path $OutputFolder 'ha_logbook.json') -Encoding utf8
-
-Write-Host "Export complete. Output folder: $OutputFolder"
-Write-Host "Shade entities discovered: $($shadeEntities.Count)"
+if ($MyInvocation.InvocationName -ne '.') {
+    Invoke-HaNuisanceEvidenceExport @PSBoundParameters
+}


### PR DESCRIPTION
- 🎯 **What:** Added Pester coverage for `Get-RedactedMessage` and refactored the script to be dot-sourceable safely without executing the export workflow.
- 📊 **Coverage:** token present, repeated token, absent token, empty/null message, empty token, literal special-character token.
- ✨ **Result:** improves confidence that AccessToken values are not leaked through API error messages.

---
*PR created automatically by Jules for task [16976715960185651451](https://jules.google.com/task/16976715960185651451) started by @ManlyRedfish*