### PR TITLE
Use Samsung saturation setpoints for existing HVAC commands

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -391,7 +391,7 @@
             # ---------------------------------------------------------
             - variables:
                 is_master_sleep: "{{ now().hour >= 18 or now().hour < 6 }}"
-                m_setpoint: "{{ 74 if away else (61 if is_master_sleep else 66) }}"
+                m_setpoint: "{{ 61 }}"
                 m_off_at: "{{ 74 if away else (62 if is_master_sleep else 68) }}"
                 m_on_at: "{{ 76 if away else (66 if is_master_sleep else 72) }}"
                 m_current: "{{ states('climate.master_bedroom_air') }}"
@@ -411,7 +411,7 @@
             # Away:      74°F set / off ≤74 / on >76
             # ---------------------------------------------------------
             - variables:
-                l_setpoint: "{{ 74 if away else 66 }}"
+                l_setpoint: "{{ 61 }}"
                 l_off_at: "{{ 74 if away else 68 }}"
                 l_on_at: "{{ 76 if away else 72 }}"
                 l_current: "{{ states('climate.lincoln_air') }}"
@@ -431,7 +431,7 @@
             # Away:      74°F set / off ≤74 / on >76
             # ---------------------------------------------------------
             - variables:
-                ly_setpoint: "{{ 74 if away else 66 }}"
+                ly_setpoint: "{{ 61 }}"
                 ly_off_at: "{{ 74 if away else 68 }}"
                 ly_on_at: "{{ 76 if away else 72 }}"
                 ly_current: "{{ states('climate.lilly_air') }}"
@@ -452,7 +452,7 @@
             # Runaway cutoff at 60°F lives in Section 3 (independent).
             # ---------------------------------------------------------
             - variables:
-                lr_setpoint: "{{ 74 if away else 66 }}"
+                lr_setpoint: "{{ 61 }}"
                 lr_off_at: "{{ 74 if away else 68 }}"
                 lr_on_at: "{{ 76 if away else 72 }}"
                 lr_current: "{{ states('climate.living_room_air') }}"
@@ -482,7 +482,7 @@
                       target: { entity_id: climate.living_room_air }
                       data:
                         hvac_mode: "{{ 'heat' if lr_temp < (58 if away else 65) else 'off' }}"
-                        temperature: "{{ 58 if away else 65 }}"
+                        temperature: 79
                     # ---------------------------------------------------------
                     # Shoulder-night Master cooling escape (sleep comfort).
                     # Outdoor temp may influence preferred climate strategy,
@@ -494,7 +494,7 @@
                     - variables:
                         m_sleep_on_at: "{{ 76 if away else 66 }}"
                         m_sleep_off_at: "{{ 74 if away else 62 }}"
-                        m_sleep_setpoint: "{{ 74 if away else 61 }}"
+                        m_sleep_setpoint: "{{ 61 }}"
                         m_current: "{{ states('climate.master_bedroom_air') }}"
                     - action: climate.set_temperature
                       target: { entity_id: climate.master_bedroom_air }
@@ -516,13 +516,13 @@
                       sequence:
                         - action: climate.set_temperature
                           target: { entity_id: climate.master_bedroom_air }
-                          data: { hvac_mode: "{{ 'cool' if master_temp > 70 else 'off' }}", temperature: 70 }
+                          data: { hvac_mode: "{{ 'cool' if master_temp > 70 else 'off' }}", temperature: 61 }
                         - action: climate.set_temperature
                           target: { entity_id: climate.lincoln_air }
-                          data: { hvac_mode: "{{ 'cool' if lincoln_temp > 70 else 'off' }}", temperature: 70 }
+                          data: { hvac_mode: "{{ 'cool' if lincoln_temp > 70 else 'off' }}", temperature: 61 }
                         - action: climate.set_temperature
                           target: { entity_id: climate.lilly_air }
-                          data: { hvac_mode: "{{ 'cool' if lilly_temp > 70 else 'off' }}", temperature: 70 }
+                          data: { hvac_mode: "{{ 'cool' if lilly_temp > 70 else 'off' }}", temperature: 61 }
                         - action: climate.set_hvac_mode
                           target: { entity_id: [climate.living_room_air, climate.dining_room] }
                           data: { hvac_mode: "off" }
