### PR TITLE
Clarify V6.1 debounce tuning changelog

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -35,7 +35,7 @@
 # CHANGELOG:
 #   V3-FIX:   Corrected entity_id slugification for Lincoln's/Lilly's
 #             apostrophe names (lincolns → lincoln_s, lillys → lilly_s)
-#   V6.1-FIX: LR delay_off 3min → 20min, Lincoln delay_off 3min → 15min
+#   V6.1:     LR delay_off tuned 3min → 20min; Lincoln 3min → 15min
 #   V3.1:     Full audit against HA device registry + telemetry (see below)
 #   STEP 2:   Surgical trim of legacy/fallback sensors from weighted truth
 #


### PR DESCRIPTION
Clarify V6.1 debounce tuning changelog in `configuration.yaml` to avoid task scanners from picking it up as a "FIX".

---
*PR created automatically by Jules for task [17807639043151168718](https://jules.google.com/task/17807639043151168718) started by @ManlyRedfish*