### PR TITLE
Clarify Safety Ceiling Gates all-season description

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -783,9 +783,9 @@
 - id: v7_5_safety_ceiling_gates
   alias: "V7.5: Safety Ceiling Gates (All-Season)"
   description: >
-    V3.1 FIX: Now active in ALL seasons including cooling. During cooling
+    V3.1 behavior: Active in all seasons including cooling. During cooling
     season, forces aggressive cool at 68°F for 45 min. During heating/shoulder,
-    uses fan_only for 45 min (original destratification behavior).
+    uses fan_only for 45 min.
   mode: parallel
   trigger:
     - platform: numeric_state


### PR DESCRIPTION
This PR addresses a false-positive task caused by the word "FIX" in the historical description of the `v7_5_safety_ceiling_gates` automation in `automations.yaml`.

The automation's actual runtime behavior was already all-season, and no functional changes were made. The description was updated from "V3.1 FIX" to "V3.1 behavior" to prevent automated scanners from treating it as an actionable item.

Testing:
- Ran `pytest tests/` successfully to verify YAML syntax integrity.

---
*PR created automatically by Jules for task [3687977641696876689](https://jules.google.com/task/3687977641696876689) started by @ManlyRedfish*