@@ -537,6 +537,7 @@
                             lr_on_at: >-
                               {% if is_bedtime and not away %}62{% elif away %}{{ 58 }}{% else %}64{% endif %}
                             lr_off_at: "{{ target_lr }}"
+                            lr_heat_command_setpoint: 79
                             lr_current: "{{ states('climate.living_room_air') }}"
                         - action: climate.set_temperature
                           target: { entity_id: climate.living_room_air }
@@ -546,7 +547,7 @@
                               {% elif lr_temp >= (lr_off_at | int) %}off
                               {% elif lr_current == 'heat' %}heat
                               {% else %}off{% endif %}
-                            temperature: "{{ target_lr }}"
+                            temperature: "{{ lr_heat_command_setpoint }}"
                         - action: climate.set_hvac_mode
                           target: { entity_id: [climate.master_bedroom_air, climate.lincoln_air, climate.lilly_air, climate.dining_room] }
                           data: { hvac_mode: "off" }
@@ -576,16 +577,16 @@
                               target: { entity_id: climate.living_room_air }
                               data:
                                 hvac_mode: "{{ 'heat' if lr_temp < (65 if away else 71) else 'off' }}"
-                                temperature: "{{ 65 if away else 71 }}"
+                                temperature: 79
                             - action: climate.set_temperature
                               target: { entity_id: climate.master_bedroom_air }
-                              data: { hvac_mode: "{{ 'heat' if master_temp < 62 else 'off' }}", temperature: 62 }
+                              data: { hvac_mode: "{{ 'heat' if master_temp < 62 else 'off' }}", temperature: 79 }
                             - action: climate.set_temperature
                               target: { entity_id: climate.lincoln_air }
-                              data: { hvac_mode: "{{ 'heat' if lincoln_temp < 62 else 'off' }}", temperature: 62 }
+                              data: { hvac_mode: "{{ 'heat' if lincoln_temp < 62 else 'off' }}", temperature: 79 }
                             - action: climate.set_temperature
                               target: { entity_id: climate.lilly_air }
-                              data: { hvac_mode: "{{ 'heat' if lilly_temp < 62 else 'off' }}", temperature: 62 }
+                              data: { hvac_mode: "{{ 'heat' if lilly_temp < 62 else 'off' }}", temperature: 79 }
                             - action: climate.set_hvac_mode
                               target: { entity_id: climate.dining_room }
                               data: { hvac_mode: "{{ 'heat' if lr_temp < 68 else 'off' }}" }
@@ -602,23 +603,23 @@
                                   target: { entity_id: climate.living_room_air }
                                   data:
                                     hvac_mode: "{{ 'heat' if lr_temp < (58 if away else 65) else 'off' }}"
-                                    temperature: "{{ 58 if away else 65 }}"
+                                    temperature: 79
                                 - action: climate.set_hvac_mode
                                   target: { entity_id: [climate.master_bedroom_air, climate.lincoln_air, climate.lilly_air, climate.dining_room] }
                                   data: { hvac_mode: "off" }
                           default:
                             - action: climate.set_temperature
                               target: { entity_id: climate.master_bedroom_air }
-                              data: { hvac_mode: "{{ 'heat' if master_temp < 67 else 'off' }}", temperature: 67 }
+                              data: { hvac_mode: "{{ 'heat' if master_temp < 67 else 'off' }}", temperature: 79 }
                             - action: climate.set_temperature
                               target: { entity_id: climate.lincoln_air }
-                              data: { hvac_mode: "{{ 'heat' if lincoln_temp < 67 else 'off' }}", temperature: 67 }
+                              data: { hvac_mode: "{{ 'heat' if lincoln_temp < 67 else 'off' }}", temperature: 79 }
                             - action: climate.set_temperature
                               target: { entity_id: climate.lilly_air }
-                              data: { hvac_mode: "{{ 'heat' if lilly_temp < 67 else 'off' }}", temperature: 67 }
+                              data: { hvac_mode: "{{ 'heat' if lilly_temp < 67 else 'off' }}", temperature: 79 }
                             - action: climate.set_temperature
                               target: { entity_id: climate.living_room_air }
-                              data: { hvac_mode: "{{ 'heat' if lr_temp < 60 else 'off' }}", temperature: 60 }
+                              data: { hvac_mode: "{{ 'heat' if lr_temp < 60 else 'off' }}", temperature: 79 }
                             - action: climate.set_hvac_mode
                               target: { entity_id: climate.dining_room }
                               data: { hvac_mode: "off" }
