### PR TITLE
Sync truth-source transports: add Master/Lilly Matter, remove LR secondary

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,6 +1,6 @@
 # =============================================================================
 # MOOSE HOUSE CLIMATE — COMPLETE CONFIGURATION.YAML
-# Last Updated: May 6, 2026
+# Last Updated: June 5, 2026
 # Architecture: V3.1 — Audited Truth / Smoothed / Control
 # =============================================================================
 #
@@ -85,11 +85,13 @@
 #   - sensor.lilly_temp_temperature_2           (Lilly,  Matter, w=1.0)
 #   - sensor.lilly_temp_humidity_2              (Lilly,  Matter, w=1.0)
 #
-# REMOVED — disabled/no-state Living Room secondary SwitchBot Hub 2
-#           transport (telemetry col LR_Temp/Hum_RoomProbe_BT_Secondary);
-#           still logged for observability, no longer in truth:
-#   - sensor.hub_2_tempsensor_temperature       (LR temp)
-#   - sensor.hub_2_humisensor_humidity          (LR humidity)
+# REMOVED — Living Room Matter route (per the live HA entity registry),
+#           disabled_by:user with no live state, excluded from truth. It is
+#           historically logged under telemetry cols
+#           LR_Temp/Hum_RoomProbe_BT_Secondary — a historical export label that
+#           does NOT make this a Bluetooth route. Telemetry cols are preserved:
+#   - sensor.hub_2_tempsensor_temperature       (LR temp, Matter, disabled)
+#   - sensor.hub_2_humisensor_humidity          (LR humidity, Matter, disabled)
 #
 # CONTRIBUTOR COUNTS AFTER SYNC (verified live 2026-06-05):
 #   Living Room 3 · Master 4 · Lincoln 4 (unchanged) · Lilly 4
@@ -213,7 +215,7 @@ template:
       #     gates (meatlocker/overcool), and the smoothed control sensor.
       #     Without this, the supervisor loses its primary first-floor input.
       #
-      # ACTIVE SENSORS (V3.1; secondary route pulled 2026-06-05 live-sync):
+      # ACTIVE SENSORS (V3.1; disabled Matter route pulled 2026-06-05 live-sync):
       #   hub_temperature          (SwitchBot Hub 2 — BT)        w=1.0   [BT]
       #   hub_temperature_2        (SwitchBot Hub 2 — ST)        w=0.9   [ST]
       #   living_room_air_temperature  (Samsung internal, -10°F) w=0.20
@@ -221,17 +223,20 @@ template:
       #
       # TRANSPORT NOTE: hub_temperature [BT] and hub_temperature_2 [ST] are
       #   alternate transports of the SAME physical SwitchBot room probe, not
-      #   independent thermometers (telemetry cols LR_Temp_RoomProbe_BT_Primary /
-      #   _ST). Samsung internal is separate hardware (low weight, biased).
-      #   Full inventory: docs/2_reference_map.md §7. (Older comments labeled
-      #   hub_temperature_2 "WonderLabs Hub"; the telemetry ST label is canonical.)
+      #   independent thermometers. The room probe's Matter transport is the
+      #   disabled route listed under REMOVED below. Samsung internal is separate
+      #   hardware (low weight, biased). Full inventory: docs/2_reference_map.md §7.
+      #   AUTHORITY: live HA registry/platform metadata defines transport identity;
+      #   automations.yaml telemetry column names are historical/export labels.
       #
       # REMOVED:
-      #   hub_2_tempsensor_temperature — disabled/no-state secondary SwitchBot
-      #     Hub 2 transport (telemetry col LR_Temp_RoomProbe_BT_Secondary);
-      #     pulled from truth + active-count in the 2026-06-05 live-sync. The
-      #     telemetry column still logs it (observability only).
-      #   hub_2_humisensor_humidity   — humidity counterpart of the above; pulled.
+      #   hub_2_tempsensor_temperature — Living Room MATTER route per the live HA
+      #     entity registry; disabled_by:user, has no live state, excluded from
+      #     truth + active-count (pulled in the 2026-06-05 live-sync). Historically
+      #     logged under telemetry column LR_Temp_RoomProbe_BT_Secondary — a
+      #     historical label that does NOT make this a Bluetooth route.
+      #   hub_2_humisensor_humidity   — humidity counterpart; same disabled Matter
+      #     route, no live state (telemetry col LR_Hum_RoomProbe_BT_Secondary).
       #   living_room_temperature_temperature — phantom, never existed (V3.1)
       #   living_room_msr_dps310_temperature  — hardware failure (V3.1)
       # =========================================================

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -41,6 +41,7 @@
 #   V6.1:     LR delay_off tuned 3min → 20min; Lincoln 3min → 15min
 #   V3.1:     Full audit against HA device registry + telemetry (see below)
 #   STEP 2:   Surgical trim of legacy/fallback sensors from weighted truth
+#   SYNC-0605: Repo ↔ live truth-source sync (2026-06-05, see below)
 #
 # =====================================================================
 # V3.1 AUDIT CHANGES (April 6, 2026)
@@ -66,6 +67,38 @@
 #   - sensor.lincoln_temp_temperature              (Outdoor Meter 18, w=1.0)
 #   - sensor.laundry_temperature                   (WoTHP, w=1.0)
 #   + all corresponding humidity entities
+# =====================================================================
+#
+# =====================================================================
+# LIVE-SYNC CHANGES (June 5, 2026) — durability/sync only
+# =====================================================================
+# Purpose: make already-verified LIVE truth-source edits durable in the
+#   repo. Entity-source changes ONLY. No weighting redesign, no change to
+#   the statistical truth model. New Matter routes use w=1.0, matching the
+#   existing Matter-route precedent (Lincoln lincoln_temp_temperature, w=1.0)
+#   and the sibling BT room-probe weight.
+#
+# ADDED — Matter transport copies already reporting live (telemetry
+#         columns *_RoomProbe_Matter), now restored to weighted truth:
+#   - sensor.master_bedroom_temp_temperature_3  (Master, Matter, w=1.0)
+#   - sensor.master_bedroom_temp_humidity_3     (Master, Matter, w=1.0)
+#   - sensor.lilly_temp_temperature_2           (Lilly,  Matter, w=1.0)
+#   - sensor.lilly_temp_humidity_2              (Lilly,  Matter, w=1.0)
+#
+# REMOVED — disabled/no-state Living Room secondary SwitchBot Hub 2
+#           transport (telemetry col LR_Temp/Hum_RoomProbe_BT_Secondary);
+#           still logged for observability, no longer in truth:
+#   - sensor.hub_2_tempsensor_temperature       (LR temp)
+#   - sensor.hub_2_humisensor_humidity          (LR humidity)
+#
+# CONTRIBUTOR COUNTS AFTER SYNC (verified live 2026-06-05):
+#   Living Room 3 · Master 4 · Lincoln 4 (unchanged) · Lilly 4
+#
+# TRANSPORT MODEL: BT / SmartThings(ST) / Matter rows for a room are
+#   alternate transports of ONE physical SwitchBot probe, not independent
+#   thermometers. Truth currently averages all available transports. Whether
+#   it should instead pick the single best transport per physical probe is a
+#   DEFERRED design question — not addressed here. See docs/2_reference_map.md §7.
 # =====================================================================
 
 
@@ -180,15 +213,27 @@ template:
       #     gates (meatlocker/overcool), and the smoothed control sensor.
       #     Without this, the supervisor loses its primary first-floor input.
       #
-      # ACTIVE SENSORS (V3.1):
-      #   hub_temperature          (SwitchBot Hub 2, Hue room)   w=1.0
-      #   hub_temperature_2        (WonderLabs Hub)              w=0.9
-      #   hub_2_tempsensor_temperature (SwitchBot Hub 2)         w=1.0
+      # ACTIVE SENSORS (V3.1; secondary route pulled 2026-06-05 live-sync):
+      #   hub_temperature          (SwitchBot Hub 2 — BT)        w=1.0   [BT]
+      #   hub_temperature_2        (SwitchBot Hub 2 — ST)        w=0.9   [ST]
       #   living_room_air_temperature  (Samsung internal, -10°F) w=0.20
