### PR TITLE
Add secure CI guardrail for docs-only pull requests

### DIFF
--- a/.github/workflows/docs-only-guard.yml
+++ b/.github/workflows/docs-only-guard.yml
@@ -1,0 +1,48 @@
+name: Docs-only PR guard
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  docs-only-scope:
+    name: Enforce docs-only file scope
+    runs-on: ubuntu-latest
+
+    steps:
+      # Security boundary: pull_request_target runs the workflow from the base
+      # branch. Check out only the trusted base SHA; never execute code from the
+      # pull request head in this job.
+      - name: Check out trusted base revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Collect complete pull request changed-file list
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh api --paginate \
+            "repos/${GH_REPO}/pulls/${PR_NUMBER}/files?per_page=100" \
+            --jq '.[].filename' > changed-files.txt
+          echo "Changed files:"
+          cat changed-files.txt
+
+      - name: Enforce docs-only label scope
+        run: >-
+          python tools/docs_only_guard.py
+          --event "$GITHUB_EVENT_PATH"
+          --changed-files changed-files.txt

--- a/README.md
+++ b/README.md
@@ -77,3 +77,25 @@ If architecture assumptions are unclear:
 ```bash
 python -m pytest tests/
 ```
+
+## Docs-only pull request guardrail
+
+Pull requests intended to change documentation only should use the exact GitHub label `docs-only`. Apply the label from the pull request sidebar; the guard re-runs when the label is added or removed.
+
+When `docs-only` is present, CI obtains the complete changed-file list from the GitHub API and checks it using trusted code from the pull request's base branch. The guard never checks out or executes code from the pull request head.
+
+The guard permits Markdown documentation and documentation assets, including images stored beneath `docs/**`.
+
+It blocks files and paths that can affect Home Assistant runtime behavior, executable logic, tests, CI, configuration, automations, or dependencies, including:
+
+- `*.yaml` and `*.yml`
+- `*.py`, `*.ps1`, and `*.sh`
+- `configuration.yaml`, `automations.yaml`, `scripts.yaml`, `scenes.yaml`, and `secrets.yaml`
+- `custom_components/**`, `packages/**`, and `blueprints/**`
+- `tools/**` and `tests/**`
+- `.github/workflows/**`
+- dependency and executable configuration such as `requirements*.txt`, `pyproject.toml`, lock files, and `Dockerfile`
+
+If a docs-only PR touches any blocked path, the failed check prints every prohibited changed path. Remove the `docs-only` label or move runtime changes to a normal PR.
+
+Normal pull requests without the `docs-only` label are unaffected. This guard is a repository-safety scope check only and does not replace normal pytest CI.