@@ -630,6 +631,7 @@
                     lr_on_at: >-
                       {% if is_bedtime and not away %}62{% elif away %}{{ 61 if outdoor < 45 else 58 }}{% else %}{{ 67 if outdoor < 45 else 64 }}{% endif %}
                     lr_off_at: "{{ target_lr }}"
+                    lr_heat_command_setpoint: 79
                     lr_current: "{{ states('climate.living_room_air') }}"
                 - action: climate.set_temperature
                   target: { entity_id: climate.living_room_air }
@@ -639,7 +641,7 @@
                       {% elif lr_temp >= (lr_off_at | int) %}off
                       {% elif lr_current == 'heat' %}heat
                       {% else %}off{% endif %}
-                    temperature: "{{ target_lr }}"
+                    temperature: "{{ lr_heat_command_setpoint }}"
                 - action: climate.set_hvac_mode
                   target: { entity_id: [climate.master_bedroom_air, climate.lincoln_air, climate.lilly_air, climate.dining_room] }
                   data: { hvac_mode: "off" }

--- a/docs/5_runtime_layer.md
+++ b/docs/5_runtime_layer.md
@@ -259,6 +259,14 @@ actuator demand, not comfort truth — it already is in the live supervisor
 (`automations.yaml` Section 2 comments), and the planned model keeps it that
 way. Samsung's preferred 72–75°F is not comfort truth for this house.
 
+**Runtime shove command scope.** Section 2 now uses Samsung saturation command
+setpoints on existing mini-split command paths only: cooling commands shove to
+61°F and heating commands shove to 79°F. The room is not intended to reach those
+values; the existing Moose House room-truth start/stop thresholds still decide
+when to run and when to shut down. Runtime house-wide arbitration,
+destratification changes, comfort profiles, watchdog changes, and live truth
+confidence/status sensors remain deferred.
+
 **Comfort bands are preferences; safety gates are physical protection.** Comfort
 bands are tunable household preference. Section 3 safety gates (LR runaway
 60°F, Master emergency floor 58°F) are absolute equipment protection and stay

--- a/tests/test_section2_cooling_setpoint_doctrine.py
+++ b/tests/test_section2_cooling_setpoint_doctrine.py
@@ -76,10 +76,10 @@ def _extract_cooling_variable_templates(actions):
 def test_section2_cooling_setpoint_and_threshold_doctrine():
     templates = _extract_cooling_variable_templates(_load_main_supervisor_actions())
 
-    assert templates['m_setpoint'] == "{{ 74 if away else (61 if is_master_sleep else 66) }}"
-    assert templates['l_setpoint'] == "{{ 74 if away else 66 }}"
-    assert templates['ly_setpoint'] == "{{ 74 if away else 66 }}"
-    assert templates['lr_setpoint'] == "{{ 74 if away else 66 }}"
+    assert templates['m_setpoint'] == "{{ 61 }}"
+    assert templates['l_setpoint'] == "{{ 61 }}"
+    assert templates['ly_setpoint'] == "{{ 61 }}"
+    assert templates['lr_setpoint'] == "{{ 61 }}"
 
     assert templates['m_off_at'] == "{{ 74 if away else (62 if is_master_sleep else 68) }}"
     assert templates['m_on_at'] == "{{ 76 if away else (66 if is_master_sleep else 72) }}"

