### PR TITLE
Add CI guardrail for docs-only pull requests

### DIFF
--- a/.github/workflows/docs-only-guard.yml
+++ b/.github/workflows/docs-only-guard.yml
@@ -1,0 +1,41 @@
+name: Docs-only PR guard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+
+jobs:
+  docs-only-scope:
+    name: Enforce docs-only file scope
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out pull request head
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Collect complete pull request changed-file list
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git remote add base "https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git" || git remote set-url base "https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git"
+          git fetch --no-tags --prune --depth=1 base "${BASE_SHA}"
+          git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" > changed-files.txt
+          echo "Changed files:"
+          cat changed-files.txt
+
+      - name: Enforce docs-only label scope
+        run: python tools/docs_only_guard.py --event "$GITHUB_EVENT_PATH" --changed-files changed-files.txt

--- a/README.md
+++ b/README.md
@@ -77,3 +77,26 @@ If architecture assumptions are unclear:
 ```bash
 python -m pytest tests/
 ```
+
+## Docs-only pull request guardrail
+
+Pull requests that are intended to change documentation only should use the exact GitHub label `docs-only`.
+Apply the label from the pull request sidebar after opening the PR; the docs-only guard also re-runs when the label is added or removed.
+
+When `docs-only` is present, CI checks the complete changed-file list between the pull request base and head commits.
+The guard permits Markdown documentation and documentation assets, including content stored beneath `docs/**`.
+
+The guard blocks files and paths that can affect Home Assistant runtime behavior, executable logic, tests, CI, configuration, automations, or dependencies, including:
+
+- `*.yaml` and `*.yml`
+- `*.py`, `*.ps1`, and `*.sh`
+- `configuration.yaml`, `automations.yaml`, `scripts.yaml`, `scenes.yaml`, and `secrets.yaml`
+- `custom_components/**`, `packages/**`, and `blueprints/**`
+- `tools/**` and `tests/**`
+- `.github/workflows/**`
+- `requirements*.txt`
+
+If a docs-only PR touches any blocked path, the failed check prints every prohibited changed path so the author can either remove the label or move the runtime change to a normal PR.
+Normal pull requests without the `docs-only` label are unaffected by this guard.
+
+This guard is a repository-safety scope check only. It does not replace normal pytest CI or any other validation for non-documentation changes.

--- a/tests/test_docs_only_guard.py
+++ b/tests/test_docs_only_guard.py
@@ -1,0 +1,93 @@
+import importlib.util
+import json
+from pathlib import Path
+
+MODULE_PATH = Path("tools/docs_only_guard.py")
+spec = importlib.util.spec_from_file_location("docs_only_guard", MODULE_PATH)
+docs_only_guard = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(docs_only_guard)
+
+
+def event_with_labels(*labels: str) -> dict:
+    return {"pull_request": {"labels": [{"name": label} for label in labels]}}
+
+
+def test_markdown_only_pr_passes() -> None:
+    assert docs_only_guard.prohibited_paths(["README.md", "architecture/notes.md"]) == []
+
+
+def test_files_under_docs_pass() -> None:
+    changed = ["docs/v9_v10_goals.md", "docs/assets/stack-effect.png", "docs/diagrams/floorplan.svg"]
+
+    assert docs_only_guard.prohibited_paths(changed) == []
+
+
+def test_automations_yaml_fails() -> None:
+    assert docs_only_guard.prohibited_paths(["automations.yaml"]) == ["automations.yaml"]
+
+
+def test_nested_yaml_fails() -> None:
+    assert docs_only_guard.prohibited_paths(["docs/examples/sample.yaml", "nested/config.yml"]) == [
+        "docs/examples/sample.yaml",
+        "nested/config.yml",
+    ]
+
+
+def test_python_and_powershell_scripts_fail() -> None:
+    changed = ["analysis/model.py", "tools/export_ha_nuisance_evidence.ps1", "scripts/check.sh"]
+
+    assert docs_only_guard.prohibited_paths(changed) == changed
+
+
+def test_tests_and_tools_paths_fail() -> None:
+    changed = ["tests/test_yaml_syntax.txt", "tools/readme.md"]
+
+    assert docs_only_guard.prohibited_paths(changed) == changed
+
+
+def test_workflow_modifications_fail() -> None:
+    changed = [".github/workflows/docs-only-guard.yml"]
+
+    assert docs_only_guard.prohibited_paths(changed) == changed
+
+
+def test_multiple_changed_files_report_every_prohibited_path() -> None:
+    changed = [
+        "docs/overview.md",
+        "automations.yaml",
+        "custom_components/moose/__init__.py",
+        "requirements-dev.txt",
+        "README.md",
+        ".github/workflows/ci.yaml",
+    ]
+
+    assert docs_only_guard.prohibited_paths(changed) == [
+        "automations.yaml",
+        "custom_components/moose/__init__.py",
+        "requirements-dev.txt",
+        ".github/workflows/ci.yaml",
+    ]
+
+
+def test_no_docs_only_label_means_guard_does_not_enforce(tmp_path, monkeypatch) -> None:
+    event_path = tmp_path / "event.json"
+    changed_files_path = tmp_path / "changed-files.txt"
+    event_path.write_text(json.dumps(event_with_labels("bug", "documentation")), encoding="utf-8")
+    changed_files_path.write_text("automations.yaml\n.github/workflows/ci.yaml\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "docs_only_guard.py",
+            "--event",
+            str(event_path),
+            "--changed-files",
+            str(changed_files_path),
+        ],
+    )
+
+    assert docs_only_guard.main() == 0
+
+
+def test_exact_docs_only_label_enforces() -> None:
+    assert docs_only_guard.event_has_docs_only_label(event_with_labels("bug", "docs-only"))