+      #   → 3 active temperature contributors (verified live 2026-06-05)
       #
-      # REMOVED (V3.1):
-      #   living_room_temperature_temperature — phantom, never existed
-      #   living_room_msr_dps310_temperature  — hardware failure
+      # TRANSPORT NOTE: hub_temperature [BT] and hub_temperature_2 [ST] are
+      #   alternate transports of the SAME physical SwitchBot room probe, not
+      #   independent thermometers (telemetry cols LR_Temp_RoomProbe_BT_Primary /
+      #   _ST). Samsung internal is separate hardware (low weight, biased).
+      #   Full inventory: docs/2_reference_map.md §7. (Older comments labeled
+      #   hub_temperature_2 "WonderLabs Hub"; the telemetry ST label is canonical.)
+      #
+      # REMOVED:
+      #   hub_2_tempsensor_temperature — disabled/no-state secondary SwitchBot
+      #     Hub 2 transport (telemetry col LR_Temp_RoomProbe_BT_Secondary);
+      #     pulled from truth + active-count in the 2026-06-05 live-sync. The
+      #     telemetry column still logs it (observability only).
+      #   hub_2_humisensor_humidity   — humidity counterpart of the above; pulled.
+      #   living_room_temperature_temperature — phantom, never existed (V3.1)
+      #   living_room_msr_dps310_temperature  — hardware failure (V3.1)
       # =========================================================
       - name: "Living Room Temperature Truth"
         unique_id: living_room_temperature_truth_v3