--- a/tests/test_section2_shove_command_setpoints.py
+++ b/tests/test_section2_shove_command_setpoints.py
@@ -1,0 +1,236 @@
+"""
+Section 2 Samsung actuator shove command regression guards.
+
+This PR changes only actuator command setpoints in the existing supervisor:
+Samsung cooling commands shove to 61°F and Samsung heating commands shove to
+79°F. Room-truth comparisons, on/off thresholds, safety gates, arbitration,
+comfort profiles, MSR/Apollo boundaries, and truth freshness are deliberately
+out of scope.
+"""
+
+import os
+import re
+
+import yaml
+
+
+class MooseAutomationLoader(yaml.SafeLoader):
+    pass
+
+
+def _secret(loader, node):
+    return f"SECRET_{node.value}"
+
+
+def _include(loader, node):
+    return f"INCLUDE_{node.value}"
+
+
+def _input(loader, node):
+    return f"INPUT_{node.value}"
+
+
+def _include_dir_merge_list(loader, node):
+    return []
+
+
+MooseAutomationLoader.add_constructor("!secret", _secret)
+MooseAutomationLoader.add_constructor("!include", _include)
+MooseAutomationLoader.add_constructor("!input", _input)
+MooseAutomationLoader.add_constructor("!include_dir_merge_list", _include_dir_merge_list)
+MooseAutomationLoader.add_constructor("!include_dir_named", _include_dir_merge_list)
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+AUTOMATIONS = os.path.join(REPO_ROOT, "automations.yaml")
+CONFIGURATION = os.path.join(REPO_ROOT, "configuration.yaml")
+SUPERVISOR_ID = "v7_5_main_supervisor"
+MINI_SPLITS = {
+    "climate.living_room_air",
+    "climate.master_bedroom_air",
+    "climate.lincoln_air",
+    "climate.lilly_air",
+}
+
+
+def _read(path):
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _load_automations():
+    with open(AUTOMATIONS, "r", encoding="utf-8") as fh:
+        return yaml.load(fh, Loader=MooseAutomationLoader)
+
+
+def _supervisor():
+    supervisor = next(
+        (a for a in _load_automations() if a.get("id") == SUPERVISOR_ID),
+        None,
+    )
+    assert supervisor is not None, f"{SUPERVISOR_ID} not found"
+    return supervisor
+
+
+def _walk(obj):
+    if isinstance(obj, dict):
+        yield obj
+        for value in obj.values():
+            yield from _walk(value)
+    elif isinstance(obj, list):
+        for value in obj:
+            yield from _walk(value)
+
+
+def _section2_text():
+    text = _read(AUTOMATIONS)
+    return text.split("# SECTION 2: MAIN SUPERVISOR", 1)[1].split(
+        "# SECTION 3: SAFETY GATES", 1
+    )[0]
+
+
+def _variable_values(supervisor):
+    values = {}
+    for node in _walk(supervisor):
+        variables = node.get("variables")
+        if isinstance(variables, dict):
+            for name, value in variables.items():
+                values.setdefault(name, set()).add(value)
+    return values
+
+
+def _temperature_value(command, variables):
+    raw = command.get("data", {}).get("temperature")
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, str):
+        direct = re.fullmatch(r"\{\{\s*(\d+)\s*\}\}", raw)
+        if direct:
+            return int(direct.group(1))
+        var = re.fullmatch(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}", raw)
+        if var:
+            name = var.group(1)
+            assert name in variables, f"Command temperature references unknown variable {name!r}"
+            resolved = variables[name]
+            assert len(resolved) == 1, f"Variable {name!r} has ambiguous command values: {resolved!r}"
+            value = next(iter(resolved))
+            if isinstance(value, int):
+                return value
+            if isinstance(value, str):
+                direct_var = re.fullmatch(r"\{\{\s*(\d+)\s*\}\}", value)
+                if direct_var:
+                    return int(direct_var.group(1))
+            raise AssertionError(f"Variable {name!r} does not resolve to a shove setpoint: {value!r}")
+    raise AssertionError(f"Unsupported command temperature payload: {raw!r}")
+
+
+def _section2_set_temperature_commands():
+    supervisor = _supervisor()
+    commands = []
+    for node in _walk(supervisor):
+        if (node.get("action") or node.get("service")) == "climate.set_temperature":
+            commands.append(node)
+    return commands, _variable_values(supervisor)
+
+
+def test_section2_cooling_actuator_commands_use_61_separate_from_thresholds():
+    commands, variables = _section2_set_temperature_commands()
+    cooling_commands = []
+    for command in commands:
+        entity = command.get("target", {}).get("entity_id")
+        hvac_template = str(command.get("data", {}).get("hvac_mode", ""))
+        if entity in MINI_SPLITS and "cool" in hvac_template and "heat" not in hvac_template:
+            cooling_commands.append(command)
+            assert _temperature_value(command, variables) == 61
+
+    assert len(cooling_commands) == 8, "Expected the existing eight mini-split cooling command paths."
+
+    text = _section2_text()
+    # Cooling comparisons / stop thresholds remain exactly as before; command
+    # payloads are tested separately above.
+    assert "m_off_at: \"{{ 74 if away else (62 if is_master_sleep else 68) }}\"" in text
+    assert "m_on_at: \"{{ 76 if away else (66 if is_master_sleep else 72) }}\"" in text
+    assert "l_off_at: \"{{ 74 if away else 68 }}\"" in text
+    assert "l_on_at: \"{{ 76 if away else 72 }}\"" in text
+    assert "ly_off_at: \"{{ 74 if away else 68 }}\"" in text
+    assert "ly_on_at: \"{{ 76 if away else 72 }}\"" in text
+    assert "lr_off_at: \"{{ 74 if away else 68 }}\"" in text
+    assert "lr_on_at: \"{{ 76 if away else 72 }}\"" in text
+    assert "m_sleep_on_at: \"{{ 76 if away else 66 }}\"" in text
+    assert "m_sleep_off_at: \"{{ 74 if away else 62 }}\"" in text
+    assert "master_temp > 70" in text
+    assert "lincoln_temp > 70" in text
+    assert "lilly_temp > 70" in text
+
+
+def test_section2_heating_actuator_commands_use_79_separate_from_thresholds():
+    commands, variables = _section2_set_temperature_commands()
+    heating_commands = []
+    for command in commands:
+        entity = command.get("target", {}).get("entity_id")
+        hvac_template = str(command.get("data", {}).get("hvac_mode", ""))
+        if entity in MINI_SPLITS and "heat" in hvac_template and "cool" not in hvac_template:
+            heating_commands.append(command)
+            assert _temperature_value(command, variables) == 79
+
+    assert len(heating_commands) == 12, "Expected the existing twelve mini-split heating command paths."
+
+    text = _section2_text()
+    # Heating thresholds remain exactly where they were; target_lr remains an
+    # off threshold, not an actuator command temperature.
+    for threshold in (
+        "lr_temp < (58 if away else 65)",
+        "lr_temp < (65 if away else 71)",
+        "master_temp < 62",
+        "lincoln_temp < 62",
+        "lilly_temp < 62",
+        "master_temp < 67",
+        "lincoln_temp < 67",
+        "lilly_temp < 67",
+        "lr_temp < 60",
+        "lr_temp < (lr_on_at | int)",
+        "lr_temp >= (lr_off_at | int)",
+    ):
+        assert threshold in text
+
+    assert text.count('lr_off_at: "{{ target_lr }}"') == 2
+    assert 'temperature: "{{ target_lr }}"' not in text
+    assert text.count("lr_heat_command_setpoint: 79") == 2
+
+
+def test_section2_dining_room_nest_setpoint_not_promoted_to_samsung_shove():
+    commands, _variables = _section2_set_temperature_commands()
+    dining_commands = [
+        command
+        for command in commands
+        if command.get("target", {}).get("entity_id") == "climate.dining_room"
+    ]
+    assert len(dining_commands) == 1
+    assert dining_commands[0].get("data", {}).get("temperature") == 68
+
+
+def test_section3_safety_floors_remain_unchanged_by_shove_commands():
+    text = _read(AUTOMATIONS)
+    assert "below: 60" in text, "Living Room runaway cooling cutoff must remain 60°F."
+    assert "below: 58" in text, "Master emergency floor must remain 58°F."
+
+
+def test_shove_pr_does_not_introduce_arbitration_or_comfort_profiles():
+    runtime_text = _read(AUTOMATIONS) + "\n" + _read(CONFIGURATION)
+    lowered = runtime_text.lower()
+    assert "opposite_mode_lockout" not in lowered
+    assert "moose_house_arbitration_state" not in lowered
+    assert "comfort_profile" not in lowered
+    assert "input_select.moose_comfort" not in lowered
+
+
+def test_shove_pr_does_not_promote_msr_or_apollo_into_supervisor_control():
+    supervisor_text = str(_supervisor()).lower()
+    for forbidden in ("msr", "apollo", "dps310", "mmwave", "ld2410", "scd40", "radar_zone", "co2"):
+        assert forbidden not in supervisor_text
+
+
+def test_truth_freshness_still_uses_report_time_not_last_changed():
+    config_text = _read(CONFIGURATION)
+    assert ".last_reported).total_seconds()" in config_text
+    assert ".last_changed).total_seconds()" not in config_text