--- a/tools/docs_only_guard.py
+++ b/tools/docs_only_guard.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Guard docs-only pull requests from changing executable/runtime files."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+from pathlib import PurePosixPath
+from typing import Any, Iterable
+
+DOCS_ONLY_LABEL = "docs-only"
+
+PROTECTED_ROOT_FILES = {
+    "configuration.yaml",
+    "automations.yaml",
+    "scripts.yaml",
+    "scenes.yaml",
+    "secrets.yaml",
+}
+
+PROTECTED_PREFIXES = (
+    "custom_components/",
+    "packages/",
+    "blueprints/",
+    "tools/",
+    "tests/",
+    ".github/workflows/",
+)
+
+PROTECTED_SUFFIXES = (
+    ".yaml",
+    ".yml",
+    ".py",
+    ".ps1",
+    ".sh",
+)
+
+PROTECTED_GLOBS = (
+    "requirements*.txt",
+)
+
+
+def normalize_path(path: str) -> str:
+    """Return a repository-relative POSIX path without leading './' segments."""
+    normalized = PurePosixPath(path.strip()).as_posix()
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def is_protected_path(path: str) -> bool:
+    """Return True when a changed path is outside docs-only PR scope."""
+    normalized = normalize_path(path)
+    lowered = normalized.lower()
+
+    if not normalized:
+        return False
+
+    if lowered in PROTECTED_ROOT_FILES:
+        return True
+
+    if lowered.startswith(PROTECTED_PREFIXES):
+        return True
+
+    if lowered.endswith(PROTECTED_SUFFIXES):
+        return True
+
+    name = PurePosixPath(lowered).name
+    return any(fnmatch.fnmatchcase(name, pattern) for pattern in PROTECTED_GLOBS)
+
+
+def prohibited_paths(changed_paths: Iterable[str]) -> list[str]:
+    """Return every protected changed path, preserving input order."""
+    return [path for path in (normalize_path(p) for p in changed_paths) if is_protected_path(path)]
+
+
+def event_has_docs_only_label(event: dict[str, Any]) -> bool:
+    """Return True when the pull request event contains the exact docs-only label."""
+    labels = event.get("pull_request", {}).get("labels", [])
+    return any(label.get("name") == DOCS_ONLY_LABEL for label in labels if isinstance(label, dict))
+
+
+def read_changed_paths(path: str) -> list[str]:
+    with open(path, "r", encoding="utf-8") as file:
+        return [line.rstrip("\n") for line in file if line.rstrip("\n")]
+
+
+def read_event(path: str) -> dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event", required=True, help="Path to the GitHub pull_request event JSON")
+    parser.add_argument("--changed-files", required=True, help="Newline-delimited changed-file list")
+    args = parser.parse_args()
+
+    event = read_event(args.event)
+    changed_paths = read_changed_paths(args.changed_files)
+
+    if not event_has_docs_only_label(event):
+        print("docs-only label is absent; docs-only scope guard is not enforcing this PR.")
+        return 0
+
+    blocked = prohibited_paths(changed_paths)
+    if not blocked:
+        print("docs-only label is present and all changed files are within permitted documentation scope.")
+        return 0
+
+    print("::error::docs-only PR modifies protected files or paths.")
+    print("The docs-only label permits documentation-only changes, but blocks runtime, executable, test, configuration, automation, workflow, and dependency files.")
+    print("Prohibited changed paths:")
+    for path in blocked:
+        print(f" - {path}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Prevent PRs labeled `docs-only` from accidentally changing runtime, executable, test, CI, configuration, or automation files while allowing documentation-only changes. 
- Provide an auditable, repo-maintainable guard that is simple to review and doesn't depend on opaque third-party changed-file actions. 
- Implement the follow-up to planning-only issue #33 as a CI/repository-safety change without touching Home Assistant runtime behavior. 

### Description
- Add a GitHub Actions workflow `/.github/workflows/docs-only-guard.yml` that triggers on `pull_request` events (`opened`, `synchronize`, `reopened`, `labeled`, `unlabeled`) and computes the complete changed-file list between PR base and head using `git diff --name-only` before running the guard. 
- Add an auditable guard script at `tools/docs_only_guard.py` that enforces checks only when the PR contains the exact `docs-only` label and reports every prohibited changed path on failure. 
- Protect common runtime/config/executable/test/workflow/dependency paths and suffixes including `*.yaml`, `*.yml`, `*.py`, `*.ps1`, `*.sh`, `configuration.yaml`, `automations.yaml`, `scripts.yaml`, `scenes.yaml`, `secrets.yaml`, `custom_components/**`, `packages/**`, `blueprints/**`, `tools/**`, `tests/**`, `.github/workflows/**`, and `requirements*.txt`, while permitting `docs/**`, Markdown, and docs assets. 
- Add focused unit tests at `tests/test_docs_only_guard.py` and document usage in `README.md` describing how to apply the `docs-only` label and what the guard permits and blocks. 

### Testing
- Ran the full test suite with `python -m pytest tests/` and observed all tests pass: `132 passed`.
- Ran the focused docs-only tests located at `tests/test_docs_only_guard.py` and confirmed they pass (`10 passed` when run individually). 
- Verified the workflow logic checks out PR head, fetches the base commit from the base repository, computes the changed-file list, and that the guard script returns non-zero and prints every prohibited path when a `docs-only` PR modifies protected files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2332df4b2c8323b82b1479d9491770)