@@ -202,8 +247,6 @@ template:
           {% if hub is not none and (now() - states.sensor.hub_temperature.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {% set hub2_legacy = states('sensor.hub_temperature_2') | float(none) %}
           {% if hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
-          {% set hub2 = states('sensor.hub_2_tempsensor_temperature') | float(none) %}
-          {% if hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {% set hp = states('sensor.living_room_air_temperature') | float(none) %}
           {% if hp is not none and (now() - states.sensor.living_room_air_temperature.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {{ fresh.count > 0 }}
@@ -213,14 +256,11 @@ template:
           {% set hub_ok = hub is not none and (now() - states.sensor.hub_temperature.last_reported).total_seconds() < max_age %}
           {% set hub2_legacy = states('sensor.hub_temperature_2') | float(none) %}
           {% set hub2_legacy_ok = hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_reported).total_seconds() < max_age %}
-          {% set hub2 = states('sensor.hub_2_tempsensor_temperature') | float(none) %}
-          {% set hub2_ok = hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_reported).total_seconds() < max_age %}
           {% set hp = states('sensor.living_room_air_temperature') | float(none) %}
           {% set hp_ok = hp is not none and (now() - states.sensor.living_room_air_temperature.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if hub_ok %}{% set ns.total = ns.total + (hub * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if hub2_legacy_ok %}{% set ns.total = ns.total + (hub2_legacy * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
-          {% if hub2_ok %}{% set ns.total = ns.total + (hub2 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if hp_ok %}{% set ns.total = ns.total + (hp * 0.20) %}{% set ns.weight = ns.weight + 0.20 %}{% endif %}
           {{ (ns.total / ns.weight) | round(2) }}
 
@@ -236,8 +276,6 @@ template:
           {% if hub is not none and (now() - states.sensor.hub_humidity.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {% set hub2_legacy = states('sensor.hub_humidity_2') | float(none) %}
           {% if hub2_legacy is not none and (now() - states.sensor.hub_humidity_2.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
-          {% set hub2 = states('sensor.hub_2_humisensor_humidity') | float(none) %}
-          {% if hub2 is not none and (now() - states.sensor.hub_2_humisensor_humidity.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {% set hp = states('sensor.living_room_air_humidity') | float(none) %}
           {% if hp is not none and (now() - states.sensor.living_room_air_humidity.last_reported).total_seconds() < max_age %}{% set fresh.count = fresh.count + 1 %}{% endif %}
           {{ fresh.count > 0 }}
@@ -247,14 +285,11 @@ template:
           {% set hub_ok = hub is not none and (now() - states.sensor.hub_humidity.last_reported).total_seconds() < max_age %}
           {% set hub2_legacy = states('sensor.hub_humidity_2') | float(none) %}
           {% set hub2_legacy_ok = hub2_legacy is not none and (now() - states.sensor.hub_humidity_2.last_reported).total_seconds() < max_age %}
-          {% set hub2 = states('sensor.hub_2_humisensor_humidity') | float(none) %}
-          {% set hub2_ok = hub2 is not none and (now() - states.sensor.hub_2_humisensor_humidity.last_reported).total_seconds() < max_age %}
           {% set hp = states('sensor.living_room_air_humidity') | float(none) %}
           {% set hp_ok = hp is not none and (now() - states.sensor.living_room_air_humidity.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if hub_ok %}{% set ns.total = ns.total + (hub * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if hub2_legacy_ok %}{% set ns.total = ns.total + (hub2_legacy * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
-          {% if hub2_ok %}{% set ns.total = ns.total + (hub2 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if hp_ok %}{% set ns.total = ns.total + (hp * 0.25) %}{% set ns.weight = ns.weight + 0.25 %}{% endif %}
           {{ (ns.total / ns.weight) | round(1) }}
 
@@ -277,8 +312,6 @@ template:
           {% if hub is not none and (now() - states.sensor.hub_temperature.last_reported).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_temperature'] %}{% endif %}
           {% set hub2_legacy = states('sensor.hub_temperature_2') | float(none) %}
           {% if hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_reported).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_temperature_2'] %}{% endif %}
-          {% set hub2 = states('sensor.hub_2_tempsensor_temperature') | float(none) %}
-          {% if hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_reported).total_seconds() < max_age %}{% set parts.items = parts.items + ['hub_2_tempsensor_temperature'] %}{% endif %}
           {% set hp = states('sensor.living_room_air_temperature') | float(none) %}
           {% if hp is not none and (now() - states.sensor.living_room_air_temperature.last_reported).total_seconds() < max_age %}{% set parts.items = parts.items + ['living_room_air_temperature'] %}{% endif %}
           {{ parts.items | join(', ') if parts.items | length > 0 else 'none' }}
@@ -292,8 +325,6 @@ template:
           {% if hub is not none and (now() - states.sensor.hub_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hub2_legacy = states('sensor.hub_temperature_2') | float(none) %}
           {% if hub2_legacy is not none and (now() - states.sensor.hub_temperature_2.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
-          {% set hub2 = states('sensor.hub_2_tempsensor_temperature') | float(none) %}
-          {% if hub2 is not none and (now() - states.sensor.hub_2_tempsensor_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hp = states('sensor.living_room_air_temperature') | float(none) %}
           {% if hp is not none and (now() - states.sensor.living_room_air_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v }}
@@ -305,10 +336,20 @@ template:
       #     and safety ceiling gates. In V8 summer doctrine, Master is
       #     the primary cooling engine / thermal shield.
       #
-      # ACTIVE SENSORS (STEP 2):
-      #   master_bedroom_temp_temperature_2  (I/O Meter 7C3F)   w=1.0
-      #   master_bedroom_temperature_temperature_2 (WonderLabs) w=0.9
+      # ACTIVE SENSORS (STEP 2; Matter route added 2026-06-05 live-sync):
+      #   master_bedroom_temp_temperature_2  (I/O Meter 7C3F)   w=1.0   [BT]
+      #   master_bedroom_temperature_temperature_2 (WonderLabs) w=0.9   [ST]
+      #   master_bedroom_temp_temperature_3  (I/O Meter 7C3F)   w=1.0   [Matter]  ← added 2026-06-05
       #   master_bedroom_air_temperature     (Samsung, +6.9°F)  w=0.20
+      #   → 4 active temperature contributors (verified live 2026-06-05)
+      #
+      # TRANSPORT NOTE: the [BT], [ST], and [Matter] rows are alternate transports
+      #   of the SAME physical Master room probe (telemetry cols
+      #   Master_Temp_RoomProbe_BT / _ST / _Matter), not independent sensors.
+      #   Current truth averages every available transport with its weight; the
+      #   live-sync only restores the Matter copy that was already live. Whether
+      #   truth should instead pick ONE best transport per physical probe is a
+      #   deferred design question — NOT changed here. See docs/2_reference_map.md §7.
       #
       # REMOVED (STEP 2):
       #   master_bedroom_temp_temperature (Outdoor Meter 3F)
@@ -325,6 +366,8 @@ template:
           {% if s1 is not none and (now() - states.sensor.master_bedroom_temp_temperature_2.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s2 = states('sensor.master_bedroom_temperature_temperature_2') | float(none) %}
           {% if s2 is not none and (now() - states.sensor.master_bedroom_temperature_temperature_2.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s3 = states('sensor.master_bedroom_temp_temperature_3') | float(none) %}
+          {% if s3 is not none and (now() - states.sensor.master_bedroom_temp_temperature_3.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hp = states('sensor.master_bedroom_air_temperature') | float(none) %}
           {% if hp is not none and (now() - states.sensor.master_bedroom_air_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
@@ -334,11 +377,15 @@ template:
           {% set s1_ok = s1 is not none and (now() - states.sensor.master_bedroom_temp_temperature_2.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.master_bedroom_temperature_temperature_2') | float(none) %}
           {% set s2_ok = s2 is not none and (now() - states.sensor.master_bedroom_temperature_temperature_2.last_reported).total_seconds() < max_age %}
+          {# Matter transport of the same physical Master room probe (added 2026-06-05 live-sync; telemetry col Master_Temp_RoomProbe_Matter) #}
+          {% set s3 = states('sensor.master_bedroom_temp_temperature_3') | float(none) %}
+          {% set s3_ok = s3 is not none and (now() - states.sensor.master_bedroom_temp_temperature_3.last_reported).total_seconds() < max_age %}
           {% set hp = states('sensor.master_bedroom_air_temperature') | float(none) %}
           {% set hp_ok = hp is not none and (now() - states.sensor.master_bedroom_air_temperature.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
+          {% if s3_ok %}{% set ns.total = ns.total + (s3 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if hp_ok %}{% set ns.total = ns.total + (hp * 0.20) %}{% set ns.weight = ns.weight + 0.20 %}{% endif %}
           {{ (ns.total / ns.weight) | round(2) }}
 
@@ -354,6 +401,8 @@ template:
           {% if s1 is not none and (now() - states.sensor.master_bedroom_temp_humidity_2.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s2 = states('sensor.master_bedroom_temperature_humidity_2') | float(none) %}
           {% if s2 is not none and (now() - states.sensor.master_bedroom_temperature_humidity_2.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s3 = states('sensor.master_bedroom_temp_humidity_3') | float(none) %}
+          {% if s3 is not none and (now() - states.sensor.master_bedroom_temp_humidity_3.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hp = states('sensor.master_bedroom_air_humidity') | float(none) %}
           {% if hp is not none and (now() - states.sensor.master_bedroom_air_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
@@ -363,11 +412,15 @@ template:
           {% set s1_ok = s1 is not none and (now() - states.sensor.master_bedroom_temp_humidity_2.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.master_bedroom_temperature_humidity_2') | float(none) %}
           {% set s2_ok = s2 is not none and (now() - states.sensor.master_bedroom_temperature_humidity_2.last_reported).total_seconds() < max_age %}
+          {# Matter transport of the same physical Master room probe (added 2026-06-05 live-sync; telemetry col Master_Hum_RoomProbe_Matter) #}
+          {% set s3 = states('sensor.master_bedroom_temp_humidity_3') | float(none) %}
+          {% set s3_ok = s3 is not none and (now() - states.sensor.master_bedroom_temp_humidity_3.last_reported).total_seconds() < max_age %}
           {% set hp = states('sensor.master_bedroom_air_humidity') | float(none) %}
           {% set hp_ok = hp is not none and (now() - states.sensor.master_bedroom_air_humidity.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
+          {% if s3_ok %}{% set ns.total = ns.total + (s3 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if hp_ok %}{% set ns.total = ns.total + (hp * 0.25) %}{% set ns.weight = ns.weight + 0.25 %}{% endif %}
           {{ (ns.total / ns.weight) | round(1) }}
 
@@ -561,14 +614,25 @@ template:
       #     safety ceiling gates, and comfort fan. V8 doctrine flags
       #     Lilly as potential drift/insulation risk due to path distance.
       #
-      # ACTIVE SENSORS (STEP 2):
-      #   lilly_temperature                   (Wyze cam sensor)     w=1.0
-      #   lilly_room_temperature_temperature  (WonderLabs)          w=0.9
+      # ACTIVE SENSORS (STEP 2; Matter route added 2026-06-05 live-sync):
+      #   lilly_temperature                   (Wyze cam sensor)     w=1.0   [BT]
+      #   lilly_room_temperature_temperature  (WonderLabs)          w=0.9   [ST]
+      #   lilly_temp_temperature_2            (Outdoor Meter 58)    w=1.0   [Matter]  ← added 2026-06-05
       #   lilly_air_temperature               (Samsung, +8.6°F)     w=0.20
+      #   → 4 active temperature contributors (verified live 2026-06-05)
+      #
+      # TRANSPORT NOTE: the [BT], [ST], and [Matter] rows are alternate transports
+      #   of the SAME physical Lilly room probe (telemetry cols
+      #   Lilly_Temp_RoomProbe_BT / _ST / _Matter), not independent sensors.
+      #   lilly_temp_temperature_2 is the Matter copy of the Outdoor Meter 58 probe
+      #   and is ACTIVE — it was previously (and wrongly) listed below as removed.
+      #   That contradiction is resolved here. Whether truth should pick ONE best
+      #   transport per probe is a deferred design question (see docs/2_reference_map.md §7).
       #
       # REMOVED (STEP 2):
-      #   lilly_temp_temperature (Outdoor Meter 58)
-      #   lilly_temp_temperature_2 (Outdoor Meter 58 fallback)
+      #   lilly_temp_temperature (Outdoor Meter 58) — legacy non-_2 transport of the
+      #     same probe; not wired to telemetry or truth. Superseded by the Matter
+      #     copy (lilly_temp_temperature_2) above. (Do NOT relist _2 as removed.)
       # =========================================================
       - name: "Lilly's Room Temperature Truth"
         unique_id: lilly_s_room_temperature_truth_v3
@@ -582,6 +646,8 @@ template:
           {% if s1 is not none and (now() - states.sensor.lilly_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s2 = states('sensor.lilly_room_temperature_temperature') | float(none) %}
           {% if s2 is not none and (now() - states.sensor.lilly_room_temperature_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s3 = states('sensor.lilly_temp_temperature_2') | float(none) %}
+          {% if s3 is not none and (now() - states.sensor.lilly_temp_temperature_2.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hp = states('sensor.lilly_air_temperature') | float(none) %}
           {% if hp is not none and (now() - states.sensor.lilly_air_temperature.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
@@ -591,11 +657,15 @@ template:
           {% set s1_ok = s1 is not none and (now() - states.sensor.lilly_temperature.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.lilly_room_temperature_temperature') | float(none) %}
           {% set s2_ok = s2 is not none and (now() - states.sensor.lilly_room_temperature_temperature.last_reported).total_seconds() < max_age %}
+          {# Matter transport of the same physical Lilly room probe (Outdoor Meter 58; added 2026-06-05 live-sync; telemetry col Lilly_Temp_RoomProbe_Matter) #}
+          {% set s3 = states('sensor.lilly_temp_temperature_2') | float(none) %}
+          {% set s3_ok = s3 is not none and (now() - states.sensor.lilly_temp_temperature_2.last_reported).total_seconds() < max_age %}
           {% set hp = states('sensor.lilly_air_temperature') | float(none) %}
           {% set hp_ok = hp is not none and (now() - states.sensor.lilly_air_temperature.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
+          {% if s3_ok %}{% set ns.total = ns.total + (s3 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if hp_ok %}{% set ns.total = ns.total + (hp * 0.20) %}{% set ns.weight = ns.weight + 0.20 %}{% endif %}
           {{ (ns.total / ns.weight) | round(2) }}
 
@@ -611,6 +681,8 @@ template:
           {% if s1 is not none and (now() - states.sensor.lilly_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set s2 = states('sensor.lilly_room_temperature_humidity') | float(none) %}
           {% if s2 is not none and (now() - states.sensor.lilly_room_temperature_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
+          {% set s3 = states('sensor.lilly_temp_humidity_2') | float(none) %}
+          {% if s3 is not none and (now() - states.sensor.lilly_temp_humidity_2.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {% set hp = states('sensor.lilly_air_humidity') | float(none) %}
           {% if hp is not none and (now() - states.sensor.lilly_air_humidity.last_reported).total_seconds() < max_age %}{% set count.v = count.v + 1 %}{% endif %}
           {{ count.v > 0 }}
@@ -620,11 +692,15 @@ template:
           {% set s1_ok = s1 is not none and (now() - states.sensor.lilly_humidity.last_reported).total_seconds() < max_age %}
           {% set s2 = states('sensor.lilly_room_temperature_humidity') | float(none) %}
           {% set s2_ok = s2 is not none and (now() - states.sensor.lilly_room_temperature_humidity.last_reported).total_seconds() < max_age %}
+          {# Matter transport of the same physical Lilly room probe (Outdoor Meter 58; added 2026-06-05 live-sync; telemetry col Lilly_Hum_RoomProbe_Matter) #}
+          {% set s3 = states('sensor.lilly_temp_humidity_2') | float(none) %}
+          {% set s3_ok = s3 is not none and (now() - states.sensor.lilly_temp_humidity_2.last_reported).total_seconds() < max_age %}
           {% set hp = states('sensor.lilly_air_humidity') | float(none) %}
           {% set hp_ok = hp is not none and (now() - states.sensor.lilly_air_humidity.last_reported).total_seconds() < max_age %}
           {% set ns = namespace(total=0.0, weight=0.0) %}
           {% if s1_ok %}{% set ns.total = ns.total + (s1 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if s2_ok %}{% set ns.total = ns.total + (s2 * 0.9) %}{% set ns.weight = ns.weight + 0.9 %}{% endif %}
+          {% if s3_ok %}{% set ns.total = ns.total + (s3 * 1.0) %}{% set ns.weight = ns.weight + 1.0 %}{% endif %}
           {% if hp_ok %}{% set ns.total = ns.total + (hp * 0.25) %}{% set ns.weight = ns.weight + 0.25 %}{% endif %}
           {{ (ns.total / ns.weight) | round(1) }}
 

--- a/docs/2_reference_map.md
+++ b/docs/2_reference_map.md
@@ -1,8 +1,14 @@
 # Doc 2 / Moose House Climate Reference Map
 
-**Canon Date:** 2026-05-06
+**Canon Date:** 2026-06-05
 **Document Role:** Reference Map — canonical routing entry point.
 **Status:** Index. Update when topology, sensor naming, source precedence, or entity routing materially changes.
+
+> **2026-06-05 live-sync:** §7 (Physical-device / source-path inventory) added,
+> capturing the per-room Bluetooth / SmartThings / Matter transport map and the
+> repo↔live truth-source sync (Master + Lilly Matter routes restored to truth;
+> the disabled Living Room secondary route excluded). Entity-source sync only —
+> the statistical truth model is unchanged.
 
 ---
 
@@ -79,6 +85,7 @@ For the topology and routing slices Doc 2 is meant to cover, current sources are
 | Live truth/control/telemetry versions | [`5_runtime_layer.md`](5_runtime_layer.md) §5, §6 | V8.3 control, V3.1 truth, V5 telemetry. |
 | Helper inventory (live) | [`5_runtime_layer.md`](5_runtime_layer.md) §6.5 + `automations.yaml` header | Helpers required for runtime. |
 | Sensor exclusions (MSR-2 DPS310 etc.) | `configuration.yaml` Sections 3–9 (live source); summarized in [`5_runtime_layer.md`](5_runtime_layer.md) §7.5 | Live config wins. |
+| Physical-device / source-path (transport) inventory | §7 below; sourced from `automations.yaml` Section 1 telemetry columns + `configuration.yaml` Sections 3–6 | Per-room BT/ST/Matter transports of one physical probe. |
 | Telemetry worksheet / column names | `automations.yaml` Section 1 (`vtherm_mega_tracker_v5`) | Worksheet `VTherm_Launch_Data_v5`. |
 | Operator-suppressed window classification | [`telemetry_confounders.md`](telemetry_confounders.md) | Read before joining columns to behavior. |
 | Apollo MSR observability validation (proposed) | [`apollo_msr_observability_checklist.md`](apollo_msr_observability_checklist.md) | Observability-only; not a control authority. The single documented narrow exception is the legacy Lincoln fan-only destratification path (`climate.lincoln_air` `fan_only`/`off` only); locked by `tests/test_msr_observability_boundary.py`. |
@@ -105,3 +112,132 @@ Update Doc 2 when:
 - The Reference Map's authoritative-source link list (§4) needs a new row.
 
 Do not update Doc 2 merely to improve prose. Doc 2 is an index, not a narrative.
+
+## 7. Physical-device / source-path inventory (per-room transports)
+
+**Last synced:** 2026-06-05 (repo ↔ live truth-source sync).
+
+### 7.1 The transport principle (read this first)
+
+Each occupied room is monitored by **one physical SwitchBot room probe**. That
+single probe reaches Home Assistant over **multiple transports**:
+
+- **Bluetooth (BT)** — the SwitchBot cloud/BT integration.
+- **SmartThings (ST)** — the same probe bridged through SmartThings.
+- **Matter** — the same probe exposed over Matter.
+
+> **BT, SmartThings, and Matter are alternate transports of the *same physical
+> thermometer*, not independent sensors.** Two transport rows reading 71.2 °F is
+> one probe reported twice — not two probes agreeing.
+
+Genuinely separate hardware (NOT transports of the room probe), kept distinct in
+this inventory:
+
+- **Samsung internal** (`*_air_temperature` / `*_air_humidity`) — the mini-split
+  return-air thermistor. Real but biased; intentionally low-weight
+  (0.20 temp / 0.25 humidity). See `truth_sensor_architecture.md` → Weighting.
+- **MSR / Apollo diagnostics** (`*_msr_*`, e.g. `lincoln_msr_dps310_*`) —
+  observability only; the DPS310 units are hardware-failed and excluded.
+- **Office anchor** = Netatmo; **Dining** = Nest. Different devices, not SwitchBot.
+
+The transport identity (BT / ST / Matter) is **canonically defined by the
+telemetry column names** in `automations.yaml` Section 1
+(`*_RoomProbe_BT`, `*_RoomProbe_ST`, `*_RoomProbe_Matter`,
+`*_HVAC_Samsung`). Some older inline `configuration.yaml` comments use legacy
+hardware labels ("WonderLabs Hub", "Wyze cam sensor") that predate the
+transport taxonomy; where they disagree, **the telemetry transport label wins**.
+
+### 7.2 Current truth model (and the deferred question)
+
+Per-room truth currently takes a **weighted average of every fresh transport**
+(plus the low-weight Samsung internal). Adding a transport adds a contributor;
+removing/disabling one drops a contributor. Freshness is report-time
+(`last_reported`), 2 h window.
+
+> **Deferred design question (NOT decided here):** because the transports are
+> copies of one probe, averaging all of them double-counts that probe relative
+> to a room with fewer working transports. Whether truth should instead **pick
+> the single best available transport per physical probe** is an open V9 question
+> for a follow-up PR. The 2026-06-05 sync is **entity-source only** and does not
+> change this model or any weight.
+
+### 7.3 Per-room transport map (mini-split rooms)
+
+Weights: primary room probe `1.0`, secondary/legacy transport `0.9`, Matter
+`1.0`, Samsung internal `0.20` temp / `0.25` humidity. "In truth?" = currently a
+weighted contributor.
+
+**Living Room** — physical probe: SwitchBot Hub 2. Active temp contributors: **3**.
+
+| Transport | Temperature entity | Humidity entity | In truth? | Weight |
+|---|---|---|---|---|
+| Bluetooth (BT, primary) | `sensor.hub_temperature` | `sensor.hub_humidity` | ✅ | 1.0 |
+| SmartThings (ST) | `sensor.hub_temperature_2` | `sensor.hub_humidity_2` | ✅ | 0.9 |
+| BT secondary (disabled/no-state) | `sensor.hub_2_tempsensor_temperature` | `sensor.hub_2_humisensor_humidity` | ❌ removed 2026-06-05 | — |
+| Samsung internal | `sensor.living_room_air_temperature` | `sensor.living_room_air_humidity` | ✅ | 0.20 / 0.25 |
+
+The disabled secondary route is still emitted to telemetry
+(`LR_Temp/Hum_RoomProbe_BT_Secondary`) for observability; it is no longer a
+truth contributor or counted in `sensor.living_room_temperature_truth_active_count`.
+
+**Master Bedroom** — physical probe: SwitchBot I/O Meter (7C3F). Active temp contributors: **4**.
+
+| Transport | Temperature entity | Humidity entity | In truth? | Weight |
+|---|---|---|---|---|
+| Bluetooth (BT) | `sensor.master_bedroom_temp_temperature_2` | `sensor.master_bedroom_temp_humidity_2` | ✅ | 1.0 |
+| SmartThings (ST) | `sensor.master_bedroom_temperature_temperature_2` | `sensor.master_bedroom_temperature_humidity_2` | ✅ | 0.9 |
+| Matter | `sensor.master_bedroom_temp_temperature_3` | `sensor.master_bedroom_temp_humidity_3` | ✅ added 2026-06-05 | 1.0 |
+| Samsung internal | `sensor.master_bedroom_air_temperature` | `sensor.master_bedroom_air_humidity` | ✅ | 0.20 / 0.25 |
+
+Legacy/removed: `sensor.master_bedroom_temp_temperature` (Outdoor Meter 3F) — not wired.
+
+**Lincoln's Room** — physical probe: SwitchBot I/O Meter (3618). Active temp contributors: **4** (reference room — already fully wired; outlier-rejection pilot, 3 °F limit on the three room-probe transports). Unchanged by the 2026-06-05 sync.
+
+| Transport | Temperature entity | Humidity entity | In truth? | Weight |
+|---|---|---|---|---|
+| Bluetooth (BT) | `sensor.lincoln_s_temp_temperature` | `sensor.lincoln_s_temp_humidity` | ✅ | 1.0 |
+| SmartThings (ST) | `sensor.lincoln_s_room_temperature_temperature` | `sensor.lincoln_s_room_temperature_humidity` | ✅ | 1.0 |
+| Matter | `sensor.lincoln_temp_temperature` | `sensor.lincoln_temp_humidity` | ✅ | 1.0 |
+| Samsung internal | `sensor.lincoln_air_temperature` | `sensor.lincoln_air_humidity` | ✅ | 0.20 / 0.25 |
+
+Diagnostics (observability only, excluded from truth): `sensor.lincoln_msr_dps310_temperature` (hardware-failed), `sensor.lincoln_msr_dps310_pressure`, `sensor.lincoln_msr_esp_temperature`.
+
+**Lilly's Room** — physical probe: SwitchBot Outdoor Meter (58). Active temp contributors: **4**.
+
+| Transport | Temperature entity | Humidity entity | In truth? | Weight |
+|---|---|---|---|---|
+| Bluetooth (BT) | `sensor.lilly_temperature` | `sensor.lilly_humidity` | ✅ | 1.0 |
+| SmartThings (ST) | `sensor.lilly_room_temperature_temperature` | `sensor.lilly_room_temperature_humidity` | ✅ | 0.9 |
+| Matter | `sensor.lilly_temp_temperature_2` | `sensor.lilly_temp_humidity_2` | ✅ added 2026-06-05 | 1.0 |
+| Samsung internal | `sensor.lilly_air_temperature` | `sensor.lilly_air_humidity` | ✅ | 0.20 / 0.25 |
+
+> **Lilly contradiction resolved (2026-06-05):** `sensor.lilly_temp_temperature_2`
+> is the **active Matter transport** of the Outdoor Meter 58 probe (telemetry
+> `Lilly_Temp_RoomProbe_Matter`). It was previously *also* listed in
+> `configuration.yaml` as a removed "Outdoor Meter 58 fallback" — listing one
+> entity as both active and removed. The Matter copy is active; only the legacy
+> non-`_2` transport `sensor.lilly_temp_temperature` remains removed/unwired.
+
+### 7.4 Other room probes (supplemental / not mini-split truth)
+
+These follow the same BT/ST/Matter transport pattern but are not first-class
+supervisor inputs; authoritative entities are the `automations.yaml` Section 1
+telemetry columns:
+
+- **Deck / Outdoor** — `Deck_*_RoomProbe_BT` (`sensor.deck_temp_temperature`),
+  `_ST` (`…_2`), `_Matter` (`…_3`).
+- **Laundry** — `Laundry_*_RoomProbe_BT` (`sensor.laundry_temperature`),
+  `_ST` (`sensor.bathroom_downstairs_*`), `_Matter` (`sensor.laundry_room_*_2`).
+- **Office** — Netatmo anchor (`sensor.indoor_*`) plus
+  `Office_*_RoomProbe_BT` (`sensor.office_temp_*`), `_ST` (`sensor.office_*_2`),
+  `_Matter` (`sensor.office_temperature` / `sensor.office_humidity`).
+
+### 7.5 Maintenance log
+
+- **2026-06-05** — Repo ↔ live truth-source sync. Added Master Matter
+  (`master_bedroom_temp_temperature_3`, `master_bedroom_temp_humidity_3`) and
+  Lilly Matter (`lilly_temp_temperature_2`, `lilly_temp_humidity_2`) to weighted
+  truth (w=1.0). Removed the disabled Living Room secondary route
+  (`hub_2_tempsensor_temperature`, `hub_2_humisensor_humidity`) from truth +
+  active count. Counts after sync: Living Room 3 · Master 4 · Lincoln 4 · Lilly 4.
+  Locked by `tests/test_truth_source_transport_sync.py`.

--- a/docs/2_reference_map.md
+++ b/docs/2_reference_map.md
@@ -85,7 +85,7 @@ For the topology and routing slices Doc 2 is meant to cover, current sources are
 | Live truth/control/telemetry versions | [`5_runtime_layer.md`](5_runtime_layer.md) §5, §6 | V8.3 control, V3.1 truth, V5 telemetry. |
 | Helper inventory (live) | [`5_runtime_layer.md`](5_runtime_layer.md) §6.5 + `automations.yaml` header | Helpers required for runtime. |
 | Sensor exclusions (MSR-2 DPS310 etc.) | `configuration.yaml` Sections 3–9 (live source); summarized in [`5_runtime_layer.md`](5_runtime_layer.md) §7.5 | Live config wins. |
-| Physical-device / source-path (transport) inventory | §7 below; sourced from `automations.yaml` Section 1 telemetry columns + `configuration.yaml` Sections 3–6 | Per-room BT/ST/Matter transports of one physical probe. |
+| Physical-device / source-path (transport) inventory | §7 below; live HA registry authoritative for transport identity; `configuration.yaml` Sections 3–6 for truth membership; `automations.yaml` Section 1 for historical telemetry column names | Per-room BT/ST/Matter transports of one physical probe. |
 | Telemetry worksheet / column names | `automations.yaml` Section 1 (`vtherm_mega_tracker_v5`) | Worksheet `VTherm_Launch_Data_v5`. |
 | Operator-suppressed window classification | [`telemetry_confounders.md`](telemetry_confounders.md) | Read before joining columns to behavior. |
 | Apollo MSR observability validation (proposed) | [`apollo_msr_observability_checklist.md`](apollo_msr_observability_checklist.md) | Observability-only; not a control authority. The single documented narrow exception is the legacy Lincoln fan-only destratification path (`climate.lincoln_air` `fan_only`/`off` only); locked by `tests/test_msr_observability_boundary.py`. |
@@ -140,12 +140,24 @@ this inventory:
   observability only; the DPS310 units are hardware-failed and excluded.
 - **Office anchor** = Netatmo; **Dining** = Nest. Different devices, not SwitchBot.
 
-The transport identity (BT / ST / Matter) is **canonically defined by the
-telemetry column names** in `automations.yaml` Section 1
-(`*_RoomProbe_BT`, `*_RoomProbe_ST`, `*_RoomProbe_Matter`,
-`*_HVAC_Samsung`). Some older inline `configuration.yaml` comments use legacy
-hardware labels ("WonderLabs Hub", "Wyze cam sensor") that predate the
-transport taxonomy; where they disagree, **the telemetry transport label wins**.
+**Authority for transport identity:**
+
+- **Live HA registry / platform metadata is authoritative** for a route's current
+  integration / transport identity — whether a route is Matter, Bluetooth, or
+  SmartThings, plus its `disabled_by` / availability state.
+- **`automations.yaml` telemetry column names** (`*_RoomProbe_BT`, `*_RoomProbe_ST`,
+  `*_RoomProbe_Matter`, `*_HVAC_Samsung`) document **historical / export naming**,
+  not current platform identity.
+- **Where a telemetry label disagrees with the live registry, preserve the
+  telemetry field name** (it is a stable observability column) **but document the
+  live registry identity.** The clearest example is the Living Room disabled route
+  (§7.3): the live registry identifies it as **Matter**, while its historical
+  telemetry column is named `LR_*_RoomProbe_BT_Secondary`. The column name does
+  not make the route Bluetooth.
+
+Some older inline `configuration.yaml` comments also use legacy hardware labels
+("WonderLabs Hub", "Wyze cam sensor") that predate this taxonomy; treat them as
+historical, not authoritative.
 
 ### 7.2 Current truth model (and the deferred question)
 
@@ -173,12 +185,16 @@ weighted contributor.
 |---|---|---|---|---|
 | Bluetooth (BT, primary) | `sensor.hub_temperature` | `sensor.hub_humidity` | ✅ | 1.0 |
 | SmartThings (ST) | `sensor.hub_temperature_2` | `sensor.hub_humidity_2` | ✅ | 0.9 |
-| BT secondary (disabled/no-state) | `sensor.hub_2_tempsensor_temperature` | `sensor.hub_2_humisensor_humidity` | ❌ removed 2026-06-05 | — |
+| Matter (disabled, per live registry) | `sensor.hub_2_tempsensor_temperature` | `sensor.hub_2_humisensor_humidity` | ❌ excluded 2026-06-05 | — |
 | Samsung internal | `sensor.living_room_air_temperature` | `sensor.living_room_air_humidity` | ✅ | 0.20 / 0.25 |
 
-The disabled secondary route is still emitted to telemetry
-(`LR_Temp/Hum_RoomProbe_BT_Secondary`) for observability; it is no longer a
-truth contributor or counted in `sensor.living_room_temperature_truth_active_count`.
+`sensor.hub_2_tempsensor_temperature` / `sensor.hub_2_humisensor_humidity` are the
+Living Room **Matter route in the live HA entity registry**. They are historically
+logged under the telemetry column name `LR_*_RoomProbe_BT_Secondary` — a historical
+label that does **not** redefine the route as Bluetooth. The route is
+`disabled_by:user`, has no live state, and is excluded from truth and from
+`sensor.living_room_temperature_truth_active_count`. The telemetry column name is
+preserved as a stable observability field.
 
 **Master Bedroom** — physical probe: SwitchBot I/O Meter (7C3F). Active temp contributors: **4**.
 
@@ -237,7 +253,8 @@ telemetry columns:
 - **2026-06-05** — Repo ↔ live truth-source sync. Added Master Matter
   (`master_bedroom_temp_temperature_3`, `master_bedroom_temp_humidity_3`) and
   Lilly Matter (`lilly_temp_temperature_2`, `lilly_temp_humidity_2`) to weighted
-  truth (w=1.0). Removed the disabled Living Room secondary route
-  (`hub_2_tempsensor_temperature`, `hub_2_humisensor_humidity`) from truth +
-  active count. Counts after sync: Living Room 3 · Master 4 · Lincoln 4 · Lilly 4.
+  truth (w=1.0). Excluded the disabled Living Room Matter route — per the live HA
+  registry — (`hub_2_tempsensor_temperature`, `hub_2_humisensor_humidity`,
+  `disabled_by:user`, no live state) from truth + active count. Counts after
+  sync: Living Room 3 · Master 4 · Lincoln 4 · Lilly 4.
   Locked by `tests/test_truth_source_transport_sync.py`.

--- a/tests/test_truth_source_transport_sync.py
+++ b/tests/test_truth_source_transport_sync.py
@@ -16,8 +16,9 @@ Verified-live facts being locked (see configuration.yaml "LIVE-SYNC CHANGES
   * Lilly truth includes the Matter transport copy of the Lilly room probe:
         sensor.lilly_temp_temperature_2            (temperature)
         sensor.lilly_temp_humidity_2               (humidity)
-  * The disabled/no-state Living Room secondary SwitchBot Hub 2 transport is
-    EXCLUDED from active truth:
+  * The disabled Living Room Matter route (Matter per the live HA entity
+    registry; disabled_by:user, no live state; historically logged under the
+    telemetry column name LR_*_RoomProbe_BT_Secondary) is EXCLUDED from truth:
         sensor.hub_2_tempsensor_temperature        (temperature)
         sensor.hub_2_humisensor_humidity           (humidity)
   * Active temperature/humidity contributor counts:
@@ -145,10 +146,10 @@ def test_lilly_truth_includes_matter_temp_and_humidity():
 
 
 # --------------------------------------------------------------------------- #
-# Exclusion: disabled Living Room secondary route is out of active truth
+# Exclusion: disabled Living Room Matter route is out of active truth
 # --------------------------------------------------------------------------- #
 
-def test_living_room_truth_excludes_disabled_secondary_routes():
+def test_living_room_truth_excludes_disabled_matter_route():
     sensors = _template_sensors()
 
     temp = sensors[LR_T]
@@ -164,7 +165,7 @@ def test_living_room_truth_excludes_disabled_secondary_routes():
 
 def test_living_room_diagnostics_exclude_disabled_route():
     """The Contributors list and Active Count diagnostic must also drop the
-    disabled secondary route so the live count of 3 is reported."""
+    disabled Matter route so the live count of 3 is reported."""
     sensors = _template_sensors()
 
     contributors = sensors["Living Room Temperature Truth Contributors"]["state"]
@@ -209,7 +210,7 @@ def test_new_matter_routes_weighted_one_point_zero():
 def test_existing_weights_unchanged_for_synced_rooms():
     """Guard the 'do not redesign weighting' rule: pre-existing source weights
     in the touched rooms are untouched (Samsung internal low-weight; ST/legacy
-    secondary at 0.9; primaries at 1.0)."""
+    transports at 0.9; primaries at 1.0)."""
     sensors = _template_sensors()
 
     # Samsung internal stays low-weight everywhere it was.
@@ -264,5 +265,5 @@ def test_reference_map_documents_transports_and_matter_entities():
         "sensor.lilly_temp_humidity_2",
     ):
         assert entity in doc, f"Reference map missing synced Matter entity {entity}."
-    # The removed Living Room secondary route is documented as excluded.
+    # The excluded Living Room Matter route is documented.
     assert "hub_2_tempsensor_temperature" in doc

--- a/tests/test_truth_source_transport_sync.py
+++ b/tests/test_truth_source_transport_sync.py
@@ -1,0 +1,268 @@
+"""
+Truth-Source ↔ Live Transport Sync Regression Guards
+====================================================
+
+Locks the 2026-06-05 durability/sync PR that ported already-verified LIVE
+truth-source edits into the repo. This is an ENTITY-SOURCE sync only — it
+does not (and these tests assert it does not) redesign weighting or change
+the statistical truth model.
+
+Verified-live facts being locked (see configuration.yaml "LIVE-SYNC CHANGES
+(June 5, 2026)" header and docs/2_reference_map.md §7):
+
+  * Master truth includes the Matter transport copy of the Master room probe:
+        sensor.master_bedroom_temp_temperature_3   (temperature)
+        sensor.master_bedroom_temp_humidity_3      (humidity)
+  * Lilly truth includes the Matter transport copy of the Lilly room probe:
+        sensor.lilly_temp_temperature_2            (temperature)
+        sensor.lilly_temp_humidity_2               (humidity)
+  * The disabled/no-state Living Room secondary SwitchBot Hub 2 transport is
+    EXCLUDED from active truth:
+        sensor.hub_2_tempsensor_temperature        (temperature)
+        sensor.hub_2_humisensor_humidity           (humidity)
+  * Active temperature/humidity contributor counts:
+        Living Room 3 · Master 4 · Lincoln 4 · Lilly 4
+
+Transport model (documented, not changed here): a room's BT / SmartThings(ST)
+/ Matter rows are alternate transports of ONE physical SwitchBot probe, not
+independent thermometers. Truth currently averages every available transport;
+"pick one best transport per physical probe" is a DEFERRED design question.
+"""
+
+import os
+import re
+
+import pytest
+import yaml
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+CONFIG = os.path.join(REPO_ROOT, "configuration.yaml")
+REFERENCE_MAP = os.path.join(REPO_ROOT, "docs", "2_reference_map.md")
+
+
+class _SyncLoader(yaml.SafeLoader):
+    pass
+
+
+_SyncLoader.add_constructor("!include", lambda loader, node: node.value)
+_SyncLoader.add_constructor("!secret", lambda loader, node: node.value)
+
+
+def _read(path):
+    if not os.path.exists(path):
+        pytest.skip(f"{os.path.basename(path)} not found.")
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _template_sensors():
+    """Return {name: sensor_dict} for every sensor under the top-level
+    `template:` → `- sensor:` list in configuration.yaml."""
+    cfg = yaml.load(_read(CONFIG), Loader=_SyncLoader)
+    sensors = {}
+    for block in cfg.get("template", []) or []:
+        if isinstance(block, dict) and "sensor" in block:
+            for sensor in block["sensor"]:
+                if isinstance(sensor, dict) and "name" in sensor:
+                    sensors[sensor["name"]] = sensor
+    assert sensors, "No template sensors parsed from configuration.yaml"
+    return sensors
+
+
+def _freshness_sources(template_text):
+    """Entities gated by a report-time freshness check in a state/availability
+    template: states.sensor.<id>.last_reported . This is exactly the set the
+    weighted average and the active-count diagnostic iterate over."""
+    return set(re.findall(r"states\.sensor\.([a-z0-9_]+)\.last_reported", template_text or ""))
+
+
+def _source_weights(state_text):
+    """Map active source entity -> weight by joining the two bindings the
+    truth templates use:
+        {% set <var> = states('sensor.<entity>') | float(none) %}
+        ... (<var> * <weight>) ...
+    Only returns entities that are actually multiplied into ns.total (i.e.
+    genuinely contribute to the weighted average)."""
+    var_to_entity = dict(
+        re.findall(r"set\s+(\w+)\s*=\s*states\('sensor\.([a-z0-9_]+)'\)", state_text or "")
+    )
+    var_to_weight = {
+        var: float(weight)
+        for var, weight in re.findall(r"\((\w+)\s*\*\s*([0-9.]+)\)", state_text or "")
+    }
+    return {
+        var_to_entity[var]: weight
+        for var, weight in var_to_weight.items()
+        if var in var_to_entity
+    }
+
+
+# Truth sensor display names.
+LR_T, LR_H = "Living Room Temperature Truth", "Living Room Humidity Truth"
+MAS_T, MAS_H = "Master Bedroom Temperature Truth", "Master Bedroom Humidity Truth"
+LIN_T, LIN_H = "Lincoln's Room Temperature Truth", "Lincoln's Room Humidity Truth"
+LIL_T, LIL_H = "Lilly's Room Temperature Truth", "Lilly's Room Humidity Truth"
+
+DISABLED_LR_TEMP = "hub_2_tempsensor_temperature"
+DISABLED_LR_HUM = "hub_2_humisensor_humidity"
+
+
+# --------------------------------------------------------------------------- #
+# Inclusion: Master + Lilly Matter transports are wired into truth
+# --------------------------------------------------------------------------- #
+
+def test_master_truth_includes_matter_temp_and_humidity():
+    sensors = _template_sensors()
+
+    temp = sensors[MAS_T]
+    assert "master_bedroom_temp_temperature_3" in _freshness_sources(temp["state"])
+    assert "master_bedroom_temp_temperature_3" in _freshness_sources(temp["availability"])
+    assert "master_bedroom_temp_temperature_3" in _source_weights(temp["state"]), (
+        "Master Matter temperature must be weighted into the average, not just read."
+    )
+
+    hum = sensors[MAS_H]
+    assert "master_bedroom_temp_humidity_3" in _freshness_sources(hum["state"])
+    assert "master_bedroom_temp_humidity_3" in _freshness_sources(hum["availability"])
+    assert "master_bedroom_temp_humidity_3" in _source_weights(hum["state"])
+
+
+def test_lilly_truth_includes_matter_temp_and_humidity():
+    sensors = _template_sensors()
+
+    temp = sensors[LIL_T]
+    assert "lilly_temp_temperature_2" in _freshness_sources(temp["state"])
+    assert "lilly_temp_temperature_2" in _freshness_sources(temp["availability"])
+    assert "lilly_temp_temperature_2" in _source_weights(temp["state"]), (
+        "Lilly Matter temperature must be weighted into the average, not just read."
+    )
+
+    hum = sensors[LIL_H]
+    assert "lilly_temp_humidity_2" in _freshness_sources(hum["state"])
+    assert "lilly_temp_humidity_2" in _freshness_sources(hum["availability"])
+    assert "lilly_temp_humidity_2" in _source_weights(hum["state"])
+
+
+# --------------------------------------------------------------------------- #
+# Exclusion: disabled Living Room secondary route is out of active truth
+# --------------------------------------------------------------------------- #
+
+def test_living_room_truth_excludes_disabled_secondary_routes():
+    sensors = _template_sensors()
+
+    temp = sensors[LR_T]
+    assert DISABLED_LR_TEMP not in _freshness_sources(temp["state"])
+    assert DISABLED_LR_TEMP not in _freshness_sources(temp["availability"])
+    assert DISABLED_LR_TEMP not in _source_weights(temp["state"])
+
+    hum = sensors[LR_H]
+    assert DISABLED_LR_HUM not in _freshness_sources(hum["state"])
+    assert DISABLED_LR_HUM not in _freshness_sources(hum["availability"])
+    assert DISABLED_LR_HUM not in _source_weights(hum["state"])
+
+
+def test_living_room_diagnostics_exclude_disabled_route():
+    """The Contributors list and Active Count diagnostic must also drop the
+    disabled secondary route so the live count of 3 is reported."""
+    sensors = _template_sensors()
+
+    contributors = sensors["Living Room Temperature Truth Contributors"]["state"]
+    active_count = sensors["Living Room Temperature Truth Active Count"]["state"]
+
+    assert DISABLED_LR_TEMP not in _freshness_sources(contributors)
+    assert DISABLED_LR_TEMP not in _freshness_sources(active_count)
+    # The literal label string emitted into the Contributors attribute is gone too.
+    assert "'hub_2_tempsensor_temperature'" not in contributors
+    assert len(_freshness_sources(active_count)) == 3
+
+
+# --------------------------------------------------------------------------- #
+# Contributor counts match the verified-live numbers
+# --------------------------------------------------------------------------- #
+
+def test_contributor_counts_match_verified_live():
+    sensors = _template_sensors()
+    expected = {
+        LR_T: 3, MAS_T: 4, LIN_T: 4, LIL_T: 4,
+        LR_H: 3, MAS_H: 4, LIN_H: 4, LIL_H: 4,
+    }
+    actual = {name: len(_freshness_sources(sensors[name]["state"])) for name in expected}
+    assert actual == expected, f"Contributor counts drifted from live: {actual}"
+
+
+# --------------------------------------------------------------------------- #
+# Weighting is PORTED, not redesigned
+# --------------------------------------------------------------------------- #
+
+def test_new_matter_routes_weighted_one_point_zero():
+    """New Matter routes carry w=1.0 — matching Lincoln's live Matter route
+    (lincoln_temp_temperature) and the sibling BT room-probe weight. This is
+    the existing scheme, not a new one."""
+    sensors = _template_sensors()
+    assert _source_weights(sensors[MAS_T]["state"])["master_bedroom_temp_temperature_3"] == 1.0
+    assert _source_weights(sensors[MAS_H]["state"])["master_bedroom_temp_humidity_3"] == 1.0
+    assert _source_weights(sensors[LIL_T]["state"])["lilly_temp_temperature_2"] == 1.0
+    assert _source_weights(sensors[LIL_H]["state"])["lilly_temp_humidity_2"] == 1.0
+
+
+def test_existing_weights_unchanged_for_synced_rooms():
+    """Guard the 'do not redesign weighting' rule: pre-existing source weights
+    in the touched rooms are untouched (Samsung internal low-weight; ST/legacy
+    secondary at 0.9; primaries at 1.0)."""
+    sensors = _template_sensors()
+
+    # Samsung internal stays low-weight everywhere it was.
+    assert _source_weights(sensors[LR_T]["state"])["living_room_air_temperature"] == 0.20
+    assert _source_weights(sensors[LR_H]["state"])["living_room_air_humidity"] == 0.25
+    assert _source_weights(sensors[MAS_T]["state"])["master_bedroom_air_temperature"] == 0.20
+    assert _source_weights(sensors[LIL_T]["state"])["lilly_air_temperature"] == 0.20
+
+    # Primary BT probes keep w=1.0; ST/legacy secondaries keep w=0.9.
+    assert _source_weights(sensors[LR_T]["state"])["hub_temperature"] == 1.0
+    assert _source_weights(sensors[LR_T]["state"])["hub_temperature_2"] == 0.9
+    assert _source_weights(sensors[MAS_T]["state"])["master_bedroom_temp_temperature_2"] == 1.0
+    assert _source_weights(sensors[MAS_T]["state"])["master_bedroom_temperature_temperature_2"] == 0.9
+    assert _source_weights(sensors[LIL_T]["state"])["lilly_temperature"] == 1.0
+    assert _source_weights(sensors[LIL_T]["state"])["lilly_room_temperature_temperature"] == 0.9
+
+
+# --------------------------------------------------------------------------- #
+# Lilly documentation contradiction is resolved
+# --------------------------------------------------------------------------- #
+
+def test_lilly_matter_entity_not_marked_removed_or_fallback():
+    """sensor.lilly_temp_temperature_2 must not be listed as both active Matter
+    and removed/legacy. The old 'Outdoor Meter 58 fallback' REMOVED line is gone,
+    and no line marks the entity as a fallback/removed source."""
+    text = _read(CONFIG)
+    assert "lilly_temp_temperature_2 (Outdoor Meter 58 fallback)" not in text
+    for line in text.splitlines():
+        if "lilly_temp_temperature_2" in line and "fallback" in line.lower():
+            pytest.fail(f"lilly_temp_temperature_2 still framed as fallback: {line.strip()}")
+    # It IS documented as the active Matter transport.
+    assert any(
+        "lilly_temp_temperature_2" in line and "Matter" in line
+        for line in text.splitlines()
+    ), "lilly_temp_temperature_2 should be documented as the Matter transport."
+
+
+# --------------------------------------------------------------------------- #
+# Reference map carries the durable transport inventory
+# --------------------------------------------------------------------------- #
+
+def test_reference_map_documents_transports_and_matter_entities():
+    doc = _read(REFERENCE_MAP)
+    # The transport principle is stated.
+    for token in ("Matter", "SmartThings", "Bluetooth", "transport"):
+        assert token in doc, f"Reference map must mention {token!r}."
+    # The four newly-synced Matter entities appear in the inventory.
+    for entity in (
+        "sensor.master_bedroom_temp_temperature_3",
+        "sensor.master_bedroom_temp_humidity_3",
+        "sensor.lilly_temp_temperature_2",
+        "sensor.lilly_temp_humidity_2",
+    ):
+        assert entity in doc, f"Reference map missing synced Matter entity {entity}."
+    # The removed Living Room secondary route is documented as excluded.
+    assert "hub_2_tempsensor_temperature" in doc


### PR DESCRIPTION
## Summary

Durability/sync PR: makes the **already-working HAOS configuration** durable in the repo. This is an **entity-source sync only** — no weighting redesign and no change to the statistical truth model. Runtime truth behavior on this branch matches the verified live (Codex-installed) HAOS configuration:

- Contributors: **Living Room 3 · Master 4 · Lincoln 4 · Lilly 4**
- Freshness: `last_reported` with a 7200 s (2 h) window
- Existing weights unchanged; Master & Lilly Matter entities included; disabled Living Room route excluded

## Key Changes

- **Added Matter transports to weighted truth (w=1.0):**
  - Master: `sensor.master_bedroom_temp_temperature_3`, `sensor.master_bedroom_temp_humidity_3`
  - Lilly: `sensor.lilly_temp_temperature_2`, `sensor.lilly_temp_humidity_2`
  - Already reporting live; restored to the weighted average.

- **Excluded the disabled Living Room Matter route from truth:**
  - `sensor.hub_2_tempsensor_temperature`, `sensor.hub_2_humisensor_humidity`
  - **This route is Matter according to the live HA entity registry** (`disabled_by:user`, no live state), despite being **historically logged under the `LR_*_RoomProbe_BT_Secondary` telemetry column**. That column name is a historical export label and does **not** make the route Bluetooth; the telemetry column name is preserved unchanged.
  - Excluded from truth and active-count diagnostics (still logged to telemetry for observability).

- **Contributor counts (verified live 2026-06-05):** Living Room 3 (was 4) · Master 4 (was 3) · Lincoln 4 (unchanged) · Lilly 4 (was 3).

- **Resolved the Lilly documentation contradiction:** `sensor.lilly_temp_temperature_2` is now documented only as the active Matter transport (previously also listed as a removed "Outdoor Meter 58 fallback").

- **Reference documentation (`docs/2_reference_map.md` §7):** the transport principle (Bluetooth / SmartThings / Matter are alternate transports of **one** physical SwitchBot probe, not independent sensors), per-room inventory tables, and an authority rule:
  - **Live HA registry / platform metadata is authoritative** for current transport identity.
  - **`automations.yaml` telemetry column names document historical / export naming.**
  - On conflict, **preserve the telemetry field name but document the live registry identity** (the Living Room disabled route is the canonical example: Matter in the registry, `BT_Secondary` in the historical telemetry column).

## Tests

`tests/test_truth_source_transport_sync.py` — **9 tests** locking the sync:
- Master & Lilly Matter routes are included in weighted truth
- Living Room disabled Matter route is excluded (incl. Contributors + Active Count diagnostics)
- Contributor counts match verified-live numbers (3 / 4 / 4 / 4)
- New Matter routes use weight 1.0 (matching Lincoln's live Matter route precedent)
- Pre-existing weights unchanged; Lilly active/removed contradiction is gone; reference-map inventory present

Full suite: `pytest -q` → **105 passed** (96 existing + 9 new, incl. YAML syntax). The freshness, truth-registry-integrity, safety-invariant, and Section 2 shove-setpoint suites are all green.

## Scope / non-goals

- Changes are limited to `configuration.yaml` (truth-source membership + comments), `docs/2_reference_map.md`, and `tests/test_truth_source_transport_sync.py`.
- **No weighting or statistical-truth redesign.** Unchanged: `automations.yaml`, source entity IDs, freshness logic / 7200 s window, averaging behavior, Section 2 comfort decisions, Section 3 safety gates, Samsung 61°F/79°F shove commands, smoothing, and MSR/Apollo control boundaries.
- New Matter weight 1.0 matches Lincoln's live Matter route and the sibling BT room-probe weight; Samsung internal stays 0.20/0.25, ST/legacy 0.9, primaries 1.0.
- The "pick one best transport per physical probe" question is explicitly **deferred** (out of scope).

https://claude.ai/code/session_01B51wXn2pbbuHuEuCecSkxT