--- a/tests/test_supervisor_shoulder_night.py
+++ b/tests/test_supervisor_shoulder_night.py
@@ -155,9 +155,10 @@ def test_shoulder_night_lr_heating_preserved(supervisor):
         "Shoulder-night LR heat/off decision must still gate on "
         "lr_temp < (58 if away else 65)."
     )
-    assert (
-        data.get("temperature") == "{{ 58 if away else 65 }}"
-    ), "Shoulder-night LR commanded temperature must still be 58/65."
+    assert data.get("temperature") == 79, (
+        "Shoulder-night LR heat command must shove to 79 while the 58/65 "
+        "truth threshold remains in hvac_mode."
+    )
 
 
 def test_shoulder_night_master_setpoint_below_off_threshold(supervisor):
@@ -182,6 +183,7 @@ def test_shoulder_night_master_setpoint_below_off_threshold(supervisor):
     assert (
         "if away else 62" in off_at
     ), f"m_sleep_off_at template unexpected: {off_at!r}"
-    assert (
-        "if away else 61" in setpoint
-    ), f"m_sleep_setpoint template unexpected: {setpoint!r}"
+    assert setpoint == "{{ 61 }}", (
+        "Shoulder-night Master cooling command must shove to 61 while the "
+        "sleep on/off thresholds remain unchanged."
+    )


