### PR TITLE
Use report-time freshness for temperature truth sensors

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -26,7 +26,10 @@
 #
 # DESIGN PRINCIPLES:
 #   - Per-room weighted-average truth from multiple physical sensors
-#   - 2-hour staleness rejection on all inputs
+#   - 2-hour staleness rejection on all inputs, measured by REPORT time
+#     (last_reported), not value-change time (last_changed). A stable sensor
+#     that keeps reporting the same temperature is NOT stale. (See
+#     docs/comfort_band_and_truth_confidence_plan.md and Doc 5 §7.9.)
 #   - Outlier rejection (Lincoln pilot, 3°F limit)
 #   - Mini-split internal sensors always low-weight (biased hardware)
 #   - MSR-2 DPS310 sensors removed (both units hardware-failed)
@@ -196,24 +199,24 @@ template:
           {% set fresh = namespace(count=0) %}
           {% set max_age = 7200 %}
           {% set hub = states('sensor.hub_temperature') | float(none) %}
-          {% if hub is not none and (now() - states.sensor.hub_temperature.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% if hub is not none and (now() - states.sensor.hub_temperature.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {% set hub2_legacy = states('sensor.hub_temperature_2') | float(none) %}
-          {% if hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% if hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {% set hub2 = states('sensor.hub_2_tempsensor_temperature') | float(none) %}
-          {% if hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% if hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {% set hp = states('sensor.living_room_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.living_room_air_temperature.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% if hp is not none and (now() - states.sensor.living_room_air_temperature.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {{ fresh.count > 0 }}
         state: >
           {% set max_age = 7200 %}
           {% set hub = states('sensor.hub_temperature') | float(none) %}
-          {% set hub_ok = hub is not none and (now() - states.sensor.hub_temperature.last_changed).total_seconds() < max_age %}
+          {% set hub_ok = hub is not none and (now() - states.sensor.hub_temperature.last_reported).total_seconds() < max_age %}
           {% set hub2_legacy = states('sensor.hub_temperature_2') | float(none) %}
-          {% set hub2_legacy_ok = hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_changed).total_seconds() < max_age %}
+          {% set hub2_legacy_ok = hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_reported).total_seconds() < max_age %}
           {% set hub2 = states('sensor.hub_2_tempsensor_temperature') | float(none) %}
-          {% set hub2_ok = hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_changed).total_seconds() < max_age %}
+          {% set hub2_ok = hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_reported).total_seconds() < max_age %}
           {% set hp = states('sensor.living_room_air_temperature') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.living_room_air_temperature.last_changed).total_seconds() < max_age %}
+          {% set hp_ok = hp is not none and (now() - states.sensor.living_room_air_temperature.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if hub_ok %}{% set ns.total = ns.total + (hub * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if hub2_legacy_ok %}{% set ns.total = ns.total + (hub2_legacy * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
@@ -230,24 +233,24 @@ template:
           {% set fresh = namespace(count=0) %}
           {% set max_age = 7200 %}
           {% set hub = states('sensor.hub_humidity') | float(none) %}
-          {% if hub is not none and (now() - states.sensor.hub_humidity.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% if hub is not none and (now() - states.sensor.hub_humidity.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {% set hub2_legacy = states('sensor.hub_humidity_2') | float(none) %}
-          {% if hub2_legacy is not none and (now() - states.sensor.hub_humidity_2.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% if hub2_legacy is not none and (now() - states.sensor.hub_humidity_2.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {% set hub2 = states('sensor.hub_2_humisensor_humidity') | float(none) %}
-          {% if hub2 is not none and (now() - states.sensor.hub_2_humisensor_humidity.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% if hub2 is not none and (now() - states.sensor.hub_2_humisensor_humidity.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {% set hp = states('sensor.living_room_air_humidity') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.living_room_air_humidity.last_changed).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
+          {% if hp is not none and (now() - states.sensor.living_room_air_humidity.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {{ fresh.count > 0 }}
         state: >
           {% set max_age = 7200 %}
           {% set hub = states('sensor.hub_humidity') | float(none) %}
-          {% set hub_ok = hub is not none and (now() - states.sensor.hub_humidity.last_changed).total_seconds() < max_age %}
+          {% set hub_ok = hub is not none and (now() - states.sensor.hub_humidity.last_reported).total_seconds() < max_age %}
           {% set hub2_legacy = states('sensor.hub_humidity_2') | float(none) %}
-          {% set hub2_legacy_ok = hub2_legacy is not none and (now() - states.sensor.hub_humidity_2.last_changed).total_seconds() < max_age %}
+          {% set hub2_legacy_ok = hub2_legacy is not none and (now() - states.sensor.hub_humidity_2.last_reported).total_seconds() < max_age %}
           {% set hub2 = states('sensor.hub_2_humisensor_humidity') | float(none) %}
-          {% set hub2_ok = hub2 is not none and (now() - states.sensor.hub_2_humisensor_humidity.last_changed).total_seconds() < max_age %}
+          {% set hub2_ok = hub2 is not none and (now() - states.sensor.hub_2_humisensor_humidity.last_reported).total_seconds() < max_age %}
           {% set hp = states('sensor.living_room_air_humidity') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.living_room_air_humidity.last_changed).total_seconds() < max_age %}
+          {% set hp_ok = hp is not none and (now() - states.sensor.living_room_air_humidity.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if hub_ok %}{% set ns.total = ns.total + (hub * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if hub2_legacy_ok %}{% set ns.total = ns.total + (hub2_legacy * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
@@ -261,7 +264,7 @@ template:
         device_class: carbon_dioxide
         state_class: measurement
         availability: >
-          {{ states('sensor.living_room_msr_co2') | float(none) is not none and (now() - states.sensor.living_room_msr_co2.last_changed).total_seconds() < 10800 }}
+          {{ states('sensor.living_room_msr_co2') | float(none) is not none and (now() - states.sensor.living_room_msr_co2.last_reported).total_seconds() < 10800 }}
         state: >
           {{ states('sensor.living_room_msr_co2') | float(none) | round(0) }}
 
@@ -271,13 +274,13 @@ template:
           {% set max_age = 7200 %}
           {% set parts = namespace(items=[]) %}
           {% set hub = states('sensor.hub_temperature') | float(none) %}
-          {% if hub is not none and (now() - states.sensor.hub_temperature.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_temperature'] %}{% endif %}
+          {% if hub is not none and (now() - states.sensor.hub_temperature.last_reported).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_temperature'] %}{% endif %}
           {% set hub2_legacy = states('sensor.hub_temperature_2') | float(none) %}
-          {% if hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_temperature_2'] %}{% endif %}
+          {% if hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_reported).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_temperature_2'] %}{% endif %}
           {% set hub2 = states('sensor.hub_2_tempsensor_temperature') | float(none) %}
-          {% if hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_2_tempsensor_temperature'] %}{% endif %}
+          {% if hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_reported).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_2_tempsensor_temperature'] %}{% endif %}
           {% set hp = states('sensor.living_room_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.living_room_air_temperature.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['living_room_air_temperature'] %}{% endif %}
+          {% if hp is not none and (now() - states.sensor.living_room_air_temperature.last_reported).total_seconds() < max_age %}{% set parts.items = parts.items + ['living_room_air_temperature'] %}{% endif %}
           {{ parts.items | join(', ') if parts.items | length > 0 else 'none' }}
 
       - name: "Living Room Temperature Truth Active Count"
@@ -286,13 +289,13 @@ template:
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
           {% set hub = states('sensor.hub_temperature') | float(none) %}
-          {% if hub is not none and (now() - states.sensor.hub_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if hub is not none and (now() - states.sensor.hub_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hub2_legacy = states('sensor.hub_temperature_2') | float(none) %}
-          {% if hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hub2 = states('sensor.hub_2_tempsensor_temperature') | float(none) %}
-          {% if hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hp = states('sensor.living_room_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.living_room_air_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if hp is not none and (now() - states.sensor.living_room_air_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v }}
 
       # =========================================================
@@ -319,20 +322,20 @@ template:
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
           {% set s1 = states('sensor.master_bedroom_temp_temperature_2') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.master_bedroom_temp_temperature_2.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s1 is not none and (now() - states.sensor.master_bedroom_temp_temperature_2.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s2 = states('sensor.master_bedroom_temperature_temperature_2') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.master_bedroom_temperature_temperature_2.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s2 is not none and (now() - states.sensor.master_bedroom_temperature_temperature_2.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hp = states('sensor.master_bedroom_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.master_bedroom_air_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if hp is not none and (now() - states.sensor.master_bedroom_air_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
           {% set s1 = states('sensor.master_bedroom_temp_temperature_2') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.master_bedroom_temp_temperature_2.last_changed).total_seconds() < max_age %}
+          {% set s1_ok = s1 is not none and (now() - states.sensor.master_bedroom_temp_temperature_2.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.master_bedroom_temperature_temperature_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.master_bedroom_temperature_temperature_2.last_changed).total_seconds() < max_age %}
+          {% set s2_ok = s2 is not none and (now() - states.sensor.master_bedroom_temperature_temperature_2.last_reported).total_seconds() < max_age %}
           {% set hp = states('sensor.master_bedroom_air_temperature') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.master_bedroom_air_temperature.last_changed).total_seconds() < max_age %}
+          {% set hp_ok = hp is not none and (now() - states.sensor.master_bedroom_air_temperature.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
@@ -348,20 +351,20 @@ template:
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
           {% set s1 = states('sensor.master_bedroom_temp_humidity_2') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.master_bedroom_temp_humidity_2.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s1 is not none and (now() - states.sensor.master_bedroom_temp_humidity_2.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s2 = states('sensor.master_bedroom_temperature_humidity_2') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.master_bedroom_temperature_humidity_2.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s2 is not none and (now() - states.sensor.master_bedroom_temperature_humidity_2.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hp = states('sensor.master_bedroom_air_humidity') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.master_bedroom_air_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if hp is not none and (now() - states.sensor.master_bedroom_air_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
           {% set s1 = states('sensor.master_bedroom_temp_humidity_2') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.master_bedroom_temp_humidity_2.last_changed).total_seconds() < max_age %}
+          {% set s1_ok = s1 is not none and (now() - states.sensor.master_bedroom_temp_humidity_2.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.master_bedroom_temperature_humidity_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.master_bedroom_temperature_humidity_2.last_changed).total_seconds() < max_age %}
+          {% set s2_ok = s2 is not none and (now() - states.sensor.master_bedroom_temperature_humidity_2.last_reported).total_seconds() < max_age %}
           {% set hp = states('sensor.master_bedroom_air_humidity') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.master_bedroom_air_humidity.last_changed).total_seconds() < max_age %}
+          {% set hp_ok = hp is not none and (now() - states.sensor.master_bedroom_air_humidity.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
@@ -396,24 +399,24 @@ template:
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
           {% set s1 = states('sensor.lincoln_s_temp_temperature') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s2 = states('sensor.lincoln_s_room_temperature_temperature') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s3 = states('sensor.lincoln_temp_temperature') | float(none) %}
-          {% if s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hp = states('sensor.lincoln_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.lincoln_air_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if hp is not none and (now() - states.sensor.lincoln_air_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
           {% set outlier_limit = 3.0 %}
 
           {% set s1 = states('sensor.lincoln_s_temp_temperature') | float(none) %}
-          {% set s1_fresh = s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_fresh = s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.lincoln_s_room_temperature_temperature') | float(none) %}
-          {% set s2_fresh = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_changed).total_seconds() < max_age %}
+          {% set s2_fresh = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_reported).total_seconds() < max_age %}
           {% set s3 = states('sensor.lincoln_temp_temperature') | float(none) %}
-          {% set s3_fresh = s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_changed).total_seconds() < max_age %}
+          {% set s3_fresh = s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_reported).total_seconds() < max_age %}
 
           {% set base_total = (s1 if s1_fresh else 0) + (s2 if s2_fresh else 0) + (s3 if s3_fresh else 0) %}
           {% set base_count = (1 if s1_fresh else 0) + (1 if s2_fresh else 0) + (1 if s3_fresh else 0) %}
@@ -423,7 +426,7 @@ template:
           {% set s2_ok = s2_fresh and (base_mean is none or ((s2 - base_mean) | abs <= outlier_limit)) %}
           {% set s3_ok = s3_fresh and (base_mean is none or ((s3 - base_mean) | abs <= outlier_limit)) %}
           {% set hp = states('sensor.lincoln_air_temperature') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.lincoln_air_temperature.last_changed).total_seconds() < max_age %}
+          {% set hp_ok = hp is not none and (now() - states.sensor.lincoln_air_temperature.last_reported).total_seconds() < max_age %}
 
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
@@ -441,24 +444,24 @@ template:
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
           {% set s1 = states('sensor.lincoln_s_temp_humidity') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.lincoln_s_temp_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s1 is not none and (now() - states.sensor.lincoln_s_temp_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s2 = states('sensor.lincoln_s_room_temperature_humidity') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s3 = states('sensor.lincoln_temp_humidity') | float(none) %}
-          {% if s3 is not none and (now() - states.sensor.lincoln_temp_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s3 is not none and (now() - states.sensor.lincoln_temp_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hp = states('sensor.lincoln_air_humidity') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.lincoln_air_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if hp is not none and (now() - states.sensor.lincoln_air_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
           {% set s1 = states('sensor.lincoln_s_temp_humidity') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.lincoln_s_temp_humidity.last_changed).total_seconds() < max_age %}
+          {% set s1_ok = s1 is not none and (now() - states.sensor.lincoln_s_temp_humidity.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.lincoln_s_room_temperature_humidity') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_humidity.last_changed).total_seconds() < max_age %}
+          {% set s2_ok = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_humidity.last_reported).total_seconds() < max_age %}
           {% set s3 = states('sensor.lincoln_temp_humidity') | float(none) %}
-          {% set s3_ok = s3 is not none and (now() - states.sensor.lincoln_temp_humidity.last_changed).total_seconds() < max_age %}
+          {% set s3_ok = s3 is not none and (now() - states.sensor.lincoln_temp_humidity.last_reported).total_seconds() < max_age %}
           {% set hp = states('sensor.lincoln_air_humidity') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.lincoln_air_humidity.last_changed).total_seconds() < max_age %}
+          {% set hp_ok = hp is not none and (now() - states.sensor.lincoln_air_humidity.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
@@ -473,11 +476,11 @@ template:
           {% set outlier_limit = 3.0 %}
           {% set parts = namespace(items=[]) %}
           {% set s1 = states('sensor.lincoln_s_temp_temperature') | float(none) %}
-          {% set s1_fresh = s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_fresh = s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.lincoln_s_room_temperature_temperature') | float(none) %}
-          {% set s2_fresh = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_changed).total_seconds() < max_age %}
+          {% set s2_fresh = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_reported).total_seconds() < max_age %}
           {% set s3 = states('sensor.lincoln_temp_temperature') | float(none) %}
-          {% set s3_fresh = s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_changed).total_seconds() < max_age %}
+          {% set s3_fresh = s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_reported).total_seconds() < max_age %}
           {% set base_total = (s1 if s1_fresh else 0) + (s2 if s2_fresh else 0) + (s3 if s3_fresh else 0) %}
           {% set base_count = (1 if s1_fresh else 0) + (1 if s2_fresh else 0) + (1 if s3_fresh else 0) %}
           {% set base_mean = (base_total / base_count) if base_count > 0 else none %}
@@ -485,7 +488,7 @@ template:
           {% if s2_fresh and (base_mean is none or ((s2 - base_mean) | abs <= outlier_limit)) %}{% set parts.items = parts.items + ['lincoln_s_room_temperature_temperature'] %}{% endif %}
           {% if s3_fresh and (base_mean is none or ((s3 - base_mean) | abs <= outlier_limit)) %}{% set parts.items = parts.items + ['lincoln_temp_temperature'] %}{% endif %}
           {% set hp = states('sensor.lincoln_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.lincoln_air_temperature.last_changed).total_seconds() < max_age %}{% set parts.items = parts.items + ['lincoln_air_temperature'] %}{% endif %}
+          {% if hp is not none and (now() - states.sensor.lincoln_air_temperature.last_reported).total_seconds() < max_age %}{% set parts.items = parts.items + ['lincoln_air_temperature'] %}{% endif %}
           {{ parts.items | join(', ') if parts.items | length > 0 else 'none' }}
 
       - name: "Lincoln Temperature Truth Rejected"
@@ -500,9 +503,9 @@ template:
           {% set s1 = s1_raw | float(none) %}
           {% set s2 = s2_raw | float(none) %}
           {% set s3 = s3_raw | float(none) %}
-          {% set s1_fresh = s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_changed).total_seconds() < max_age %}
-          {% set s2_fresh = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_changed).total_seconds() < max_age %}
-          {% set s3_fresh = s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_fresh = s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_reported).total_seconds() < max_age %}
+          {% set s2_fresh = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_reported).total_seconds() < max_age %}
+          {% set s3_fresh = s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_reported).total_seconds() < max_age %}
           {% set base_total = (s1 if s1_fresh else 0) + (s2 if s2_fresh else 0) + (s3 if s3_fresh else 0) %}
           {% set base_count = (1 if s1_fresh else 0) + (1 if s2_fresh else 0) + (1 if s3_fresh else 0) %}
           {% set base_mean = (base_total / base_count) if base_count > 0 else none %}
@@ -536,11 +539,11 @@ template:
           {% set outlier_limit = 3.0 %}
           {% set count = namespace(v=0) %}
           {% set s1 = states('sensor.lincoln_s_temp_temperature') | float(none) %}
-          {% set s1_fresh = s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_fresh = s1 is not none and (now() - states.sensor.lincoln_s_temp_temperature.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.lincoln_s_room_temperature_temperature') | float(none) %}
-          {% set s2_fresh = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_changed).total_seconds() < max_age %}
+          {% set s2_fresh = s2 is not none and (now() - states.sensor.lincoln_s_room_temperature_temperature.last_reported).total_seconds() < max_age %}
           {% set s3 = states('sensor.lincoln_temp_temperature') | float(none) %}
-          {% set s3_fresh = s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_changed).total_seconds() < max_age %}
+          {% set s3_fresh = s3 is not none and (now() - states.sensor.lincoln_temp_temperature.last_reported).total_seconds() < max_age %}
           {% set base_total = (s1 if s1_fresh else 0) + (s2 if s2_fresh else 0) + (s3 if s3_fresh else 0) %}
           {% set base_count = (1 if s1_fresh else 0) + (1 if s2_fresh else 0) + (1 if s3_fresh else 0) %}
           {% set base_mean = (base_total / base_count) if base_count > 0 else none %}
@@ -548,7 +551,7 @@ template:
           {% if s2_fresh and (base_mean is none or ((s2 - base_mean) | abs <= outlier_limit)) %}{% set count.v = count.v + 1 %}{% endif %}
           {% if s3_fresh and (base_mean is none or ((s3 - base_mean) | abs <= outlier_limit)) %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hp = states('sensor.lincoln_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.lincoln_air_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if hp is not none and (now() - states.sensor.lincoln_air_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v }}
 
       # =========================================================
@@ -576,20 +579,20 @@ template:
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
           {% set s1 = states('sensor.lilly_temperature') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.lilly_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s1 is not none and (now() - states.sensor.lilly_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s2 = states('sensor.lilly_room_temperature_temperature') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.lilly_room_temperature_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s2 is not none and (now() - states.sensor.lilly_room_temperature_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hp = states('sensor.lilly_air_temperature') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.lilly_air_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if hp is not none and (now() - states.sensor.lilly_air_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
           {% set s1 = states('sensor.lilly_temperature') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.lilly_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_ok = s1 is not none and (now() - states.sensor.lilly_temperature.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.lilly_room_temperature_temperature') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.lilly_room_temperature_temperature.last_changed).total_seconds() < max_age %}
+          {% set s2_ok = s2 is not none and (now() - states.sensor.lilly_room_temperature_temperature.last_reported).total_seconds() < max_age %}
           {% set hp = states('sensor.lilly_air_temperature') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.lilly_air_temperature.last_changed).total_seconds() < max_age %}
+          {% set hp_ok = hp is not none and (now() - states.sensor.lilly_air_temperature.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
@@ -605,20 +608,20 @@ template:
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
           {% set s1 = states('sensor.lilly_humidity') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.lilly_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s1 is not none and (now() - states.sensor.lilly_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s2 = states('sensor.lilly_room_temperature_humidity') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.lilly_room_temperature_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s2 is not none and (now() - states.sensor.lilly_room_temperature_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hp = states('sensor.lilly_air_humidity') | float(none) %}
-          {% if hp is not none and (now() - states.sensor.lilly_air_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if hp is not none and (now() - states.sensor.lilly_air_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
           {% set s1 = states('sensor.lilly_humidity') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.lilly_humidity.last_changed).total_seconds() < max_age %}
+          {% set s1_ok = s1 is not none and (now() - states.sensor.lilly_humidity.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.lilly_room_temperature_humidity') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.lilly_room_temperature_humidity.last_changed).total_seconds() < max_age %}
+          {% set s2_ok = s2 is not none and (now() - states.sensor.lilly_room_temperature_humidity.last_reported).total_seconds() < max_age %}
           {% set hp = states('sensor.lilly_air_humidity') | float(none) %}
-          {% set hp_ok = hp is not none and (now() - states.sensor.lilly_air_humidity.last_changed).total_seconds() < max_age %}
+          {% set hp_ok = hp is not none and (now() - states.sensor.lilly_air_humidity.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
@@ -650,20 +653,20 @@ template:
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
           {% set s1 = states('sensor.office_temp_temperature') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.office_temp_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s1 is not none and (now() - states.sensor.office_temp_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s2 = states('sensor.office_temperature_2') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.office_temperature_2.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s2 is not none and (now() - states.sensor.office_temperature_2.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set net = states('sensor.indoor_temperature') | float(none) %}
-          {% if net is not none and (now() - states.sensor.indoor_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if net is not none and (now() - states.sensor.indoor_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
           {% set s1 = states('sensor.office_temp_temperature') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.office_temp_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_ok = s1 is not none and (now() - states.sensor.office_temp_temperature.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.office_temperature_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.office_temperature_2.last_changed).total_seconds() < max_age %}
+          {% set s2_ok = s2 is not none and (now() - states.sensor.office_temperature_2.last_reported).total_seconds() < max_age %}
           {% set net = states('sensor.indoor_temperature') | float(none) %}
-          {% set net_ok = net is not none and (now() - states.sensor.indoor_temperature.last_changed).total_seconds() < max_age %}
+          {% set net_ok = net is not none and (now() - states.sensor.indoor_temperature.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 0.95) %}{% set ns.weight = ns.weight + 0.95 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.95) %}{% set ns.weight = ns.weight + 0.95 %}{% endif %}
@@ -679,20 +682,20 @@ template:
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
           {% set s1 = states('sensor.office_temp_humidity') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.office_temp_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s1 is not none and (now() - states.sensor.office_temp_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s2 = states('sensor.office_humidity_2') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.office_humidity_2.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s2 is not none and (now() - states.sensor.office_humidity_2.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set net = states('sensor.indoor_humidity') | float(none) %}
-          {% if net is not none and (now() - states.sensor.indoor_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if net is not none and (now() - states.sensor.indoor_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
           {% set s1 = states('sensor.office_temp_humidity') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.office_temp_humidity.last_changed).total_seconds() < max_age %}
+          {% set s1_ok = s1 is not none and (now() - states.sensor.office_temp_humidity.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.office_humidity_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.office_humidity_2.last_changed).total_seconds() < max_age %}
+          {% set s2_ok = s2 is not none and (now() - states.sensor.office_humidity_2.last_reported).total_seconds() < max_age %}
           {% set net = states('sensor.indoor_humidity') | float(none) %}
-          {% set net_ok = net is not none and (now() - states.sensor.indoor_humidity.last_changed).total_seconds() < max_age %}
+          {% set net_ok = net is not none and (now() - states.sensor.indoor_humidity.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 0.95) %}{% set ns.weight = ns.weight + 0.95 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.95) %}{% set ns.weight = ns.weight + 0.95 %}{% endif %}
@@ -705,7 +708,7 @@ template:
         device_class: carbon_dioxide
         state_class: measurement
         availability: >
-          {{ states('sensor.indoor_carbon_dioxide') | float(none) is not none and (now() - states.sensor.indoor_carbon_dioxide.last_changed).total_seconds() < 10800 }}
+          {{ states('sensor.indoor_carbon_dioxide') | float(none) is not none and (now() - states.sensor.indoor_carbon_dioxide.last_reported).total_seconds() < 10800 }}
         state: >
           {{ states('sensor.indoor_carbon_dioxide') | float(none) | round(0) }}
 
@@ -733,16 +736,16 @@ template:
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
           {% set s1 = states('sensor.laundry_temperature') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.laundry_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s1 is not none and (now() - states.sensor.laundry_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s2 = states('sensor.bathroom_downstairs_temperature') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.bathroom_downstairs_temperature.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s2 is not none and (now() - states.sensor.bathroom_downstairs_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
           {% set s1 = states('sensor.laundry_temperature') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.laundry_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_ok = s1 is not none and (now() - states.sensor.laundry_temperature.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.bathroom_downstairs_temperature') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.bathroom_downstairs_temperature.last_changed).total_seconds() < max_age %}
+          {% set s2_ok = s2 is not none and (now() - states.sensor.bathroom_downstairs_temperature.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.8) %}{% set ns.weight = ns.weight + 0.8 %}{% endif %}
@@ -757,16 +760,16 @@ template:
           {% set max_age = 7200 %}
           {% set count = namespace(v=0) %}
           {% set s1 = states('sensor.laundry_humidity') | float(none) %}
-          {% if s1 is not none and (now() - states.sensor.laundry_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s1 is not none and (now() - states.sensor.laundry_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s2 = states('sensor.bathroom_downstairs_humidity') | float(none) %}
-          {% if s2 is not none and (now() - states.sensor.bathroom_downstairs_humidity.last_changed).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% if s2 is not none and (now() - states.sensor.bathroom_downstairs_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
         state: >
           {% set max_age = 7200 %}
           {% set s1 = states('sensor.laundry_humidity') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.laundry_humidity.last_changed).total_seconds() < max_age %}
+          {% set s1_ok = s1 is not none and (now() - states.sensor.laundry_humidity.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.bathroom_downstairs_humidity') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.bathroom_downstairs_humidity.last_changed).total_seconds() < max_age %}
+          {% set s2_ok = s2 is not none and (now() - states.sensor.bathroom_downstairs_humidity.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.8) %}{% set ns.weight = ns.weight + 0.8 %}{% endif %}
@@ -795,16 +798,16 @@ template:
         availability: >
           {% set max_age = 7200 %}
           {% set s1 = states('sensor.deck_temp_temperature') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.deck_temp_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_ok = s1 is not none and (now() - states.sensor.deck_temp_temperature.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.deck_temp_temperature_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.deck_temp_temperature_2.last_changed).total_seconds() < max_age %}
+          {% set s2_ok = s2 is not none and (now() - states.sensor.deck_temp_temperature_2.last_reported).total_seconds() < max_age %}
           {{ s1_ok or s2_ok }}
         state: >
           {% set max_age = 7200 %}
           {% set s1 = states('sensor.deck_temp_temperature') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.deck_temp_temperature.last_changed).total_seconds() < max_age %}
+          {% set s1_ok = s1 is not none and (now() - states.sensor.deck_temp_temperature.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.deck_temp_temperature_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.deck_temp_temperature_2.last_changed).total_seconds() < max_age %}
+          {% set s2_ok = s2 is not none and (now() - states.sensor.deck_temp_temperature_2.last_reported).total_seconds() < max_age %}
           {% if s1_ok and s2_ok %}
             {{ ((s1 + s2) / 2) | round(2) }}
           {% elif s1_ok %}
@@ -821,16 +824,16 @@ template:
         availability: >
           {% set max_age = 7200 %}
           {% set s1 = states('sensor.deck_temp_humidity') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.deck_temp_humidity.last_changed).total_seconds() < max_age %}
+          {% set s1_ok = s1 is not none and (now() - states.sensor.deck_temp_humidity.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.deck_temp_humidity_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.deck_temp_humidity_2.last_changed).total_seconds() < max_age %}
+          {% set s2_ok = s2 is not none and (now() - states.sensor.deck_temp_humidity_2.last_reported).total_seconds() < max_age %}
           {{ s1_ok or s2_ok }}
         state: >
           {% set max_age = 7200 %}
           {% set s1 = states('sensor.deck_temp_humidity') | float(none) %}
-          {% set s1_ok = s1 is not none and (now() - states.sensor.deck_temp_humidity.last_changed).total_seconds() < max_age %}
+          {% set s1_ok = s1 is not none and (now() - states.sensor.deck_temp_humidity.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.deck_temp_humidity_2') | float(none) %}
-          {% set s2_ok = s2 is not none and (now() - states.sensor.deck_temp_humidity_2.last_changed).total_seconds() < max_age %}
+          {% set s2_ok = s2 is not none and (now() - states.sensor.deck_temp_humidity_2.last_reported).total_seconds() < max_age %}
           {% if s1_ok and s2_ok %}
             {{ ((s1 + s2) / 2) | round(1) }}
           {% elif s1_ok %}

--- a/docs/5_runtime_layer.md
+++ b/docs/5_runtime_layer.md
@@ -306,18 +306,24 @@ boundary.
    Matter / Bluetooth / SmartThings remain available — partial degradation must
    not collapse into `failed` (consistent with Startup Canon §4 and §6).
 3. A stable temperature sensor must not be treated as stale merely because its
-   value did not change. Today's truth templates use `last_changed` + a 2-hour
-   `max_age`, which false-stales an unchanging-but-reporting sensor. The planned
-   correction is to use report time (`last_reported` / `last_updated`). **This
-   migration is deferred to its own runtime PR** because it changes the live
-   `availability` of every truth sensor.
+   value did not change. **LANDED:** the live truth templates now measure
+   freshness by report time (`last_reported`) instead of value-change time
+   (`last_changed`), so an unchanging-but-reporting sensor is no longer
+   false-staled. The 2-hour (`max_age = 7200`) temperature/humidity window and
+   the 3-hour (`10800`) CO2 window are unchanged; only the freshness clock
+   moved. `last_updated` was rejected as the clock because it also fails to
+   advance when a stable sensor reports an unchanged value with unchanged
+   attributes. `automations.yaml` still uses `climate.*.last_changed` for
+   state-duration (how long a unit has held a mode) — that is value-transition
+   measurement, not reporting freshness, and is correctly left unchanged.
 
-**Regression guardrails (this PR, docs/tests only):**
+**Regression guardrails:**
 `tests/test_comfort_band_safety_separation.py` locks the comfort-vs-safety
 separation and the 60°F/58°F floors; `tests/test_truth_confidence_model_contract.py`
-locks the four-state ladder as a pure model contract, with the
-`last_reported` freshness expectation against live config marked `xfail`
-(reason: runtime freshness migration deferred to later PR).
+locks the four-state ladder as a pure model contract and asserts the live
+config uses report-time freshness; `tests/test_truth_freshness_report_time.py`
+locks the freshness clock (config uses `last_reported`, never `last_changed`;
+`automations.yaml` untouched; CO2/temperature windows and weights preserved).
 
 ## 8. Runtime Change Rules
 

--- a/tests/test_truth_confidence_model_contract.py
+++ b/tests/test_truth_confidence_model_contract.py
@@ -209,42 +209,45 @@ def test_plan_doc_documents_status_ladder():
 
 
 # --------------------------------------------------------------------------- #
-# Deferred runtime expectation — xfail until the freshness migration lands.
+# Runtime expectation — the freshness migration has landed (see
+# claude/truth-freshness-last-reported). These were xfail in PR #123 and are
+# now hard assertions: truth freshness is measured by report time.
 # --------------------------------------------------------------------------- #
 
-@pytest.mark.xfail(
-    reason="runtime freshness migration deferred to later PR", strict=False
-)
-def test_live_truth_templates_use_report_time_freshness():
-    """FUTURE CONTRACT (currently expected to fail).
-
-    The live truth templates in configuration.yaml should use report-time
-    freshness (last_reported / last_updated) instead of last_changed, so a
-    stable-but-reporting sensor is not false-staled. Today they use
-    last_changed, so this assertion fails and is marked xfail. When the
-    freshness-migration PR lands, this will xpass and can be promoted to a
-    hard assertion.
-    """
+def _read_config_text():
     path = os.path.join(os.path.dirname(__file__), "..", "configuration.yaml")
     if not os.path.exists(path):
         pytest.skip("configuration.yaml not found.")
     with open(path, "r", encoding="utf-8") as fh:
-        config_text = fh.read()
+        return fh.read()
+
+
+def test_live_truth_templates_use_report_time_freshness():
+    """The live truth templates use report-time freshness (last_reported /
+    last_updated) so a stable-but-reporting sensor is not false-staled."""
+    config_text = _read_config_text()
     assert "last_reported" in config_text or "last_updated" in config_text, (
-        "Truth templates should use report-time freshness (deferred runtime PR)."
+        "Truth templates must use report-time freshness (last_reported / "
+        "last_updated)."
     )
 
 
-def test_live_truth_templates_currently_use_last_changed():
-    """Documents current reality (PASSES today): live freshness is last_changed.
+def test_live_truth_freshness_clock_is_not_last_changed():
+    """Regression guard: last_changed must not be used as the freshness clock
+    for truth templates. The freshness-check shape is
+    `(now() - <state>.<clock>).total_seconds() < max_age`; that clock must be
+    report-time, never value-change time.
 
-    Paired with the xfail above, this makes the deferred migration explicit:
-    when freshness moves to report-time, update both tests together."""
-    path = os.path.join(os.path.dirname(__file__), "..", "configuration.yaml")
-    if not os.path.exists(path):
-        pytest.skip("configuration.yaml not found.")
-    with open(path, "r", encoding="utf-8") as fh:
-        config_text = fh.read()
-    assert "last_changed" in config_text, (
-        "Current runtime is expected to still use last_changed freshness."
+    Note: this asserts on configuration.yaml only. automations.yaml legitimately
+    uses climate.*.last_changed for state-duration logic (how long a unit has
+    been in a mode), which is a value-transition measurement, not freshness."""
+    config_text = _read_config_text()
+    assert ".last_changed).total_seconds()" not in config_text, (
+        "configuration.yaml truth freshness must not use last_changed as its "
+        "max_age clock; use last_reported (report-time freshness)."
+    )
+    # And the report-time clock must actually be the one wired into the
+    # freshness comparison.
+    assert ".last_reported).total_seconds()" in config_text, (
+        "configuration.yaml truth freshness must compare against last_reported."
     )

--- a/tests/test_truth_confidence_model_contract.py
+++ b/tests/test_truth_confidence_model_contract.py
@@ -82,8 +82,9 @@ def is_report_fresh(last_changed_age_s, last_reported_age_s, max_age_s=7200):
 
 
 def is_value_change_fresh(last_changed_age_s, max_age_s=7200):
-    """The CURRENT (live) freshness rule, modelled here only to document the
-    bug the proposed model fixes. Not a target — see the xfail test below."""
+    """The OLD freshness rule (value-change time), modelled here only to
+    document the bug the report-time model fixes. Not a target; the live
+    config now uses report-time freshness (see the report-time tests below)."""
     return last_changed_age_s < max_age_s
 
 

--- a/tests/test_truth_freshness_report_time.py
+++ b/tests/test_truth_freshness_report_time.py
@@ -1,0 +1,137 @@
+"""
+Truth-Sensor Report-Time Freshness Regression Guards
+====================================================
+
+Locks the freshness-clock migration delivered in
+``claude/truth-freshness-last-reported`` (the follow-up to PR #123).
+
+Doctrine: freshness means "is this sensor still REPORTING?" — measured by
+report time (``last_reported``), not value-change time (``last_changed``). A
+thermally stable room can report the same temperature for hours; that is not
+staleness. See:
+  docs/comfort_band_and_truth_confidence_plan.md
+  docs/5_runtime_layer.md §7.9
+  truth_sensor_architecture.md (Sensor Freshness)
+
+These tests inspect the live YAML source text. They assert nothing about, and
+change nothing in, comfort thresholds, weights, source lists, safety gates, or
+supervisor behavior.
+"""
+
+import os
+import re
+
+import pytest
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+
+CONFIG = os.path.join(REPO_ROOT, "configuration.yaml")
+AUTOMATIONS = os.path.join(REPO_ROOT, "automations.yaml")
+
+# The freshness-check shape used throughout the truth templates:
+#   (now() - states.<entity>.<clock>).total_seconds() < <max_age>
+FRESHNESS_CALL = ".total_seconds()"
+LAST_CHANGED_CLOCK = ".last_changed).total_seconds()"
+LAST_REPORTED_CLOCK = ".last_reported).total_seconds()"
+
+
+def _read(path):
+    if not os.path.exists(path):
+        pytest.skip(f"{os.path.basename(path)} not found.")
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+# --------------------------------------------------------------------------- #
+# configuration.yaml: freshness clock migrated to report time
+# --------------------------------------------------------------------------- #
+
+def test_config_truth_freshness_uses_report_time_clock():
+    text = _read(CONFIG)
+    assert LAST_REPORTED_CLOCK in text, (
+        "Truth freshness checks must compare against last_reported."
+    )
+
+
+def test_config_truth_freshness_does_not_use_last_changed_clock():
+    text = _read(CONFIG)
+    assert LAST_CHANGED_CLOCK not in text, (
+        "configuration.yaml must not use last_changed as a freshness clock; "
+        "a stable-but-reporting sensor would be false-staled."
+    )
+    # Note: the word "last_changed" may still appear in an explanatory comment;
+    # what matters is that it is never wired into a .total_seconds() freshness
+    # comparison (asserted above).
+
+
+def test_config_every_freshness_call_uses_report_time():
+    """Every (... ).total_seconds() freshness comparison resolves to a
+    last_reported clock — none slipped through as last_changed."""
+    text = _read(CONFIG)
+    total_calls = text.count(FRESHNESS_CALL)
+    reported_calls = text.count(LAST_REPORTED_CLOCK)
+    changed_calls = text.count(LAST_CHANGED_CLOCK)
+    assert changed_calls == 0
+    assert reported_calls == total_calls, (
+        f"{total_calls} freshness calls found but only {reported_calls} use "
+        "last_reported; some freshness check is on a different clock."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# CO2 cadence preserved (distinct 3h window, only the clock changed)
+# --------------------------------------------------------------------------- #
+
+def test_config_co2_three_hour_window_preserved():
+    """CO2 truth keeps its distinct 10800s (3h) window — this PR changes the
+    freshness CLOCK only, not any max_age / cadence value."""
+    text = _read(CONFIG)
+    assert "< 10800" in text, "CO2 truth 3-hour (10800s) window must be preserved."
+    # The 2-hour temperature/humidity window is also untouched.
+    assert "max_age = 7200" in text, "2-hour (7200s) staleness window must be preserved."
+
+
+# --------------------------------------------------------------------------- #
+# Migration did not bleed into automations.yaml
+# --------------------------------------------------------------------------- #
+
+def test_automations_freshness_clock_untouched():
+    """automations.yaml must not be touched by this migration: it legitimately
+    uses climate.*.last_changed to measure how long a unit has been in a mode
+    (state-duration / value-transition), which is NOT a reporting-freshness
+    check and must stay last_changed."""
+    text = _read(AUTOMATIONS)
+    assert ".last_reported)" not in text, (
+        "automations.yaml should not have been migrated to last_reported."
+    )
+    # Every last_changed in automations.yaml must be on a climate.* entity
+    # (state-duration), never a sensor.* freshness check.
+    domains = re.findall(r"states\.(\w+)\.\w+\.last_changed", text)
+    assert domains, "Expected the existing climate.* state-duration checks to remain."
+    non_climate = [d for d in domains if d != "climate"]
+    assert not non_climate, (
+        f"automations.yaml last_changed used on non-climate domains {non_climate}; "
+        "those would be freshness checks that should use report-time instead."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Safety + comfort invariants untouched by a freshness PR
+# --------------------------------------------------------------------------- #
+
+def test_section3_safety_floor_thresholds_unchanged():
+    """A freshness PR must not alter Section 3 safety floors."""
+    text = _read(AUTOMATIONS)
+    assert "below: 60" in text, "LR runaway 60°F floor must remain."
+    assert "below: 58" in text, "Master emergency 58°F floor must remain."
+
+
+def test_truth_sensor_weights_unchanged_spot_check():
+    """Spot-check that representative truth weights are untouched (this PR
+    changes only the freshness clock, never weights)."""
+    text = _read(CONFIG)
+    # Samsung internal stays low-weight; primaries keep their weights.
+    assert "(hp * 0.20)" in text, "Samsung internal temperature weight 0.20 must remain."
+    assert "(hp * 0.25)" in text, "Samsung internal humidity weight 0.25 must remain."
+    assert "outlier_limit = 3.0" in text, "Lincoln 3°F outlier limit must remain."

--- a/truth_sensor_architecture.md
+++ b/truth_sensor_architecture.md
@@ -56,6 +56,14 @@ Standard staleness threshold:
 
 Stale sensors are excluded from weighted calculations.
 
+Freshness is measured by **report time** (`last_reported`), not value-change
+time (`last_changed`). A stable sensor that keeps reporting the same temperature
+for hours is still fresh; only a sensor that has stopped reporting (or is
+`unavailable`/`unknown`, or fails value-sanity) is treated as stale. Using
+`last_changed` here would false-stale a healthy but thermally stable room. See
+`docs/comfort_band_and_truth_confidence_plan.md` and `docs/5_runtime_layer.md`
+§7.9.
+
 ---
 
 # Weighting Philosophy


### PR DESCRIPTION
## What

Migrates Moose House truth-sensor freshness checks from value-change time
(`last_changed`) to report-time freshness (`last_reported`), so stable
temperature sensors are not falsely marked stale just because their value did
not change.

## Why

Temperature sensors can remain healthy while reporting the same value for hours.
Using `last_changed` as the freshness clock causes false staleness in thermally
stable rooms and can collapse truth availability even when sources are present.

## Scope

- Updates `configuration.yaml` truth freshness checks only (105 occurrences of
  `(now() - states.<entity>.last_changed).total_seconds() < max_age` →
  `.last_reported`). Temperature, humidity, CO2, contributor / active-count,
  Lincoln outlier diagnostics, and Deck truth all covered.
- Preserves existing source weights, `max_age` values (7200 temp/humidity,
  10800 CO2), source lists, outlier limit, thresholds, comfort bands, and
  safety gates.
- Converts the deferred freshness `xfail` from PR #123 into a passing
  regression and adds `tests/test_truth_freshness_report_time.py`.

## Why `last_reported` (not `last_updated`)

`last_updated` only advances when state **or attributes** change, so it carries
the same false-stale bug for a stable sensor reporting an unchanged value.
`last_reported` advances on every report, which is the correct meaning of
"still reporting."

## Safety

- No `automations.yaml` runtime supervisor change (empty diff). Its three
  `climate.*.last_changed` uses are state-duration (how long a unit has held a
  mode) — value-transition measurement, not reporting freshness — and are
  intentionally left untouched.
- No Section 3 safety-gate change (60°F LR runaway / 58°F Master floor intact).
- No comfort-profile implementation.
- No Apollo/MSR/ESP promotion into control.
- No telemetry schema change. No helper change.

## Tests

- Converted the PR #123 xfail (`test_live_truth_templates_use_report_time_freshness`)
  into a passing assertion; replaced the "currently uses last_changed" test
  with a guard that the freshness clock is no longer `last_changed`.
- Added `tests/test_truth_freshness_report_time.py`: every freshness call uses
  `last_reported`, none use `last_changed`, CO2 3h + temperature 2h windows
  preserved, `automations.yaml` not migrated, safety floors and representative
  weights unchanged.
- `docs/5_runtime_layer.md` §7.9 and `truth_sensor_architecture.md` updated to
  record the landed migration.

Full suite: **89 passed** (0 xfail remaining).

## Deployment verification

The tests in this repo confirm the source-text migration and regression contract,
but they do not execute the Jinja templates against a live Home Assistant state
machine. Because this deployment is on HA 2024.8+ where last_reported is available
on template state objects, first deploy should include a quick Developer Tools →
Template check confirming a truth sensor remains available when the room
temperature is stable.

---

This is the runtime follow-up to PR #122 (planning) and PR #123 (doctrine +
guardrails). It implements only the freshness-clock correction; comfort-profile
runtime and live `_confidence`/`_status` sensors remain deferred.

https://claude.ai/code/session_011A38qJMfvY5dMZNz7hQB7D

---
_Generated by [Claude Code](https://claude.ai/code/session_011A38qJMfvY5dMZNz7hQB7D)_