### PR TITLE
Use a List in Convert-HistoryResponseToRows and add unit tests

### DIFF
--- a/tools/export_ha_nuisance_evidence.Tests.ps1
+++ b/tools/export_ha_nuisance_evidence.Tests.ps1
@@ -38,3 +38,20 @@ Describe "Get-RedactedMessage" {
             Should -Be "token [REDACTED_TOKEN] leaked"
     }
 }
+
+
+Describe "Convert-HistoryResponseToRows" {
+    BeforeAll {
+        . "$PSScriptRoot/export_ha_nuisance_evidence.ps1"
+    }
+
+    It "returns no rows when HistoryResponse is null" {
+        $result = @(Convert-HistoryResponseToRows -HistoryResponse $null -Category "test")
+        $result.Count | Should -Be 0
+    }
+
+    It "returns no rows when HistoryResponse is empty" {
+        $result = @(Convert-HistoryResponseToRows -HistoryResponse @() -Category "test")
+        $result.Count | Should -Be 0
+    }
+}

--- a/tools/export_ha_nuisance_evidence.ps1
+++ b/tools/export_ha_nuisance_evidence.ps1
@@ -71,10 +71,10 @@ function Convert-HistoryResponseToRows {
         [string]$Category
     )
 
-    $rows = @()
+    $rows = [System.Collections.Generic.List[object]]::new()
 
     if ($null -eq $HistoryResponse) {
-        return $rows
+        return $rows.ToArray()
     }
 
     foreach ($entitySeries in $HistoryResponse) {
@@ -92,7 +92,7 @@ function Convert-HistoryResponseToRows {
                 $seriesEntityId
             }
 
-            $rows += [pscustomobject]@{
+            $rows.Add([pscustomobject]@{
                 category      = $Category
                 entity_id     = $effectiveEntityId
                 state         = $statePoint.state
@@ -102,11 +102,11 @@ function Convert-HistoryResponseToRows {
                 context_user  = $statePoint.context.user_id
                 context_parent = $statePoint.context.parent_id
                 attributes_json = ($statePoint.attributes | ConvertTo-Json -Depth 10 -Compress)
-            }
+            })
         }
     }
 
-    return $rows
+    return $rows.ToArray()
 }
 
 function Export-Category {


### PR DESCRIPTION
### Motivation
- Improve performance and correctness of `Convert-HistoryResponseToRows` by avoiding repeated array concatenation and ensuring a consistent array return value.
- Add unit tests to verify behavior for null and empty history responses.

### Description
- Replace array accumulation with a `System.Collections.Generic.List[object]` and use `.Add()` to append rows in `Convert-HistoryResponseToRows`.
- Return the collected rows as an array via `.ToArray()` and ensure a null `HistoryResponse` returns an empty array.
- Build each row using `[pscustomobject]` and add it to the list instead of using the `+=` operator.
- Add Pester tests in `tools/export_ha_nuisance_evidence.Tests.ps1` to cover `Convert-HistoryResponseToRows` behaviors for null and empty inputs and ensure the test file dot-sources the script under test.

### Testing
- Ran the Pester unit tests in `tools/export_ha_nuisance_evidence.Tests.ps1` which include the new `Convert-HistoryResponseToRows` tests, and they passed.
- Existing tests for `Get-RedactedMessage` were retained and executed as part of the test suite, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1614d5114c8323a6097af079f6b04e)