### PR DESCRIPTION
### Motivation

- Reduce Samsung mini-split low-demand modulation by making actuator commands decisive: cooling shove to 61°F and heating shove to 79°F while keeping Moose House comfort bands and safety logic authoritative. 
- Preserve all start/stop decisions, comparisons, bands, safety gates, MSR boundaries, telemetry, and truth-freshness behavior exactly as runtime doctrine requires.

### Description

- Replaced only actuator command setpoint values in Section 2 `v7_5_main_supervisor` where `climate.set_temperature` sends temperatures to mini-splits so that cooling commands resolve to `61` and heating commands resolve to `79` while leaving all comparison/on/off thresholds unchanged. (Changed eligible mini-split command payloads only; Dining/Nest path left at `68`.)
- Split shared `target_lr` usage where needed so `target_lr` remains the stop/threshold variable and a new `lr_heat_command_setpoint` variable supplies the 79°F actuator command for LR heating branches.
- Updated runtime docs to record that this PR implements shove-command changes only and defers arbitration, destratification, comfort profiles, and other architectural work to later PRs (`docs/5_runtime_layer.md`).
- Tests updated/added: adjusted `tests/test_section2_cooling_setpoint_doctrine.py` to reflect new command-values-as-variables where applicable, updated `tests/test_supervisor_shoulder_night.py` to assert shove semantics in shoulder-night paths, and added `tests/test_section2_shove_command_setpoints.py` to validate: cooling commands == 61°F, heating commands == 79°F, all thresholds unchanged, safety floors unchanged, no MSR promotion, no comfort-profile/arbitration runtime introduced, and truth freshness remains `last_reported`.
- Files changed: `automations.yaml` (Section 2 changes), `docs/5_runtime_layer.md` (note), `tests/test_section2_cooling_setpoint_doctrine.py`, `tests/test_supervisor_shoulder_night.py`, and new `tests/test_section2_shove_command_setpoints.py`.
- Classification work: a full review enumerated every Section 2 `climate.set_temperature` command and confirmed eligibility before editing; only actuator command values were replaced.

### Testing

- Ran full test suite: `pytest -q` — all tests passed after the incremental edits (final result: 96 passed).
- Ran focused regression set verifying the PR intents: `pytest -q tests/test_safety_invariants.py tests/test_section2_cooling_setpoint_doctrine.py tests/test_msr_observability_boundary.py tests/test_truth_freshness_report_time.py tests/test_section2_shove_command_setpoints.py` — all passed (27 tests).
- Ran the new shove-command test module alone: `pytest -q tests/test_section2_shove_command_setpoints.py` — passed (7 tests).

Additional verification recorded before commit:
- `automations.yaml` changed: yes.
- `configuration.yaml` changed: no.
- Exact count of mini-split command temperature fields changed (resolved): 20.
- Exact count of comparison/stop-threshold patterns changed: 0.

This PR is narrowly scoped to actuator-shove commands only and preserves safety, thresholds, telemetry, MSR boundaries, and the supervisor decision logic exactly as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eda99daf88323b30b6556341a11a4)