--- a/tests/test_docs_only_guard.py
+++ b/tests/test_docs_only_guard.py
@@ -1,0 +1,109 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "docs_only_guard.py"
+spec = importlib.util.spec_from_file_location("docs_only_guard", MODULE_PATH)
+docs_only_guard = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = docs_only_guard
+spec.loader.exec_module(docs_only_guard)
+
+
+def event_with_labels(*labels: str) -> dict:
+    return {"pull_request": {"labels": [{"name": label} for label in labels]}}
+
+
+def test_markdown_only_pr_passes() -> None:
+    assert docs_only_guard.prohibited_paths(
+        ["README.md", "architecture/notes.md"]
+    ) == []
+
+
+def test_documentation_assets_under_docs_pass() -> None:
+    changed = [
+        "docs/v9_v10_goals.md",
+        "docs/assets/stack-effect.png",
+        "docs/diagrams/floorplan.svg",
+    ]
+    assert docs_only_guard.prohibited_paths(changed) == []
+
+
+def test_automations_yaml_fails() -> None:
+    assert docs_only_guard.prohibited_paths(
+        ["automations.yaml"]
+    ) == ["automations.yaml"]
+
+
+def test_nested_yaml_fails_even_under_docs() -> None:
+    changed = ["docs/examples/sample.yaml", "nested/config.yml"]
+    assert docs_only_guard.prohibited_paths(changed) == changed
+
+
+def test_python_powershell_and_shell_scripts_fail() -> None:
+    changed = [
+        "analysis/model.py",
+        "tools/export_ha_nuisance_evidence.ps1",
+        "scripts/check.sh",
+    ]
+    assert docs_only_guard.prohibited_paths(changed) == changed
+
+
+def test_tests_and_tools_paths_fail_regardless_of_extension() -> None:
+    changed = ["tests/test_yaml_syntax.txt", "tools/readme.md"]
+    assert docs_only_guard.prohibited_paths(changed) == changed
+
+
+def test_workflow_modifications_fail() -> None:
+    changed = [".github/workflows/docs-only-guard.yml"]
+    assert docs_only_guard.prohibited_paths(changed) == changed
+
+
+def test_dependency_and_executable_configuration_fails() -> None:
+    changed = [
+        "requirements-dev.txt",
+        "pyproject.toml",
+        "package-lock.json",
+        "Dockerfile",
+    ]
+    assert docs_only_guard.prohibited_paths(changed) == changed
+
+
+def test_multiple_changed_files_report_every_prohibited_path() -> None:
+    changed = [
+        "docs/overview.md",
+        "automations.yaml",
+        "custom_components/moose/__init__.py",
+        "requirements-dev.txt",
+        "README.md",
+        ".github/workflows/ci.yaml",
+    ]
+    code, output = docs_only_guard.run(event_with_labels("docs-only"), changed)
+    assert code == 1
+    for path in (
+        "automations.yaml",
+        "custom_components/moose/__init__.py",
+        "requirements-dev.txt",
+        ".github/workflows/ci.yaml",
+    ):
+        assert f" - {path}" in output
+    assert "docs/overview.md" not in output
+    assert "README.md" not in output
+
+
+def test_no_docs_only_label_means_guard_does_not_enforce() -> None:
+    code, output = docs_only_guard.run(
+        event_with_labels("bug", "documentation"),
+        ["automations.yaml"],
+    )
+    assert code == 0
+    assert "not enforcing" in output
+
+
+def test_exact_docs_only_label_enforces() -> None:
+    code, output = docs_only_guard.run(
+        event_with_labels("bug", "docs-only"),
+        ["automations.yaml"],
+    )
+    assert code == 1
+    assert "automations.yaml" in output

--- a/tools/docs_only_guard.py
+++ b/tools/docs_only_guard.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Guard docs-only pull requests from changing executable/runtime files."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+from pathlib import PurePosixPath
+from typing import Any, Iterable
+
+DOCS_ONLY_LABEL = "docs-only"
+
+PROTECTED_ROOT_FILES = {
+    "configuration.yaml",
+    "automations.yaml",
+    "scripts.yaml",
+    "scenes.yaml",
+    "secrets.yaml",
+    "pytest.ini",
+    "pyproject.toml",
+    "setup.cfg",
+    "tox.ini",
+    "dockerfile",
+    "makefile",
+}
+
+PROTECTED_PREFIXES = (
+    "custom_components/",
+    "packages/",
+    "blueprints/",
+    "tools/",
+    "tests/",
+    ".github/workflows/",
+)
+
+PROTECTED_SUFFIXES = (
+    ".yaml",
+    ".yml",
+    ".py",
+    ".ps1",
+    ".sh",
+)
+
+PROTECTED_GLOBS = (
+    "requirements*.txt",
+    "package*.json",
+    "*lock",
+)
+
+
+def normalize_path(path: str) -> str:
+    """Return a repository-relative POSIX path without leading './' segments."""
+    normalized = PurePosixPath(path.strip()).as_posix()
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def is_protected_path(path: str) -> bool:
+    """Return True when a changed path is outside docs-only PR scope."""
+    normalized = normalize_path(path)
+    lowered = normalized.lower()
+
+    if not normalized or normalized == ".":
+        return False
+    if lowered in PROTECTED_ROOT_FILES:
+        return True
+    if lowered.startswith(PROTECTED_PREFIXES):
+        return True
+    if lowered.endswith(PROTECTED_SUFFIXES):
+        return True
+
+    name = PurePosixPath(lowered).name
+    return any(fnmatch.fnmatchcase(name, pattern) for pattern in PROTECTED_GLOBS)
+
+
+def prohibited_paths(changed_paths: Iterable[str]) -> list[str]:
+    """Return every protected changed path, preserving input order."""
+    return [
+        path
+        for path in (normalize_path(item) for item in changed_paths)
+        if is_protected_path(path)
+    ]
+
+
+def event_has_docs_only_label(event: dict[str, Any]) -> bool:
+    """Return True when the pull request has the exact docs-only label."""
+    labels = event.get("pull_request", {}).get("labels", [])
+    return any(
+        isinstance(label, dict) and label.get("name") == DOCS_ONLY_LABEL
+        for label in labels
+    )
+
+
+def read_changed_paths(path: str) -> list[str]:
+    with open(path, "r", encoding="utf-8") as file:
+        return [line.rstrip("\n") for line in file if line.rstrip("\n")]
+
+
+def read_event(path: str) -> dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def run(event: dict[str, Any], changed_paths: Iterable[str]) -> tuple[int, str]:
+    """Evaluate the guard and return an exit code plus user-facing output."""
+    if not event_has_docs_only_label(event):
+        return 0, (
+            "docs-only label is absent; docs-only scope guard is not "
+            "enforcing this PR."
+        )
+
+    blocked = prohibited_paths(changed_paths)
+    if not blocked:
+        return 0, (
+            "docs-only label is present and all changed files are within "
+            "permitted documentation scope."
+        )
+
+    lines = [
+        "::error::docs-only PR modifies protected files or paths.",
+        (
+            "The docs-only label permits documentation-only changes, but "
+            "blocks runtime, executable, test, configuration, automation, "
+            "workflow, and dependency files."
+        ),
+        "Prohibited changed paths:",
+        *(f" - {path}" for path in blocked),
+    ]
+    return 1, "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--event",
+        required=True,
+        help="Path to the GitHub pull_request event JSON",
+    )
+    parser.add_argument(
+        "--changed-files",
+        required=True,
+        help="Newline-delimited changed-file list",
+    )
+    args = parser.parse_args()
+
+    code, output = run(read_event(args.event), read_changed_paths(args.changed_files))
+    print(output)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements the deferred CI follow-up from issue #33.

This pull request adds a `docs-only` scope guard that:

- runs on pull-request open, synchronize, reopen, label, and unlabel events;
- enforces only when the exact `docs-only` label is present;
- obtains the complete changed-file list through the GitHub API;
- prints every prohibited path before failing;
- leaves normal pull requests unaffected;
- preserves the existing pytest workflow.

## Security design

The guard uses `pull_request_target`, checks out only the trusted base SHA, and never checks out or executes code from the pull-request head. This prevents a docs-only PR from modifying the checker it is being evaluated by.

## Protected scope

The guard blocks runtime/configuration YAML, Python/PowerShell/shell files, tests, tools, workflows, custom components, packages, blueprints, dependency manifests, lock files, and executable configuration.

Markdown documentation and documentation assets remain permitted.

## Testing

- Focused guard tests: 11 passed locally.
- Full repository suite will run in GitHub Actions.

## Boundaries

- CI/repository-safety change only.
- Zero Home Assistant runtime behavior changes.
- No changes to `automations.yaml`, `configuration.yaml`, thresholds, truth math, setpoints, safety gates, helpers, or telemetry.
- Issue #33 was planning-only; this PR implements its deferred follow-up and should close #33 after merge.