### PR TITLE
Add Packet A design audit and contract tests for truth-unavailable cooling fail-safe

### DIFF
--- a/docs/audits/v8_3_supervisor_audit_2026-06-09.md
+++ b/docs/audits/v8_3_supervisor_audit_2026-06-09.md
@@ -1,0 +1,249 @@
+# V8.3 Four-Zone Cooling Supervisor — Architecture Audit
+
+**Audit date:** 2026-06-09
+**Scope:** Read-only audit pass (no runtime change). Evidence packet: Hermes
+"Opus Handoff" Blocks 1–5.
+**Primary subject:** `automation.v7_5_main_supervisor` — alias
+*"V8.3: Main Supervisor (Deadband Cooling + Heating)"* (`automations.yaml:358`).
+**Verdict:** **No runtime changes required.** The YAML correctly implements the
+verified cooling design. Two known, intentionally-deferred gaps are reconfirmed
+and one documentation/implementation mismatch is newly surfaced — all advisory.
+
+---
+
+## a) Design explanation — does the YAML implement the verified design?
+
+**Yes, for everything the supervisor actually owns.** The cooling branch matches
+the doctrine that `tests/test_section2_cooling_setpoint_doctrine.py` pins
+verbatim.
+
+### Cooling deadband + setpoint (Branch 1, `automations.yaml:401-492`)
+Per-zone logic, evaluated every run:
+
+```
+hvac_mode = cool      if  truth_temp >  on_at
+          = off       if  truth_temp <= off_at
+          = <hold>    otherwise   (keep prior cool/off state)
+temperature = 61      (always commanded)
+```
+
+- **61 °F stored target — CONFIRMED.** `m_setpoint = l_setpoint = ly_setpoint =
+  lr_setpoint = {{ 61 }}` (`automations.yaml:419,439,459,480`). The 61 °F command
+  is *actuator demand*, intentionally below the off threshold so the unit pulls
+  down decisively and shuts off on truth, not on a weak near-setpoint crawl
+  (design note `automations.yaml:393-397`).
+- **68 / 72 deadband — CONFIRMED for the normal (home) case**, but the handoff's
+  "uniform 68–72 across all four zones" is a **simplification**. The real,
+  test-locked thresholds are mode-dependent:
+
+  | Zone | off_at | on_at | Source |
+  |---|---|---|---|
+  | Living Room | `74 if away else 68` | `76 if away else 72` | `automations.yaml:481-482` |
+  | Lincoln | `74 if away else 68` | `76 if away else 72` | `automations.yaml:440-441` |
+  | Lilly | `74 if away else 68` | `76 if away else 72` | `automations.yaml:460-461` |
+  | Master | `74 if away else (62 if is_master_sleep else 68)` | `76 if away else (66 if is_master_sleep else 72)` | `automations.yaml:420-421` |
+
+  `is_master_sleep = now().hour >= 18 or now().hour < 6` (`automations.yaml:418`).
+  So Master runs a tighter **62/66 sleep band 18:00–06:00** and the standard
+  **68/72** during the day. This is intentional doctrine, not a defect
+  (test asserts these exact templates).
+
+- **Hysteresis / hold — CONFIRMED.** Between thresholds the zone holds its prior
+  state via `{% elif <x>_current == 'cool' %}cool {% else %}off`, reading the
+  live `climate.*_air` state. State-retention is genuine, not a universal
+  on/off.
+
+### Household-mode behavior
+- **Season gate — CONFIRMED.** Cooling commands live only inside the
+  `season == 'cooling'` branch (`automations.yaml:401-403`). `shoulder` and
+  `heating` are separate branches.
+- **Away — CONFIRMED as setback (not hard-off).** Away relaxes thresholds to
+  74/76 and keeps the 61 command; a zone still cools if truth > 76. (Handoff
+  Block 4 Test 7 allows "or setback per design" — this is the setback path.)
+- **Nest / Dining Room — CONFIRMED forced off.** First action of the cooling
+  branch is `climate.set_hvac_mode → climate.dining_room: off`
+  (`automations.yaml:406-408`). Dining Room is never sent a cool command
+  anywhere.
+
+### Items the handoff expected but the supervisor does *not* implement
+- **Night mode (LR):** `lr_night_primary` is computed (`automations.yaml:379`)
+  but in the **cooling** branch it is **unused**. It only changes behavior in
+  the **heating-season night** branch (`automations.yaml:625`). Handoff Test 9
+  ("night_mode_lr_primary modifies LR thresholds") therefore **does not apply to
+  cooling season** — no effect there.
+- **15-min compressor cooldown:** **Not implemented in the control path** — see
+  Finding 1 below.
+
+---
+
+## b) Entity dependency map
+
+### Supervisor reads (inputs)
+| Variable | Entity read | Default if unavailable |
+|---|---|---|
+| `outdoor` | `sensor.deck_temperature_truth` | `50` |
+| `lr_temp` | `sensor.living_room_temperature_truth` | `70` |
+| `master_temp` | `sensor.master_bedroom_temperature_truth` | `70` |
+| `lincoln_temp` | `sensor.lincoln_s_room_temperature_truth` | `70` |
+| `lilly_temp` | `sensor.lilly_s_room_temperature_truth` | `70` |
+| `season` | `input_select.hvac_season_mode` | — |
+| `away` | `input_boolean.away_mode` | — |
+| `lr_night_primary` | `input_boolean.night_mode_lr_primary` | — |
+| `*_current` | live `climate.*_air` state | — |
+| gate | `timer.manual_hvac_override` (must be `idle`) | condition fails ⇒ no run |
+
+### Supervisor writes (outputs)
+`climate.living_room_air`, `climate.master_bedroom_air`, `climate.lincoln_air`,
+`climate.lilly_air`, `climate.dining_room` (off-only in cooling).
+
+### Intermediate template entities (definitions in `configuration.yaml`)
+```
+Physical sensors
+  → sensor.*_temperature_truth        (weighted fusion, 7200 s staleness)   :243-270, etc.
+      → sensor.*_temperature_smoothed  (lowpass, time_constant=10, prec 2)   :1089-1143
+          → sensor.*_temperature_control (UI/"supervisor" wrapper)           :938-1006
+binary_sensor.*_heat_pump_firing       (template; state ≠ off/unavail)       :175-189
+timer.*_compressor_cooldown            (15 min helpers — defined, unused)    :123-138
+```
+**Critical routing fact:** the supervisor (and every Section 3 safety gate)
+reads **`sensor.*_temperature_truth` (raw truth)**. The `_smoothed` and
+`_control` layers are **not** in any automation's read path — they feed only the
+HA UI. (See Finding 3.)
+
+---
+
+## c) Failure modes that could affect equipment safety
+
+| # | Failure mode | Behavior | Severity | Likelihood |
+|---|---|---|---|---|
+| C1 | **Truth sensor `unavailable`/all-stale (>2 h) while a unit is cooling** | `float(70)` default ⇒ temp treated as 70 °F ⇒ supervisor **holds** current state (70 is inside the deadband). Simultaneously the runaway-60 °F and Master-floor-58 °F gates are `numeric_state` triggers that **cannot fire** on a non-numeric truth. Net: a cooling unit can keep running to its 61 °F demand with no truth-based shutoff until the sensor recovers. | Moderate | Low |
+| C2 | **No compressor anti-short-cycle interlock** (Finding 1) | Each 15-min tick may flip a zone off→cool→off if truth dances across a threshold; nothing enforces a minimum off-time at the supervisor. The 15-min tick cadence and lowpass smoothing on the *display* sensors are the only damping; the *control* sensor is raw truth (Finding 3), so the intended smoothing is not applied to control. | Low–Moderate | Low |
+| C3 | **Supervisor disabled / crashed** | Climate entities retain last commanded state (Samsung holds). Comfort updates stop, but the three independent Section 3 gates (runaway 60, Master floor 58, ceiling 76) and Ghost Assassin remain armed. No new unsafe command is issued. | Low | Low |
+| C4 | **Firing sensor unavailable** | No safety logic depends on `binary_sensor.*_heat_pump_firing`; they only feed runtime history_stats/telemetry. Control unaffected. | Negligible | Low |
+| C5 | **Manual-override helper missing/never idle** | Supervisor condition `timer.manual_hvac_override == idle` would be false ⇒ supervisor never acts. Helper is UI-defined (not in repo YAML — see Unknowns). | Moderate | Very low |
+
+None of C1–C5 is a *new* regression introduced by the current YAML; C1 and C2
+are inherent to the truth-default + no-cooldown design and are the most worth
+operator attention.
+
+---
+
+## d) Acceptance / failure-test results (Handoff Block 4)
+
+### Acceptance tests
+| # | Test | Result | Evidence |
+|---|---|---|---|
+| 1 | Deadband state-retention, all 4 zones | **PASS** | hold via `*_current` (`:429,449,469,490`) |
+| 2 | Off→Cool only when on-threshold satisfied | **PASS** | `temp > on_at` (`:427,447,467,488`) |
+| 3 | Cool→Off only when off-threshold satisfied | **PASS** | `temp <= off_at` |
+| 4 | Equality-boundary inspection | **PASS (documented)** | `> on_at` (strict) and `<= off_at` (inclusive). At **exactly off_at ⇒ OFF**; at **exactly on_at ⇒ HOLD**. Hold band is `(off_at, on_at]`. |
+| 5 | Dining Room forced off in cooling | **PASS** | `:406-408` |
+| 6 | Season gate (≠cooling ⇒ no cool) | **PASS** | branch guard `:402-403` |
+| 7 | Away mode | **PASS (setback, per design)** | 74/76 thresholds, not hard-off |
+| 8 | Compressor cooldown linkage | **FAIL — not implemented** | no automation references `timer.*_compressor_cooldown` (Finding 1) |
+| 9 | Night mode (LR) modifies LR | **N/A in cooling** | `lr_night_primary` only used in heating-night `:625` |
+
+### Failure-mode tests
+| # | Test | Result |
+|---|---|---|
+| 1 | Supervisor crash ⇒ no stuck-unsafe | **PASS** (gates independent; see C3) |
+| 2 | Firing sensor unavailable ⇒ still functions | **PASS** (C4) |
+| 3 | Truth stale >2 h rejected | **PARTIAL** — staleness *availability* logic is correct (`:248-257`), but the supervisor's `float(70)` fallback means a fully-unavailable truth sensor yields a "hold at 70" rather than a fail-to-safe-off (C1) |
+| 4 | Season toggled mid-cooling ⇒ cooling stops | **PASS** — `input_select` change is a trigger (`:364-365`); next evaluation leaves the cooling branch |
+| 5 | Away during cooling ⇒ zones off within a cycle | **PARTIAL/PASS** — away is *setback to 74/76*, not forced-off; zones below 74 do go off next tick |
+| 6 | Cooldown prevents forced restart | **FAIL — no cooldown enforcement** (Finding 1) |
+
+---
+
+## e) Findings & migration steps
+
+### Finding 1 — Compressor cooldown timers are orphaned (KNOWN / intentional)
+`timer.lr_/master_/lincoln_/lilly_compressor_cooldown` (15 min) are defined
+(`configuration.yaml:123-138`) but **no automation starts or checks them**
+(verified by repo-wide grep; only references are the definitions, the nuisance
+export list, and comments). The supervisor has **no minimum-off-time enforcement**.
+
+This is **already documented and intentionally deferred**, not a silent defect:
+- `docs/analysis/open_issue_v9_v10_validation.md:817` — "Compressor cooldown
+  timers are orphaned helpers … no automation references any of these timers."
+- `docs/6_proposals.md:16` — isolated 15-min per-unit cooldown timers are
+  **"design-only doctrine"** under V9, "does not weaken any existing Section 3
+  safety gate."
+- `docs/7_day_nuisance_evidence_plan.md` §M7 tracks reference-coverage.
+
+**Migration:** **None in this pass.** Wiring cooldown enforcement is V9 scope
+with its own design constraints (decoupled control loops, event-time accounting,
+`docs/event_telemetry_plan.md:481`). Implementing it here would exceed the audit
+objective and pre-empt the V9 decision. *Recommend:* leave as-is; let V9 own it.
+
+### Finding 2 — Handoff "uniform 68/72" understates Master's sleep/away bands
+Not a YAML defect — a packet simplification. The YAML's mode-dependent Master
+band (62/66 sleep, 68/72 day, 74/76 away) is correct and test-locked.
+**Migration:** None. (Operator doc note only: update the handoff's "verified
+topology" to reflect the Master sleep band so future audits don't flag a false
+discrepancy.)
+
+### Finding 3 — Supervisor reads raw `_truth`, not the documented `_control` wrapper (NEW)
+`configuration.yaml:36` and the Section 10 header (`:927-936`) state
+*"Smoothed output → control wrapper → V8.3 supervisor"* and that the wrappers
+exist *"so the V8.3 supervisor … can manage them."* In fact the supervisor reads
+`sensor.*_temperature_truth` directly (`automations.yaml:373-376`); the
+`_smoothed` (lowpass) and `_control` layers feed only the UI. The stated
+short-cycling benefit of smoothing (`truth_sensor_architecture.md:106-121`) is
+therefore **not applied to control decisions**.
+
+This is a **documentation/implementation mismatch**, and it means the only
+control-loop damping is the 15-min tick cadence (Finding 1 / C2).
+**Migration options (DEFERRED — do not apply without operator decision):**
+- *(Doc-only, low risk)* Correct the `configuration.yaml` comments to say the
+  control/smoothed wrappers are **UI-only** and the supervisor consumes raw
+  truth; or
+- *(Behavioral, NOT this pass)* Repoint the supervisor reads to
+  `sensor.*_temperature_control` to actually engage smoothing. This **changes
+  control behavior** and regression comparability and must go through the
+  evidence/telemetry process — out of scope for an audit pass.
+
+---
+
+## f) Rollback
+
+No runtime files were modified by this audit (docs-only). If any of the deferred
+migrations above are later applied:
+1. Git backup confirmed present (clean tree at audit time; supervisor unchanged).
+2. Pre-change supervisor logic captured above and in trace
+   `run_id 2cc51682fc628808ecb3a00c6b499204` (Handoff Block 2).
+3. Revert any change with `git checkout -- automations.yaml configuration.yaml`
+   (or restore the corresponding lines) and re-run `python -m pytest tests/`.
+4. Confirm `tests/test_section2_cooling_setpoint_doctrine.py` and
+   `tests/test_safety_invariants.py` pass post-rollback.
+
+---
+
+## g) Codex implementation prompt
+
+**No changes required — audit complete.**
+
+The V8.3 supervisor accurately implements the verified cooling design (68/72
+deadband with documented Master sleep/away bands, 61 °F stored target,
+hysteresis state-retention, season/away gating, Dining Room forced-off). The
+only non-conformances to the handoff's expectations are:
+- the 15-min compressor cooldown (Finding 1) — **knowingly orphaned, V9-deferred
+  by existing doctrine**; and
+- the smoothing/control-wrapper read path (Finding 3) — a **documentation**
+  mismatch.
+
+Neither warrants a Codex change in an audit pass. If the operator later elects to
+act on Finding 3's doc-only correction or any V9 cooldown work, that requires a
+separate, explicitly-approved change request with before/after telemetry — not an
+audit deliverable.
+
+---
+
+## Unknowns — NOT silently resolved
+| Unknown | Why | What would resolve it |
+|---|---|---|
+| `input_select.hvac_season_mode` option list, `input_boolean.away_mode/night_mode_lr_primary`, `timer.manual_hvac_override` definitions | UI/storage helpers — not in repo YAML | Read live HA `.storage` / helper registry |
+| Handoff `automation.v7_5_main_supervisor_rev_b` vs actual id `v7_5_main_supervisor` | "_rev_b" suffix not in repo | Confirm live entity_id in HA |
+| Trace generic var names `_off_at/_on_at/_current` vs YAML `m_/l_/ly_/lr_` | Handoff likely normalized names; values (61/68/72) match | Compare raw trace JSON to YAML var names |
+| Lincoln 0.35 °F gap (truth 71.77 vs trace 71.42) | Most likely temporal (truth updated between trace and read), **not** smoothed-vs-raw since control reads raw truth (Finding 3) | Time-aligned truth history at trace timestamp |
+| Master/Lilly presence sensors, `is_master_sleep` "presence" | `is_master_sleep` is purely time-based (`hour>=18 or <6`), no presence entity involved | n/a — resolved: time-based |

--- a/docs/packets/packetA_truth_unavailable_failsafe.md
+++ b/docs/packets/packetA_truth_unavailable_failsafe.md
@@ -9,10 +9,18 @@ enforcement (V9 backlog), thresholds, the 61 °F target, or hardware. Proposed
 YAML is illustrative and must not be committed to `automations.yaml` /
 `configuration.yaml` until separately approved.
 
-**Status (2026-06-09):** All three design decisions **APPROVED** (see §Decisions).
-Static contract tests added in `tests/test_packetA_truth_unavailable_failsafe.py`
-— implementation-facing checks are `xfail(strict=False)` until Codex applies the
-runtime change; healthy-state/doctrine checks pass now and must stay green.
+**Status (2026-06-09, pass 2 — hardened):** All three design decisions
+**APPROVED** (see §Decisions). Pass-2 hardening applied: (1) event validity now
+covers **any** non-numeric truth via a shared `float(none) is none` definition
+matching the supervisor guard; (2) a restart/reload-safe **reconciliation**
+automation (§3c) closes the `for:`-reset blind spot; (3) the test gate is
+**enforceable** (a normal-priority gate test fails the suite if the guard is
+implemented but `xfail` markers remain); (4) the notifier is **non-blocking** and
+must be verified, never gating the protective OFF.
+Contract tests: `tests/test_packetA_truth_unavailable_failsafe.py` — **design-only
+baseline: 136 passed, 14 xfailed** (3 Packet A pass now; 14 `xfail(strict=False)`
+until implemented). **Expected post-implementation: 150 passed, 0 xfailed, 0
+xpassed** once Codex applies the YAML and removes the markers.
 
 ---
 
@@ -149,6 +157,12 @@ the variables checked by `test_section2_cooling_setpoint_doctrine.py` (it assert
 green.
 
 ### 3b. Event protective-OFF automation (new block — DO NOT APPLY)
+
+Uses **template triggers**, not `state … to: [unavailable, unknown]`, so the
+validity test matches the supervisor guard **exactly** and catches **any**
+non-numeric value (e.g. a stray `"err"`/`"NaN"` string), not only the two known
+states. Shared validity definition (truth is INVALID iff):
+`{{ not has_value(<truth>) or states(<truth>) | float(none) is none }}`.
 ```yaml
 # DO NOT APPLY — illustrative new automation
 - id: v8_6_truth_unavailable_cooling_failsafe
@@ -156,24 +170,28 @@ green.
   mode: parallel
   max: 4
   trigger:
-    - platform: state
-      entity_id: sensor.living_room_temperature_truth
-      to: ["unavailable", "unknown"]
+    - platform: template
+      value_template: >-
+        {{ not has_value('sensor.living_room_temperature_truth')
+           or states('sensor.living_room_temperature_truth') | float(none) is none }}
       for: "00:02:00"
       id: climate.living_room_air
-    - platform: state
-      entity_id: sensor.master_bedroom_temperature_truth
-      to: ["unavailable", "unknown"]
+    - platform: template
+      value_template: >-
+        {{ not has_value('sensor.master_bedroom_temperature_truth')
+           or states('sensor.master_bedroom_temperature_truth') | float(none) is none }}
       for: "00:02:00"
       id: climate.master_bedroom_air
-    - platform: state
-      entity_id: sensor.lincoln_s_room_temperature_truth
-      to: ["unavailable", "unknown"]
+    - platform: template
+      value_template: >-
+        {{ not has_value('sensor.lincoln_s_room_temperature_truth')
+           or states('sensor.lincoln_s_room_temperature_truth') | float(none) is none }}
       for: "00:02:00"
       id: climate.lincoln_air
-    - platform: state
-      entity_id: sensor.lilly_s_room_temperature_truth
-      to: ["unavailable", "unknown"]
+    - platform: template
+      value_template: >-
+        {{ not has_value('sensor.lilly_s_room_temperature_truth')
+           or states('sensor.lilly_s_room_temperature_truth') | float(none) is none }}
       for: "00:02:00"
       id: climate.lilly_air
   condition:
@@ -182,24 +200,84 @@ green.
     - condition: template
       value_template: "{{ is_state(trigger.id, 'cool') }}"
   action:
+    # Protective OFF FIRST — it must not depend on any notification succeeding.
     - action: climate.set_hvac_mode
       target: { entity_id: "{{ trigger.id }}" }
       data: { hvac_mode: "off" }
-    - action: notify.notify
+    # Notification is SECONDARY and non-blocking. continue_on_error guarantees a
+    # missing/failed notifier cannot invalidate the protective OFF above.
+    # Codex must verify the live notify service (see §10); if none is approved,
+    # drop this step entirely — the OFF action stands alone.
+    - action: notify.notify          # VERIFY-OR-REPLACE (non-blocking)
+      continue_on_error: true
       data:
         title: "🌡️⚠️ Truth-Unavailable Cooling Fail-Safe"
         message: >
-          {{ trigger.id }} forced OFF — its truth sensor went
-          unavailable/unknown for >2 min while the unit was cooling.
-          Truth-based safety gates (runaway/floor/ceiling) are blind until
-          the sensor recovers. Investigate the sensor/integration; the V8.3
-          supervisor will resume control automatically on recovery.
+          {{ trigger.id }} forced OFF — its truth input was invalid
+          (unavailable/unknown/non-numeric) for >2 min while the unit was
+          cooling. Truth-based safety gates are blind until recovery. The V8.3
+          supervisor resumes control automatically once truth is numeric again.
 ```
 Notes: `mode: parallel, max: 4` keeps zones independent; the automation **only
 ever commands OFF** (never `cool`); commands carry an automation context so the
-`v7_5_waf_manual_override` watcher (which requires `context.parent_id is none`)
-is **not** tripped. If the climate entity is already `off`/`heat`/`unavailable`,
-the `cool`-only condition skips it (no needless command).
+`v7_5_waf_manual_override` watcher (requires `context.parent_id is none`) is
+**not** tripped. The `cool`-only condition skips units already `off`/`heat`.
+**`for: "00:02:00"` resets on automation reload / HA restart — §3c covers that.**
+
+### 3c. Restart / reload reconciliation (new block — DO NOT APPLY)
+
+HA template (and `for:`) edges are **not** re-fired for a condition that was
+already true before an automation reload or HA restart — a sensor already
+invalid across that boundary would otherwise sit in a blind spot until the
+15-min supervisor tick. This automation closes that gap with two restart-safe
+triggers and an all-zone sweep. **Chosen approach: `homeassistant` start trigger
+(with a bounded settle delay) + a periodic reconciliation sweep.** Rationale:
+the start trigger handles HA restart promptly; the periodic `time_pattern`
+handles **automation reload** (which fires no start event) and bounds any blind
+spot to ≤5 min — tighter than the 15-min supervisor backstop, which remains the
+final scheduled guard.
+```yaml
+# DO NOT APPLY — illustrative new automation
+- id: v8_6b_truth_unavailable_cooling_reconciliation
+  alias: "V8.6b: Truth-Unavailable Cooling Reconciliation (Restart/Reload Safe)"
+  mode: single
+  trigger:
+    - platform: homeassistant
+      event: start
+      id: reconcile_start
+    - platform: time_pattern
+      minutes: "/5"
+      id: reconcile_periodic
+  action:
+    # On HA start, let sensors report before judging validity (avoid startup
+    # false-positives from briefly-unavailable entities). Periodic runs: no wait.
+    - choose:
+        - conditions: "{{ trigger.id == 'reconcile_start' }}"
+          sequence:
+            - delay: "00:03:00"
+    # Sweep all four zones; force OFF any unit cooling while its truth is invalid.
+    # Per-item condition preserves four-zone independence. OFF-only.
+    - repeat:
+        for_each:
+          - { truth: sensor.living_room_temperature_truth,    climate: climate.living_room_air }
+          - { truth: sensor.master_bedroom_temperature_truth, climate: climate.master_bedroom_air }
+          - { truth: sensor.lincoln_s_room_temperature_truth, climate: climate.lincoln_air }
+          - { truth: sensor.lilly_s_room_temperature_truth,   climate: climate.lilly_air }
+        sequence:
+          - if:
+              - condition: template
+                value_template: >-
+                  {{ is_state(repeat.item.climate, 'cool')
+                     and (not has_value(repeat.item.truth)
+                          or states(repeat.item.truth) | float(none) is none) }}
+            then:
+              - action: climate.set_hvac_mode
+                target: { entity_id: "{{ repeat.item.climate }}" }
+                data: { hvac_mode: "off" }
+```
+The reconciliation also covers "**reload mid-persistence**": if a reload resets a
+pending 2-min `for:` timer, the next periodic sweep (≤5 min) forces OFF a
+cooling+invalid zone. No persistent inhibit helpers are required.
 
 ---
 
@@ -237,7 +315,14 @@ Diagnostic-only (NOT used here): binary_sensor.*_heat_pump_firing, sensor.*_temp
   (their limitation, not a new conflict) and re-arm on recovery. Fail-safe
   complements them by covering exactly the blind window.
 - **`mode` choices:** fail-safe `parallel/max:4` → no cross-zone queueing.
-  Supervisor stays `single`.
+  Supervisor stays `single`; reconciliation `single`.
+- **Reconciliation (`v8_6b`) vs event fail-safe vs supervisor:** all three only
+  ever command **OFF** on a cooling+invalid zone, so they converge — no opposing
+  commands. Reconciliation exists solely to cover the restart/reload boundary
+  where the event automation's `for:` edge is not re-fired; it shares the exact
+  `float(none) is none` validity test, so it never disagrees about validity. Its
+  start-path settle `delay` prevents startup-unavailable false positives; its
+  `/5` sweep bounds the reload blind spot below the 15-min supervisor backstop.
 
 ---
 
@@ -259,17 +344,46 @@ Diagnostic-only (NOT used here): binary_sensor.*_heat_pump_firing, sensor.*_temp
 
 ## 7. Tests
 
-### 7a. Static (repo-style, pytest over parsed YAML — proposed)
-- `test_truth_unavailable_failsafe_present`: automation
-  `v8_6_truth_unavailable_cooling_failsafe` exists; 4 state triggers to
-  `['unavailable','unknown']` with `for >= 60s`, each `id` = a `climate.*_air`;
-  condition gates on `is_state(trigger.id,'cool')`; action sets
-  `hvac_mode: off`; **no** action sets `cool`.
-- `test_supervisor_truth_guard_present`: top variables define
-  `lr_/master_/lincoln_/lilly_truth_ok` using `has_value(...)`; each cooling
-  `hvac_mode` template begins with `{% if not <zone>_truth_ok %}off`.
-- `test_doctrine_unchanged`: `test_section2_cooling_setpoint_doctrine.py` still
-  green (thresholds/targets untouched).
+### 7a. Static + behavioral (implemented: `tests/test_packetA_truth_unavailable_failsafe.py`)
+17 tests. **3 pass now and must stay green**; **14 are `xfail(strict=False)`**
+until the runtime change lands (Codex removes the marks at implementation).
+
+*Always-green (doctrine / enforcement gate):*
+- `test_healthy_state_doctrine_unchanged` — setpoints 61, thresholds, away,
+  Master sleep band all unchanged.
+- `test_healthy_deadband_behavior_unchanged` — renders the Master template:
+  `>on_at`→cool, `<=off_at`→off, else HOLD, with healthy truth.
+- `test_packet_a_xfail_markers_removed_once_implemented` — **enforceable gate.**
+  If the supervisor guard is present in YAML (implemented) it asserts **zero**
+  `xfail` markers remain in this module; in design phase it asserts the markers
+  are present. This fails the suite if YAML is implemented but markers are left
+  (the dangerous strict=False XPASS state).
+
+*xfail until implemented — supervisor guard:*
+- `test_supervisor_defines_per_zone_truth_ok` — each `*_truth_ok` uses
+  **`has_value` AND `float(none)`** (shared validity; rejects non-numeric).
+- `test_cooling_hvac_templates_guard_unavailable_before_cool`,
+  `test_unavailable_truth_forces_off_each_zone` (behavioral render),
+  `test_master_sleep_unavailable_cannot_create_cool` (behavioral render).
+
+*xfail until implemented — event fail-safe:*
+- `test_event_failsafe_present_per_zone_validity_triggers` — **template**
+  triggers, one per zone, `id` = climate entity, `for` = 2 min.
+- `test_event_failsafe_validity_covers_non_numeric` — trigger templates contain
+  `float(none) is none` (arbitrary non-numeric, not just unavailable/unknown).
+- `test_event_failsafe_two_minute_persistence`,
+  `test_event_failsafe_only_commands_off_and_gates_on_cooling`,
+  `test_event_failsafe_ignores_manual_override`,
+  `test_event_failsafe_recovery_never_turns_cooling_on`.
+- `test_protective_off_not_blocked_by_notification` — climate OFF precedes any
+  notify, and any notify carries `continue_on_error: true`.
+
+*xfail until implemented — restart/reload reconciliation:*
+- `test_reconciliation_present_restart_and_reload_safe` — `v8_6b…` has a
+  `homeassistant` **start** trigger **and** a `time_pattern` trigger.
+- `test_reconciliation_startup_settle_delay` — start path has a bounded `delay`.
+- `test_reconciliation_off_only_all_zones_on_invalid_truth` — sweeps all four
+  zones, OFF-only, gated on `cool` + invalid truth.
 
 ### 7b. Acceptance (runtime / trace — operator-executed)
 | # | Scenario | Expected |
@@ -360,36 +474,61 @@ Diagnostic-only (NOT used here): binary_sensor.*_heat_pump_firing, sensor.*_temp
 >    remain byte-identical otherwise. Result: unavailable/non-numeric truth ⇒
 >    that zone is commanded OFF (never COOL, never HOLD-on-stale).
 > 5. **Add the event automation** `v8_6_truth_unavailable_cooling_failsafe`
->    exactly per design §3b: `mode: parallel, max: 4`; four `state` triggers, one
->    per `sensor.*_temperature_truth`, `to: ['unavailable','unknown']`,
->    `for: "00:02:00"`, `id:` = the matching `climate.*_air`; condition
->    `is_state(trigger.id,'cool')`; action `climate.set_hvac_mode` →
->    `hvac_mode: off` on `{{ trigger.id }}` + a `notify.notify`. It must have
->    **no** condition referencing `timer.manual_hvac_override`, and **no** action
->    that issues `cool` or otherwise restores cooling.
-> 6. **Configuration validation:** run `ha core check` (HAOS) — must be clean.
-> 7. **Repository tests:** run the full suite `python -m pytest tests/`. All
->    previously-green tests stay green; the Packet A `xfail` contract tests in
->    `tests/test_packetA_truth_unavailable_failsafe.py` must now **xpass/pass**.
->    (Once confirmed, flip them from `xfail(strict=False)` to plain asserts.)
-> 8. **Reload minimally if safe:** reload the `automation` domain (and `template`
->    only if touched — it is not in this packet). If a full restart is required
->    in your environment, state that instead of forcing a reload.
-> 9. **Verify via traces, not by endangering rooms:** inspect the supervisor
->    trace to confirm the guard path renders `off` for a simulated
->    unavailable/non-numeric truth and that healthy-truth traces are unchanged;
->    confirm the fail-safe automation registers its four triggers. Do **not**
->    physically force a real sensor offline in a way that leaves an occupied room
->    unsafe. Capture `run_id`s.
-> 10. **Exact rollback (if any step fails or review rejects):**
->     `git checkout -- automations.yaml` (discard the guard + new automation), or
->     `git revert <checkpoint-range>` if already committed; re-run
->     `python -m pytest tests/` and `ha core check`; reload the `automation`
->     domain; confirm the supervisor trace shows the original `float(70)` path.
+>    exactly per design §3b: `mode: parallel, max: 4`; **four `template`
+>    triggers** (NOT `state … to:[unavailable,unknown]`), one per zone, each
+>    `value_template: {{ not has_value(<truth>) or states(<truth>) | float(none)
+>    is none }}`, `for: "00:02:00"`, `id:` = the matching `climate.*_air`. This
+>    validity definition must be **byte-identical in meaning** to the supervisor
+>    guard so no non-numeric string is rejected by one path but missed by the
+>    other. Condition `is_state(trigger.id,'cool')`. Action: **`climate.set_hvac_mode
+>    off` FIRST**, then an optional notification that is **non-blocking**
+>    (`continue_on_error: true`) and **secondary** — the OFF must never depend on
+>    it. **No** condition referencing `timer.manual_hvac_override`; **no** action
+>    issuing `cool` or restoring cooling.
+> 6. **Notifier — do not hard-code an unverified service.** Before using
+>    `notify.notify`, confirm an approved notify service exists in the live
+>    config (it is used elsewhere in `automations.yaml`, but verify it resolves).
+>    If verified, keep it with `continue_on_error: true`. If not, **omit the
+>    notify step entirely** — the protective OFF action stands alone.
+> 7. **Add the reconciliation automation** `v8_6b_truth_unavailable_cooling_reconciliation`
+>    exactly per design §3c: triggers = `homeassistant` `event: start` **and**
+>    `time_pattern minutes:"/5"`; on the start path apply a bounded settle
+>    `delay: "00:03:00"` (avoid startup false-positives) before sweeping; then a
+>    `repeat.for_each` over the four `{truth, climate}` pairs forcing
+>    `hvac_mode: off` only where `is_state(climate,'cool')` **and** truth is
+>    invalid. OFF-only; preserves four-zone independence; **no** inhibit helpers.
+> 8. **Configuration validation:** run `ha core check` (HAOS) — must be clean.
+> 9. **Make the test gate enforceable — in this order:**
+>    a. implement the YAML (steps 3–7);
+>    b. **remove all `xfail` markers** in
+>       `tests/test_packetA_truth_unavailable_failsafe.py` (do not leave any);
+>    c. run the full suite `python -m pytest tests/ -rA`;
+>    d. **require every Packet A test to PASS as a normal assertion** — there must
+>       be **zero Packet A XFAIL and zero Packet A XPASS**. A green pytest exit
+>       with remaining XPASS/XFAIL is **not** acceptance. The
+>       `test_packet_a_xfail_markers_removed_once_implemented` gate will itself
+>       fail the suite if markers remain after the guard is implemented.
+>    Expected final result (no unrelated test-count changes): **150 passed, 0
+>    xfailed, 0 xpassed** (design-only baseline is 136 passed + 14 xfailed; the 14
+>    convert to passes once implemented and un-marked).
+> 10. **Reload minimally if safe:** reload the `automation` domain. The
+>     reconciliation start-trigger only re-arms on a full HA restart; if your
+>     environment requires a restart to register it, state that rather than
+>     forcing one.
+> 11. **Verify via traces, not by endangering rooms:** confirm the supervisor
+>     trace renders `off` for a simulated invalid truth and is unchanged for
+>     healthy truth; confirm `v8_6_…` registers four template triggers and
+>     `v8_6b_…` its start + periodic triggers. Do **not** force a real sensor
+>     offline in a way that leaves an occupied room unsafe. Capture `run_id`s.
+> 12. **Exact rollback (on any failure/rejection):** `git checkout --
+>     automations.yaml tests/test_packetA_truth_unavailable_failsafe.py` (or
+>     `git revert <checkpoint-range>` if committed); re-run `python -m pytest
+>     tests/` and `ha core check`; reload the `automation` domain; confirm the
+>     trace shows the original `float(70)` path restored.
 >
 > Do not merge or deploy without operator sign-off. Produce a diff for review
-> first; report files changed, `ha core check` output, full pytest results, and
-> the verifying `run_id`s.
+> first; report files changed, `ha core check` output, full pytest results
+> (showing 0 XFAIL/0 XPASS for Packet A), and the verifying `run_id`s.
 
 ---
 

--- a/docs/packets/packetA_truth_unavailable_failsafe.md
+++ b/docs/packets/packetA_truth_unavailable_failsafe.md
@@ -1,0 +1,378 @@
+# Packet A — Design Audit: Truth Sensor Unavailable During Active Cooling
+
+**Type:** Design / engineering audit. **Read-only — DO NOT APPLY.**
+**Date:** 2026-06-09  **Branch:** `claude/compassionate-davinci-8ly5pv`  **PR:** #135
+**Audit provenance:** `docs/audits/v8_3_supervisor_audit_2026-06-09.md`
+**Scope guard:** This packet designs the sensor-loss fail-safe **only**. It does
+**not** touch raw-vs-smoothed/control input (Packet B), compressor cooldown
+enforcement (V9 backlog), thresholds, the 61 °F target, or hardware. Proposed
+YAML is illustrative and must not be committed to `automations.yaml` /
+`configuration.yaml` until separately approved.
+
+---
+
+## 0. Audit source verification
+
+Verified directly against the repository (not inferred from live HA):
+
+- Supervisor `v7_5_main_supervisor`, alias *"V8.3: Main Supervisor"*
+  (`automations.yaml:358`), `mode: single`, trigger `time_pattern /15` + state
+  change on `input_select.hvac_season_mode` (`:361-365`), gated on
+  `timer.manual_hvac_override == idle` (`:366-369`).
+- Inputs read **raw** `sensor.*_temperature_truth` with `float(70)` fallback,
+  no unavailable handling (`automations.yaml:372-376` — re-read 2026-06-09).
+- Cooling deadband + operators per zone (`:417-492`), thresholds test-locked by
+  `tests/test_section2_cooling_setpoint_doctrine.py` (9/9 green).
+- Truth-based safety gates are `numeric_state` triggers: LR runaway 60 °F
+  (`:737-753`), Master floor 58 °F (`:778-792`), ceiling 76 °F (`:810-856`).
+- Repo automation IDs: `v8_2_lr_runaway_cooling_cutoff`,
+  `v8_2_master_emergency_floor`. The packet's live entity IDs
+  (`…_lr_equipment_protection_2`, `…master_emergency_cooling_floor`) are
+  HA-registry slugs; the `_2` suffix implies a duplicate registration to confirm
+  live (see Unknowns).
+
+## 0.1 Failure mode — arithmetic confirmed
+
+When a zone's truth is `unavailable`/`unknown`, `states()` returns a non-numeric
+string and `| float(70)` yields **70**. Per operating band:
+
+| Mode (not away) | off_at / on_at | 70 vs band | Supervisor result | Hazard |
+|---|---|---|---|---|
+| Standard (LR/Lincoln/Lilly, Master day) | 68 / 72 | between | **HOLD prior state** | False HOLD — cooling persists with no truth shutoff |
+| Master sleep 18:00–06:00 | 62 / 66 | above on_at | **COOL** | False COOL — spurious cooling created |
+| Away | 74 / 76 | ≤ off_at | **OFF** | False OFF — masks the fault, but unit stops |
+
+Compounding hazard: every truth-based safety gate (`numeric_state` on the same
+truth entity) is **inert** while that entity is non-numeric. During a truth
+outage the supervisor may HOLD/COOL **and** the 60/58/76 °F gates cannot fire —
+cooling toward the 61 °F demand has **no truth-based shutoff** until recovery.
+Classification: **likelihood Low, severity Moderate, no observed incident.**
+
+---
+
+## 1. Recommended design + rationale
+
+**Two coordinated, additive parts — Design 1 (recommended):**
+
+**(1a) Supervisor per-zone truth-validity guard (tick-level correctness).**
+Before the deadband comparison, compute a per-zone `*_truth_ok` flag and, when
+false, force a protective decision (**never COOL; drop active cooling to OFF**).
+This eliminates the `float(70)` false-HOLD and false-COOL paths at every 15-min
+tick and is per-zone independent.
+
+**(1b) Event-triggered protective-OFF automation (speed + cross-season).**
+A new dedicated automation triggers on each truth entity transitioning to
+`unavailable`/`unknown` (short debounce via `for:`), and if the matching climate
+entity is `cool`, forces it OFF — **regardless of season**, **never creating a
+cooling command**.
+
+**Why both, and why this is the safest default:**
+- The supervisor guard alone is **tick-bound** (≤15 min, and only inside the
+  cooling branch). It cannot meet "act sooner" or cross-season protection.
+- The event automation alone races the supervisor: in **Master sleep**, an
+  unguarded supervisor re-issues COOL every tick (false-COOL), fighting the
+  fail-safe's OFF → oscillation. The guard removes that re-cool, so the two
+  **only ever drive toward OFF** when truth is bad — **no conflicting commands.**
+- Both are **per-zone independent** (one failed sensor never touches the other
+  three). When truth is healthy, behavior is **byte-for-byte unchanged**, so
+  regression comparability is preserved.
+- **Recovery authority stays with the V8.3 supervisor**: the fail-safe never
+  turns anything ON. When truth becomes numeric again, the guard passes and the
+  supervisor resumes on its next trigger, subject to all existing gates.
+
+**Debounce = `for: "00:02:00"` (justified).** The truth `availability` template
+only goes false when **every** contributor is stale (>7200 s) or absent
+(`configuration.yaml:248-257`), so a genuine `unavailable` is already a sustained
+fault, not a value blip. The 2-minute window exists mainly to ride out **HA
+restart / integration reload**, where entities are briefly `unavailable` before
+first report. 2 min of extra cooling is acceptable because this fail-safe is the
+*only* live protection during the outage and is far inside the 60 °F runaway
+margin. A 60 s alternative is offered for operators who prefer faster action.
+
+**Manual-override interaction (decision surfaced).** Recommend the protective-OFF
+fires **regardless of `timer.manual_hvac_override`**, matching the runaway/floor
+equipment-protection precedent (those gates do **not** check override), since the
+hazard is unbounded cooling with no shutoff. Flagged as a decision point (§Open).
+
+---
+
+## 2. Options comparison (all five required)
+
+| Option | Time to protective OFF | False-shutdown risk | Recovery | Race risk | Restart behavior | Helpers/timers | Supervisor-fail behavior | Flapping behavior | Std / Sleep / Away |
+|---|---|---|---|---|---|---|---|---|---|
+| **1. Immediate forced OFF** (no debounce) | seconds | Higher (HA-restart blips trip it) | Supervisor resumes | Low (with guard) | None (never restarts) | none | Still protects (independent automation) | Can fire on every blip | Off in all; guard stops re-cool |
+| **2. Debounce → forced OFF** *(recommended, with guard)* | ~2 min | Low (rides out restarts) | Supervisor resumes | **None** (both drive OFF) | None | none (guard inline) | Still protects | Bounded by `for:`+15-min cadence | Correct in all three |
+| **3. Timeout-degraded → OFF** | up to N min running "blind" | Low | Supervisor resumes | Low | None | 1 timer/zone | Protects after timeout | Timer churn | Allows blind cooling during timeout — weaker |
+| **4. Alert-only** | never (human) | n/a | Manual | n/a | n/a | none | **No protection** | n/a | **Rejected** — leaves the hazard live |
+| **5. Per-zone inhibit helper** | event speed | Low | Supervisor resumes when inhibit clears | Low | None | 4 `input_boolean` | Protects | Helper toggle churn | Needs supervisor to read inhibit; +4 helpers |
+
+**Selected: Option 2 + supervisor guard.** Option 4 rejected (no protection).
+Option 3 rejected (intentionally permits blind cooling). Option 5 is the viable
+**alternative (Design 2)** if the operator prefers not to edit the supervisor's
+hvac_mode templates — but it adds 4 helpers and still requires a supervisor read,
+so it is more moving parts for the same outcome.
+
+---
+
+## 3. Proposed YAML / pseudocode — **DO NOT APPLY**
+
+### 3a. Supervisor guard (illustrative edit to `automations.yaml`)
+Add per-zone validity flags to the top variables block (`:371-380`):
+```yaml
+# DO NOT APPLY — illustrative
+lr_truth_ok:      "{{ has_value('sensor.living_room_temperature_truth')   and states('sensor.living_room_temperature_truth')   | float(none) is not none }}"
+master_truth_ok:  "{{ has_value('sensor.master_bedroom_temperature_truth') and states('sensor.master_bedroom_temperature_truth') | float(none) is not none }}"
+lincoln_truth_ok: "{{ has_value('sensor.lincoln_s_room_temperature_truth') and states('sensor.lincoln_s_room_temperature_truth') | float(none) is not none }}"
+lilly_truth_ok:   "{{ has_value('sensor.lilly_s_room_temperature_truth')   and states('sensor.lilly_s_room_temperature_truth')   | float(none) is not none }}"
+```
+Then prepend a guard to each zone's cooling `hvac_mode` template (Master shown;
+LR/Lincoln/Lilly identical pattern):
+```yaml
+# DO NOT APPLY — illustrative (Master, cf. automations.yaml:426-431)
+hvac_mode: >-
+  {% if not master_truth_ok %}off
+  {% elif master_temp > m_on_at %}cool
+  {% elif master_temp <= m_off_at %}off
+  {% elif m_current == 'cool' %}cool
+  {% else %}off{% endif %}
+```
+`has_value()` returns false for `unknown`/`unavailable`; the `float(none) is not
+none` clause also rejects any other non-numeric. When `*_truth_ok` is true the
+template is unchanged → **healthy behavior identical**. This does **not** alter
+the variables checked by `test_section2_cooling_setpoint_doctrine.py` (it asserts
+`*_setpoint`/`*_off_at`/`*_on_at`, not the hvac_mode string), so that suite stays
+green.
+
+### 3b. Event protective-OFF automation (new block — DO NOT APPLY)
+```yaml
+# DO NOT APPLY — illustrative new automation
+- id: v8_6_truth_unavailable_cooling_failsafe
+  alias: "V8.6: Truth-Unavailable Cooling Fail-Safe (Per-Zone Protective OFF)"
+  mode: parallel
+  max: 4
+  trigger:
+    - platform: state
+      entity_id: sensor.living_room_temperature_truth
+      to: ["unavailable", "unknown"]
+      for: "00:02:00"
+      id: climate.living_room_air
+    - platform: state
+      entity_id: sensor.master_bedroom_temperature_truth
+      to: ["unavailable", "unknown"]
+      for: "00:02:00"
+      id: climate.master_bedroom_air
+    - platform: state
+      entity_id: sensor.lincoln_s_room_temperature_truth
+      to: ["unavailable", "unknown"]
+      for: "00:02:00"
+      id: climate.lincoln_air
+    - platform: state
+      entity_id: sensor.lilly_s_room_temperature_truth
+      to: ["unavailable", "unknown"]
+      for: "00:02:00"
+      id: climate.lilly_air
+  condition:
+    # Only act if the matching unit is actually cooling. Cross-season by design:
+    # no season gate — protective OFF allowed even in heating/shoulder.
+    - condition: template
+      value_template: "{{ is_state(trigger.id, 'cool') }}"
+  action:
+    - action: climate.set_hvac_mode
+      target: { entity_id: "{{ trigger.id }}" }
+      data: { hvac_mode: "off" }
+    - action: notify.notify
+      data:
+        title: "🌡️⚠️ Truth-Unavailable Cooling Fail-Safe"
+        message: >
+          {{ trigger.id }} forced OFF — its truth sensor went
+          unavailable/unknown for >2 min while the unit was cooling.
+          Truth-based safety gates (runaway/floor/ceiling) are blind until
+          the sensor recovers. Investigate the sensor/integration; the V8.3
+          supervisor will resume control automatically on recovery.
+```
+Notes: `mode: parallel, max: 4` keeps zones independent; the automation **only
+ever commands OFF** (never `cool`); commands carry an automation context so the
+`v7_5_waf_manual_override` watcher (which requires `context.parent_id is none`)
+is **not** tripped. If the climate entity is already `off`/`heat`/`unavailable`,
+the `cool`-only condition skips it (no needless command).
+
+---
+
+## 4. Entity & automation dependency map
+
+```
+TRUTH (raw, control input)         CLIMATE (writes)            SAFETY (numeric_state on truth)
+sensor.living_room_temperature_truth ─┬─► climate.living_room_air      v8_2_lr_runaway_cooling_cutoff (LR, <60)
+sensor.master_bedroom_temperature_truth ─► climate.master_bedroom_air  v8_2_master_emergency_floor (Master, <58)
+sensor.lincoln_s_room_temperature_truth ─► climate.lincoln_air         v7_5_safety_ceiling_gates (M/Lin/Lil, >76)
+sensor.lilly_s_room_temperature_truth ──► climate.lilly_air
+            │                                   ▲
+            │ (unavailable/unknown >2m)          │ resumes on recovery
+            └─► [NEW] v8_6_truth_unavailable_cooling_failsafe ─► protective OFF (cool-only, any season)
+            └─► [GUARD] v7_5_main_supervisor *_truth_ok → OFF (cooling branch, per tick)
+Gating helper: timer.manual_hvac_override (supervisor only; fail-safe recommended to IGNORE)
+Diagnostic-only (NOT used here): binary_sensor.*_heat_pump_firing, sensor.*_temperature_{smoothed,control}
+```
+
+---
+
+## 5. Race / conflict analysis
+
+- **Supervisor vs fail-safe (truth bad):** both target the same entity toward
+  **OFF** (guard → off; fail-safe → off). No opposing command. Without the guard,
+  Master-sleep would race (supervisor COOL vs fail-safe OFF) — the guard is what
+  removes the race.
+- **Recovery window:** when truth returns numeric, the fail-safe condition is
+  false (won't fire) and the guard passes; the supervisor's next tick/trigger is
+  sole re-enable authority. No independent restart.
+- **WAF manual-override watcher:** fail-safe commands have a parent context →
+  `parent_id` not none → watcher does not start `timer.manual_hvac_override`. No
+  false override.
+- **Existing safety gates:** unaffected; they remain blind during the outage
+  (their limitation, not a new conflict) and re-arm on recovery. Fail-safe
+  complements them by covering exactly the blind window.
+- **`mode` choices:** fail-safe `parallel/max:4` → no cross-zone queueing.
+  Supervisor stays `single`.
+
+---
+
+## 6. Exact sequence (unavailable → debounce → OFF → recovery)
+
+1. `t0`: zone truth → `unavailable` (all contributors stale/absent).
+2. `t0…t0+2m`: debounce. Supervisor, if it ticks here, sees `*_truth_ok=false`
+   → commands OFF (cooling branch) — early protection in-season.
+3. `t0+2m`: fail-safe fires **iff** climate entity == `cool` → `set_hvac_mode
+   off` + notify. Cross-season.
+4. Outage persists: each supervisor tick keeps the zone OFF (guard); fail-safe
+   won't re-fire unless the truth re-enters then re-exits the unavailable state
+   for >2 min while cooling (cannot, since it's OFF).
+5. `tR`: truth → numeric. Fail-safe inert. Next supervisor trigger: guard passes,
+   normal deadband resumes; COOL only if `temp > on_at` and all season/away/
+   sleep/safety gates permit.
+
+---
+
+## 7. Tests
+
+### 7a. Static (repo-style, pytest over parsed YAML — proposed)
+- `test_truth_unavailable_failsafe_present`: automation
+  `v8_6_truth_unavailable_cooling_failsafe` exists; 4 state triggers to
+  `['unavailable','unknown']` with `for >= 60s`, each `id` = a `climate.*_air`;
+  condition gates on `is_state(trigger.id,'cool')`; action sets
+  `hvac_mode: off`; **no** action sets `cool`.
+- `test_supervisor_truth_guard_present`: top variables define
+  `lr_/master_/lincoln_/lilly_truth_ok` using `has_value(...)`; each cooling
+  `hvac_mode` template begins with `{% if not <zone>_truth_ok %}off`.
+- `test_doctrine_unchanged`: `test_section2_cooling_setpoint_doctrine.py` still
+  green (thresholds/targets untouched).
+
+### 7b. Acceptance (runtime / trace — operator-executed)
+| # | Scenario | Expected |
+|---|---|---|
+| 1 | Std, cooling, truth→unavail | Fail-safe OFF ≤2 min; cooling not indefinite |
+| 2 | Std, off, truth→unavail | No COOL created (guard) |
+| 3 | Master sleep, off, truth→unavail | **No false-COOL** (guard) — key fix |
+| 4 | Away, truth→unavail | Explicit OFF via guard, not float-OFF accident |
+| 5 | One zone fails | Other 3 controlled normally |
+| 6 | Healthy truth | `<=off_at`/`>on_at`/HOLD unchanged |
+| 7 | Cooling while season=heating/shoulder | Protective OFF allowed; no COOL |
+| 8 | Truth restored | Supervisor resumes ≤1 cycle; fail-safe doesn't restart |
+
+### 7c. Recovery tests
+- Restored truth ≤ band → no inappropriate restart.
+- Restored truth > on_at → supervisor MAY restart only if all gates permit.
+- Repeated flap → no rapid cycling (bounded by `for:` + 15-min cadence).
+- Supervisor disabled while fail-safe active → unit not stuck cooling (fail-safe
+  already forced OFF; nothing re-cools).
+
+### 7d. Failure-mode tests
+- All 4 truths unavailable, all 4 cooling → all forced OFF independently.
+- Unavailable during Master sleep / during away → §7b #3/#4.
+- HA restart mid-outage → debounce rides startup; on restore, supervisor resumes.
+- Fail-safe automation disabled/errors → supervisor guard still prevents
+  re-cool in-season (defense in depth); cross-season gap noted.
+- Truth restores just before/at a supervisor run → guard passes; normal decision.
+
+---
+
+## 8. Rollback plan
+
+1. Pre-change state captured here + audit doc + trace
+   `2cc51682fc628808ecb3a00c6b499204`.
+2. Revert: `git revert <commit>` or `git checkout -- automations.yaml`
+   (removes the `v8_6_…` block and the supervisor guard lines).
+3. `python -m pytest tests/` must return to the prior green set (and the two new
+   static tests are removed/skipped with the revert).
+4. `ha core check` (or HA *Developer Tools → YAML check*) clean; reload
+   automations.
+5. Confirm supervisor trace shows the original `float(70)` path restored.
+
+## 9. Post-change observation plan
+
+- Watch `notify` events + `hvac_provenance_log` for any `v8_6_…` firing.
+  Expectation under healthy sensors: **~0 firings**. Any firing ⇒ investigate the
+  sensor/integration, not the threshold.
+- For ≥7 days, count: fail-safe firings/zone, supervisor `*_truth_ok=false`
+  ticks, and confirm **zero false shutdowns** (fail-safe fired while truth was
+  actually numeric — should be impossible by construction).
+- Confirm regression comparability: healthy-state runtime/setpoint telemetry
+  unchanged vs. pre-change baseline.
+
+---
+
+## 10. Codex implementation prompt (self-contained — use only after operator approval)
+
+> **Task:** Apply the approved Packet A sensor-loss fail-safe to the Moose House
+> HA repo. Design source: `docs/packets/packetA_truth_unavailable_failsafe.md`.
+> Make ONLY these changes; do not touch Packet B (smoothing/control), cooldown
+> timers, thresholds, the 61 °F target, or hardware.
+>
+> 1. **Locate the supervisor** in `automations.yaml` by repository `id:
+>    v7_5_main_supervisor` (alias "V8.3: Main Supervisor"; live entity may be
+>    `automation.v7_5_main_supervisor` or `…_rev_b` — confirm before editing).
+> 2. **Add per-zone guards:** in the supervisor's first `variables:` block add
+>    `lr_truth_ok`, `master_truth_ok`, `lincoln_truth_ok`, `lilly_truth_ok` using
+>    `has_value(<truth>) and states(<truth>)|float(none) is not none`. Prepend
+>    `{% if not <zone>_truth_ok %}off` as the first branch of each cooling-branch
+>    `hvac_mode` template (LR, Master, Lincoln, Lilly). Leave all setpoints and
+>    off_at/on_at templates byte-identical.
+> 3. **Add automation** `v8_6_truth_unavailable_cooling_failsafe` exactly as in
+>    design §3b (4 state triggers → `['unavailable','unknown']`, `for: 00:02:00`,
+>    `id` = climate entity; condition `is_state(trigger.id,'cool')`; action
+>    `climate.set_hvac_mode off` + notify; `mode: parallel, max: 4`).
+> 4. **Validate:** run `ha core check` (or `python` YAML load) and
+>    `python -m pytest tests/` — all prior tests plus the two new static tests in
+>    §7a must pass.
+> 5. **Verify behavior:** trigger a truth sensor to `unavailable` in a test
+>    context; confirm a trace shows protective OFF and that healthy-truth traces
+>    are unchanged. Capture `run_id`s.
+> 6. **Rollback if anything fails:** `git checkout -- automations.yaml`; re-run
+>    pytest to confirm restoration. Report results, traces, and diffs.
+>
+> Do not merge or deploy without operator sign-off. Report a diff for review
+> first.
+
+---
+
+## Open decision points (for operator / Hermes)
+1. **Debounce:** 2 min (recommended) vs 60 s (faster, slightly more restart
+   sensitivity).
+2. **Manual-override:** fail-safe ignores `timer.manual_hvac_override`
+   (recommended, runaway/floor precedent) vs respects it (honors WAF, but leaves
+   hazard during an active override).
+3. **Design 1 (supervisor guard + automation, 0 helpers, recommended)** vs
+   **Design 2 (automation + 4 inhibit `input_boolean`s)** if editing the
+   supervisor templates is undesirable.
+
+## Remaining unknowns (not silently resolved)
+- Live entity ID of the supervisor (`…` vs `…_rev_b`) and the `_2` suffix on the
+  LR runaway automation — resolve in live HA registry before Codex applies.
+- `input_select.hvac_season_mode` / `input_boolean.*` / `timer.manual_hvac_override`
+  are UI/storage helpers, not in repo YAML — option lists unverifiable here.
+- Whether a climate entity can report a transient `cool` during its own
+  `unavailable` recovery (Samsung cloud) — minor edge; condition `cool`-gate
+  handles it conservatively.
+
+**Reconciliation result:** Packet A design complete; no production change made.
+Packet B (raw vs smoothed/control) and V9 cooldown enforcement remain separate
+and out of scope here.

--- a/docs/packets/packetA_truth_unavailable_failsafe.md
+++ b/docs/packets/packetA_truth_unavailable_failsafe.md
@@ -9,6 +9,11 @@ enforcement (V9 backlog), thresholds, the 61 °F target, or hardware. Proposed
 YAML is illustrative and must not be committed to `automations.yaml` /
 `configuration.yaml` until separately approved.
 
+**Status (2026-06-09):** All three design decisions **APPROVED** (see §Decisions).
+Static contract tests added in `tests/test_packetA_truth_unavailable_failsafe.py`
+— implementation-facing checks are `xfail(strict=False)` until Codex applies the
+runtime change; healthy-state/doctrine checks pass now and must stay green.
+
 ---
 
 ## 0. Audit source verification
@@ -80,7 +85,7 @@ cooling command**.
   turns anything ON. When truth becomes numeric again, the guard passes and the
   supervisor resumes on its next trigger, subject to all existing gates.
 
-**Debounce = `for: "00:02:00"` (justified).** The truth `availability` template
+**Debounce = `for: "00:02:00"` — APPROVED.** The truth `availability` template
 only goes false when **every** contributor is stale (>7200 s) or absent
 (`configuration.yaml:248-257`), so a genuine `unavailable` is already a sustained
 fault, not a value blip. The 2-minute window exists mainly to ride out **HA
@@ -89,10 +94,10 @@ first report. 2 min of extra cooling is acceptable because this fail-safe is the
 *only* live protection during the outage and is far inside the 60 °F runaway
 margin. A 60 s alternative is offered for operators who prefer faster action.
 
-**Manual-override interaction (decision surfaced).** Recommend the protective-OFF
+**Manual-override interaction — APPROVED: ignore override.** The protective-OFF
 fires **regardless of `timer.manual_hvac_override`**, matching the runaway/floor
-equipment-protection precedent (those gates do **not** check override), since the
-hazard is unbounded cooling with no shutoff. Flagged as a decision point (§Open).
+equipment-protection precedent (those gates do **not** check override). Manual
+override is a comfort/control authority, not an equipment-safety bypass.
 
 ---
 
@@ -322,47 +327,88 @@ Diagnostic-only (NOT used here): binary_sensor.*_heat_pump_firing, sensor.*_temp
 
 ## 10. Codex implementation prompt (self-contained — use only after operator approval)
 
-> **Task:** Apply the approved Packet A sensor-loss fail-safe to the Moose House
-> HA repo. Design source: `docs/packets/packetA_truth_unavailable_failsafe.md`.
-> Make ONLY these changes; do not touch Packet B (smoothing/control), cooldown
-> timers, thresholds, the 61 °F target, or hardware.
+> **Task:** Apply **only** Packet A Design 1 (truth-unavailable cooling fail-safe)
+> to the live Moose House HAOS repo. Design source of truth:
+> `docs/packets/packetA_truth_unavailable_failsafe.md` on branch
+> `claude/compassionate-davinci-8ly5pv` (PR #135). Decisions are APPROVED:
+> 2-minute persistence, ignore manual override, Design 1 (no inhibit helpers).
 >
-> 1. **Locate the supervisor** in `automations.yaml` by repository `id:
->    v7_5_main_supervisor` (alias "V8.3: Main Supervisor"; live entity may be
->    `automation.v7_5_main_supervisor` or `…_rev_b` — confirm before editing).
-> 2. **Add per-zone guards:** in the supervisor's first `variables:` block add
->    `lr_truth_ok`, `master_truth_ok`, `lincoln_truth_ok`, `lilly_truth_ok` using
->    `has_value(<truth>) and states(<truth>)|float(none) is not none`. Prepend
->    `{% if not <zone>_truth_ok %}off` as the first branch of each cooling-branch
->    `hvac_mode` template (LR, Master, Lincoln, Lilly). Leave all setpoints and
->    off_at/on_at templates byte-identical.
-> 3. **Add automation** `v8_6_truth_unavailable_cooling_failsafe` exactly as in
->    design §3b (4 state triggers → `['unavailable','unknown']`, `for: 00:02:00`,
->    `id` = climate entity; condition `is_state(trigger.id,'cool')`; action
->    `climate.set_hvac_mode off` + notify; `mode: parallel, max: 4`).
-> 4. **Validate:** run `ha core check` (or `python` YAML load) and
->    `python -m pytest tests/` — all prior tests plus the two new static tests in
->    §7a must pass.
-> 5. **Verify behavior:** trigger a truth sensor to `unavailable` in a test
->    context; confirm a trace shows protective OFF and that healthy-truth traces
->    are unchanged. Capture `run_id`s.
-> 6. **Rollback if anything fails:** `git checkout -- automations.yaml`; re-run
->    pytest to confirm restoration. Report results, traces, and diffs.
+> **Hard exclusions:** make **no** Packet B smoothing/control changes; **no** V9
+> compressor-cooldown changes; do **not** alter any threshold, equality operator
+> (`<= off_at`, `> on_at`, else HOLD), the 61 °F target, away logic, the Master
+> 18:00–06:00 sleep band, or four-zone independence; add no hardware; do not
+> treat `binary_sensor.*_heat_pump_firing` as physical proof.
 >
-> Do not merge or deploy without operator sign-off. Report a diff for review
-> first.
+> 1. **Inspect first, edit second.** Read the live `automations.yaml` in full
+>    before any change. Resolve the supervisor identity: repository `id:
+>    v7_5_main_supervisor` vs live entity `automation.v7_5_main_supervisor_rev_b`
+>    — match by `id:`, `alias:` ("V8.3: Main Supervisor (Deadband Cooling +
+>    Heating)"), and YAML source location. Confirm you are editing the single
+>    canonical supervisor block before proceeding.
+> 2. **Create a Git checkpoint:** `git rev-parse HEAD` (record), and
+>    `git stash list`/`git status` clean check; tag or branch as needed so the
+>    pre-change state is recoverable.
+> 3. **Add four per-zone truth-validity guards** in the supervisor's first
+>    `variables:` block: `lr_truth_ok`, `master_truth_ok`, `lincoln_truth_ok`,
+>    `lilly_truth_ok`, each = `{{ has_value(<truth>) and states(<truth>) |
+>    float(none) is not none }}` for the matching `sensor.*_temperature_truth`.
+>    This validation must occur **before** any `float(70)` fallback is used as a
+>    control value.
+> 4. **Guard each cooling-branch `hvac_mode` template** (LR, Master, Lincoln,
+>    Lilly) by prepending `{% if not <zone>_truth_ok %}off` as the **first**
+>    branch, ahead of the existing `> on_at`/`<= off_at`/HOLD logic, which must
+>    remain byte-identical otherwise. Result: unavailable/non-numeric truth ⇒
+>    that zone is commanded OFF (never COOL, never HOLD-on-stale).
+> 5. **Add the event automation** `v8_6_truth_unavailable_cooling_failsafe`
+>    exactly per design §3b: `mode: parallel, max: 4`; four `state` triggers, one
+>    per `sensor.*_temperature_truth`, `to: ['unavailable','unknown']`,
+>    `for: "00:02:00"`, `id:` = the matching `climate.*_air`; condition
+>    `is_state(trigger.id,'cool')`; action `climate.set_hvac_mode` →
+>    `hvac_mode: off` on `{{ trigger.id }}` + a `notify.notify`. It must have
+>    **no** condition referencing `timer.manual_hvac_override`, and **no** action
+>    that issues `cool` or otherwise restores cooling.
+> 6. **Configuration validation:** run `ha core check` (HAOS) — must be clean.
+> 7. **Repository tests:** run the full suite `python -m pytest tests/`. All
+>    previously-green tests stay green; the Packet A `xfail` contract tests in
+>    `tests/test_packetA_truth_unavailable_failsafe.py` must now **xpass/pass**.
+>    (Once confirmed, flip them from `xfail(strict=False)` to plain asserts.)
+> 8. **Reload minimally if safe:** reload the `automation` domain (and `template`
+>    only if touched — it is not in this packet). If a full restart is required
+>    in your environment, state that instead of forcing a reload.
+> 9. **Verify via traces, not by endangering rooms:** inspect the supervisor
+>    trace to confirm the guard path renders `off` for a simulated
+>    unavailable/non-numeric truth and that healthy-truth traces are unchanged;
+>    confirm the fail-safe automation registers its four triggers. Do **not**
+>    physically force a real sensor offline in a way that leaves an occupied room
+>    unsafe. Capture `run_id`s.
+> 10. **Exact rollback (if any step fails or review rejects):**
+>     `git checkout -- automations.yaml` (discard the guard + new automation), or
+>     `git revert <checkpoint-range>` if already committed; re-run
+>     `python -m pytest tests/` and `ha core check`; reload the `automation`
+>     domain; confirm the supervisor trace shows the original `float(70)` path.
+>
+> Do not merge or deploy without operator sign-off. Produce a diff for review
+> first; report files changed, `ha core check` output, full pytest results, and
+> the verifying `run_id`s.
 
 ---
 
-## Open decision points (for operator / Hermes)
-1. **Debounce:** 2 min (recommended) vs 60 s (faster, slightly more restart
-   sensitivity).
-2. **Manual-override:** fail-safe ignores `timer.manual_hvac_override`
-   (recommended, runaway/floor precedent) vs respects it (honors WAF, but leaves
-   hazard during an active override).
-3. **Design 1 (supervisor guard + automation, 0 helpers, recommended)** vs
-   **Design 2 (automation + 4 inhibit `input_boolean`s)** if editing the
-   supervisor templates is undesirable.
+## Decisions — APPROVED 2026-06-09
+1. **Debounce:** 2-minute persistent unavailable/non-numeric requirement on the
+   event-triggered protective-OFF automation. ✅ APPROVED. (Filters brief
+   SmartThings/template glitches; acts well before the 15-min supervisor cycle;
+   within the accepted maximum response window.)
+2. **Manual override:** the fail-safe **ignores** `timer.manual_hvac_override`,
+   following the runaway-cooling / emergency-floor equipment-protection
+   precedent. ✅ APPROVED.
+3. **Architecture — Design 1.** ✅ APPROVED. Per-zone `*_truth_ok` validation
+   inside the V8.3 supervisor **before** any `float(70)`/deadband comparison;
+   unavailable/non-numeric truth ⇒ that zone is commanded OFF. Plus a separate
+   event-triggered protective-OFF automation (2-min persistence, **OFF-only**,
+   never COOL, never independently restores cooling). Recovery authority remains
+   solely with the V8.3 supervisor once truth is numeric again. Do **not** add
+   four persistent inhibit helpers unless repository constraints prove Design 1
+   cannot be implemented safely.
 
 ## Remaining unknowns (not silently resolved)
 - Live entity ID of the supervisor (`…` vs `…_rev_b`) and the `_2` suffix on the

--- a/docs/packets/packetA_truth_unavailable_failsafe.md
+++ b/docs/packets/packetA_truth_unavailable_failsafe.md
@@ -9,18 +9,35 @@ enforcement (V9 backlog), thresholds, the 61 °F target, or hardware. Proposed
 YAML is illustrative and must not be committed to `automations.yaml` /
 `configuration.yaml` until separately approved.
 
-**Status (2026-06-09, pass 2 — hardened):** All three design decisions
-**APPROVED** (see §Decisions). Pass-2 hardening applied: (1) event validity now
-covers **any** non-numeric truth via a shared `float(none) is none` definition
-matching the supervisor guard; (2) a restart/reload-safe **reconciliation**
-automation (§3c) closes the `for:`-reset blind spot; (3) the test gate is
-**enforceable** (a normal-priority gate test fails the suite if the guard is
-implemented but `xfail` markers remain); (4) the notifier is **non-blocking** and
-must be verified, never gating the protective OFF.
+**Status (2026-06-09, pass 3 — hardened):** All three design decisions
+**APPROVED** (see §Decisions). Pass-3 hardening applied on top of pass 2:
+
+1. **Finite-value validity (BLOCKER 1 fixed).** The shared validity test no
+   longer relies on `float(none) is not none` alone — that wrongly **accepted**
+   `"NaN"`, `"inf"`, `"Infinity"`, etc., because they parse to floating-point
+   values. The supervisor guard, the event automation, and the reconciliation
+   sweep now use **one shared finite-value definition** (§3.0) that rejects
+   `unknown`, `unavailable`, empty/non-numeric strings, **NaN**, **+infinity**,
+   and **−infinity**.
+2. **Reconciliation preserves the 2-minute persistence (BLOCKER 2 fixed).** The
+   `/5` periodic sweep and the startup sweep now force OFF **only** when truth
+   has been invalid for **≥ 2 minutes** (state-age check on the truth entity's
+   current invalid-state timestamp), so an automation reload can no longer turn
+   a unit off on a brief invalid blip. Worst-case reconciliation response stays
+   well under the 15-minute maximum.
+3. A restart/reload-safe **reconciliation** automation (§3c) still closes the
+   `for:`-reset blind spot; (4) the test gate is **enforceable** (a
+   normal-priority gate test fails the suite if the guard is implemented but
+   `xfail` markers remain); (5) the notifier is **non-blocking** and must be
+   verified, never gating the protective OFF.
+
 Contract tests: `tests/test_packetA_truth_unavailable_failsafe.py` — **design-only
-baseline: 136 passed, 14 xfailed** (3 Packet A pass now; 14 `xfail(strict=False)`
-until implemented). **Expected post-implementation: 150 passed, 0 xfailed, 0
-xpassed** once Codex applies the YAML and removes the markers.
+baseline: 156 passed, 17 xfailed** (23 design-proving Packet A checks pass now —
+including behavioral proof that NaN/±infinity are rejected and that the
+reconciliation 2-minute persistence holds; 17 `xfail(strict=False)` are the
+implementation contracts that flip to passing once the YAML lands). **Expected
+post-implementation: 173 passed, 0 xfailed, 0 xpassed** once Codex applies the
+YAML and removes the markers.
 
 ---
 
@@ -74,10 +91,11 @@ This eliminates the `float(70)` false-HOLD and false-COOL paths at every 15-min
 tick and is per-zone independent.
 
 **(1b) Event-triggered protective-OFF automation (speed + cross-season).**
-A new dedicated automation triggers on each truth entity transitioning to
-`unavailable`/`unknown` (short debounce via `for:`), and if the matching climate
-entity is `cool`, forces it OFF — **regardless of season**, **never creating a
-cooling command**.
+A new dedicated automation triggers on each truth entity becoming **invalid**
+under the shared finite-value definition (§3.0) — i.e. `unavailable`, `unknown`,
+a parse failure, **NaN**, or **±infinity** (short debounce via `for:`), and if
+the matching climate entity is `cool`, forces it OFF — **regardless of season**,
+**never creating a cooling command**.
 
 **Why both, and why this is the safest default:**
 - The supervisor guard alone is **tick-bound** (≤15 min, and only inside the
@@ -129,14 +147,77 @@ so it is more moving parts for the same outcome.
 
 ## 3. Proposed YAML / pseudocode — **DO NOT APPLY**
 
+### 3.0 Shared finite-value validity definition (BLOCKER 1) — **one definition, three users**
+
+A truth value is a **valid control temperature** only if it is a **finite
+number**. The earlier `float(none) is not none` test is **insufficient**:
+`"NaN"`, `"nan"`, `"inf"`, `"-inf"`, `"Infinity"` all parse to floating-point
+values and would slip through. NaN makes every threshold comparison evaluate
+false (false HOLD); ±infinity forces extreme threshold outcomes. So the test must
+reject **all** of:
+
+`unknown`, `unavailable`, empty/non-numeric strings, **NaN**, **+infinity**,
+**−infinity**.
+
+There is no single universally-portable finite predicate in older HA Jinja, so
+the canonical definition uses a **clearly documented combination**, verified
+against HA template behavior (Home Assistant's own `is_number()` test also
+rejects NaN/inf on modern cores; the explicit form below is version-robust and
+self-documenting):
+
+* parse with `float(none)` → `none` on any non-numeric/`unknown`/`unavailable`/empty,
+* `x is not none` → rejects all parse failures,
+* `x == x` → **rejects NaN** (NaN is the only value not equal to itself),
+* `SAFETY_TEMP_MIN_F <= x <= SAFETY_TEMP_MAX_F` → **rejects ±infinity** (and any
+  absurd reading), because no finite comparison admits `inf`/`-inf`.
+
+**SAFETY plausibility band — validity only, NOT a comfort/control threshold:**
+
+| Constant | Value (°F) | Purpose |
+|---|---|---|
+| `SAFETY_TEMP_MIN_F` | **−90** | lower validity bound; far below any real indoor reading |
+| `SAFETY_TEMP_MAX_F` | **+200** | upper validity bound; far above any real indoor reading |
+
+These two bounds are **deliberately broad safety-validation limits**. They are
+intentionally documented **here, apart from every HVAC threshold** (the 61 °F
+target; 68/72 home; 74/76 away; 62/66 Master sleep; 60/58/76 safety gates) and
+must never be confused with or narrowed toward comfort thresholds. Their only job
+is to reject `±inf`/absurd values while never rejecting a genuine temperature.
+
+```jinja
+{# Canonical VALID form (supervisor `*_truth_ok`) — truth is finite & usable #}
+{% set x = states('<truth_entity>') | float(none) %}
+{{ x is not none and x == x and -90 <= x <= 200 }}
+
+{# Canonical INVALID form (event trigger / reconciliation) — exact negation #}
+{% set x = states('<truth_entity>') | float(none) %}
+{{ x is none or x != x or x < -90 or x > 200 }}
+```
+
+The supervisor guard uses the VALID form; the event automation and reconciliation
+use the INVALID form. They are **exact logical negations** of one another
+(proven across `err`/`NaN`/`nan`/`inf`/`-inf`/`Infinity`/empty/`unknown`/
+`unavailable` and ordinary signed & decimal temperatures by
+`test_supervisor_and_event_validity_are_semantically_identical`), so **no value
+is rejected by one path but missed by another**.
+
 ### 3a. Supervisor guard (illustrative edit to `automations.yaml`)
-Add per-zone validity flags to the top variables block (`:371-380`):
+Add per-zone validity flags to the top variables block (`:371-380`), each using
+the **canonical VALID form** from §3.0:
 ```yaml
-# DO NOT APPLY — illustrative
-lr_truth_ok:      "{{ has_value('sensor.living_room_temperature_truth')   and states('sensor.living_room_temperature_truth')   | float(none) is not none }}"
-master_truth_ok:  "{{ has_value('sensor.master_bedroom_temperature_truth') and states('sensor.master_bedroom_temperature_truth') | float(none) is not none }}"
-lincoln_truth_ok: "{{ has_value('sensor.lincoln_s_room_temperature_truth') and states('sensor.lincoln_s_room_temperature_truth') | float(none) is not none }}"
-lilly_truth_ok:   "{{ has_value('sensor.lilly_s_room_temperature_truth')   and states('sensor.lilly_s_room_temperature_truth')   | float(none) is not none }}"
+# DO NOT APPLY — illustrative (finite-value validity; SAFETY band -90..200 °F)
+lr_truth_ok: >-
+  {% set x = states('sensor.living_room_temperature_truth') | float(none) %}
+  {{ x is not none and x == x and -90 <= x <= 200 }}
+master_truth_ok: >-
+  {% set x = states('sensor.master_bedroom_temperature_truth') | float(none) %}
+  {{ x is not none and x == x and -90 <= x <= 200 }}
+lincoln_truth_ok: >-
+  {% set x = states('sensor.lincoln_s_room_temperature_truth') | float(none) %}
+  {{ x is not none and x == x and -90 <= x <= 200 }}
+lilly_truth_ok: >-
+  {% set x = states('sensor.lilly_s_room_temperature_truth') | float(none) %}
+  {{ x is not none and x == x and -90 <= x <= 200 }}
 ```
 Then prepend a guard to each zone's cooling `hvac_mode` template (Master shown;
 LR/Lincoln/Lilly identical pattern):
@@ -149,20 +230,22 @@ hvac_mode: >-
   {% elif m_current == 'cool' %}cool
   {% else %}off{% endif %}
 ```
-`has_value()` returns false for `unknown`/`unavailable`; the `float(none) is not
-none` clause also rejects any other non-numeric. When `*_truth_ok` is true the
-template is unchanged → **healthy behavior identical**. This does **not** alter
-the variables checked by `test_section2_cooling_setpoint_doctrine.py` (it asserts
+The `float(none)` parse rejects `unknown`/`unavailable`/empty/non-numeric, `x ==
+x` rejects NaN, and the `-90..200` band rejects ±infinity (see §3.0). When
+`*_truth_ok` is true the template is unchanged → **healthy behavior identical**.
+This does **not** alter the variables checked by
+`test_section2_cooling_setpoint_doctrine.py` (it asserts
 `*_setpoint`/`*_off_at`/`*_on_at`, not the hvac_mode string), so that suite stays
 green.
 
 ### 3b. Event protective-OFF automation (new block — DO NOT APPLY)
 
 Uses **template triggers**, not `state … to: [unavailable, unknown]`, so the
-validity test matches the supervisor guard **exactly** and catches **any**
-non-numeric value (e.g. a stray `"err"`/`"NaN"` string), not only the two known
-states. Shared validity definition (truth is INVALID iff):
-`{{ not has_value(<truth>) or states(<truth>) | float(none) is none }}`.
+validity test matches the supervisor guard **exactly** and catches **every**
+invalid value — `unavailable`, `unknown`, a parse failure (`"err"`), **NaN**, and
+**±infinity** — not only the two known states. Shared **INVALID** form from §3.0
+(truth is INVALID iff):
+`{% set x = states(<truth>) | float(none) %}{{ x is none or x != x or x < -90 or x > 200 }}`.
 ```yaml
 # DO NOT APPLY — illustrative new automation
 - id: v8_6_truth_unavailable_cooling_failsafe
@@ -170,28 +253,30 @@ states. Shared validity definition (truth is INVALID iff):
   mode: parallel
   max: 4
   trigger:
+    # Each value_template is the canonical INVALID form (§3.0): true when truth
+    # is unavailable/unknown/parse-failure/NaN/±infinity.
     - platform: template
       value_template: >-
-        {{ not has_value('sensor.living_room_temperature_truth')
-           or states('sensor.living_room_temperature_truth') | float(none) is none }}
+        {% set x = states('sensor.living_room_temperature_truth') | float(none) %}
+        {{ x is none or x != x or x < -90 or x > 200 }}
       for: "00:02:00"
       id: climate.living_room_air
     - platform: template
       value_template: >-
-        {{ not has_value('sensor.master_bedroom_temperature_truth')
-           or states('sensor.master_bedroom_temperature_truth') | float(none) is none }}
+        {% set x = states('sensor.master_bedroom_temperature_truth') | float(none) %}
+        {{ x is none or x != x or x < -90 or x > 200 }}
       for: "00:02:00"
       id: climate.master_bedroom_air
     - platform: template
       value_template: >-
-        {{ not has_value('sensor.lincoln_s_room_temperature_truth')
-           or states('sensor.lincoln_s_room_temperature_truth') | float(none) is none }}
+        {% set x = states('sensor.lincoln_s_room_temperature_truth') | float(none) %}
+        {{ x is none or x != x or x < -90 or x > 200 }}
       for: "00:02:00"
       id: climate.lincoln_air
     - platform: template
       value_template: >-
-        {{ not has_value('sensor.lilly_s_room_temperature_truth')
-           or states('sensor.lilly_s_room_temperature_truth') | float(none) is none }}
+        {% set x = states('sensor.lilly_s_room_temperature_truth') | float(none) %}
+        {{ x is none or x != x or x < -90 or x > 200 }}
       for: "00:02:00"
       id: climate.lilly_air
   condition:
@@ -214,9 +299,9 @@ states. Shared validity definition (truth is INVALID iff):
         title: "🌡️⚠️ Truth-Unavailable Cooling Fail-Safe"
         message: >
           {{ trigger.id }} forced OFF — its truth input was invalid
-          (unavailable/unknown/non-numeric) for >2 min while the unit was
-          cooling. Truth-based safety gates are blind until recovery. The V8.3
-          supervisor resumes control automatically once truth is numeric again.
+          (unavailable/unknown/parse failure/NaN/±infinity) for >2 min while the
+          unit was cooling. Truth-based safety gates are blind until recovery. The
+          V8.3 supervisor resumes control automatically once truth is finite again.
 ```
 Notes: `mode: parallel, max: 4` keeps zones independent; the automation **only
 ever commands OFF** (never `cool`); commands carry an automation context so the
@@ -233,9 +318,37 @@ invalid across that boundary would otherwise sit in a blind spot until the
 triggers and an all-zone sweep. **Chosen approach: `homeassistant` start trigger
 (with a bounded settle delay) + a periodic reconciliation sweep.** Rationale:
 the start trigger handles HA restart promptly; the periodic `time_pattern`
-handles **automation reload** (which fires no start event) and bounds any blind
-spot to ≤5 min — tighter than the 15-min supervisor backstop, which remains the
-final scheduled guard.
+handles **automation reload** (which fires no start event), and the supervisor's
+15-min tick remains the final scheduled backstop.
+
+**BLOCKER 2 — reconciliation must honour the 2-minute persistence.** The pass-2
+sweep forced OFF whenever truth was invalid **at that instant**. That bypassed
+the approved 2-minute debounce: right after an automation reload, a *brief*
+invalid blip could shut a cooling unit down immediately. The corrected sweep
+forces OFF only when **all three** hold:
+
+* the climate entity state is `cool`,
+* truth is invalid under the **shared finite-value definition** (§3.0), **and**
+* that invalid state has **persisted ≥ 2 minutes**, measured from the truth
+  entity's **current invalid-state timestamp** (`last_changed`).
+
+**Why `last_changed` is a safe age basis (verified against HA behavior):** when a
+sensor's value transitions from a number to an invalid state (e.g. `unavailable`,
+or a `NaN`/`inf` string), HA updates that entity's `last_changed`. So
+`now() - states[truth].last_changed` is the age of the **current** invalid
+episode. An **automation reload does not touch entity states**, so this age
+*survives a reload* and the debounce is genuinely preserved (it is **not** reset
+by the reload, unlike a trigger `for:` timer). After a **full HA restart**,
+`last_changed` re-initialises to the restart time; the start path therefore keeps
+its **3-minute settle delay**, and after that delay the **same ≥ 2-minute
+invalid-age rule still applies explicitly** — startup cannot bypass persistence.
+
+**Worst-case timing:** the periodic sweep fires at the first `/5` tick at which
+the invalid age has already reached 2 minutes, so the worst-case reconciliation
+response is **≈ 7 minutes** (a `/5` cadence plus the 2-minute floor), comfortably
+**under the 15-minute maximum**. The event automation (§3b) still handles the
+ordinary case at 2 minutes; reconciliation only matters across the reload/restart
+boundary where the event `for:` edge is not re-fired.
 ```yaml
 # DO NOT APPLY — illustrative new automation
 - id: v8_6b_truth_unavailable_cooling_reconciliation
@@ -255,8 +368,10 @@ final scheduled guard.
         - conditions: "{{ trigger.id == 'reconcile_start' }}"
           sequence:
             - delay: "00:03:00"
-    # Sweep all four zones; force OFF any unit cooling while its truth is invalid.
-    # Per-item condition preserves four-zone independence. OFF-only.
+    # Sweep all four zones; force OFF any unit cooling while its truth has been
+    # invalid for >= 2 minutes. Per-item condition preserves four-zone
+    # independence. OFF-only. The age gate (last_changed) makes this safe across
+    # an automation reload — a brief invalid blip will NOT force OFF.
     - repeat:
         for_each:
           - { truth: sensor.living_room_temperature_truth,    climate: climate.living_room_air }
@@ -267,17 +382,24 @@ final scheduled guard.
           - if:
               - condition: template
                 value_template: >-
+                  {% set x = states(repeat.item.truth) | float(none) %}
+                  {% set invalid = x is none or x != x or x < -90 or x > 200 %}
+                  {% set st = states[repeat.item.truth] %}
+                  {% set invalid_age = (now() - st.last_changed).total_seconds()
+                     if st is not none else 0 %}
                   {{ is_state(repeat.item.climate, 'cool')
-                     and (not has_value(repeat.item.truth)
-                          or states(repeat.item.truth) | float(none) is none) }}
+                     and invalid and invalid_age >= 120 }}
             then:
               - action: climate.set_hvac_mode
                 target: { entity_id: "{{ repeat.item.climate }}" }
                 data: { hvac_mode: "off" }
 ```
-The reconciliation also covers "**reload mid-persistence**": if a reload resets a
-pending 2-min `for:` timer, the next periodic sweep (≤5 min) forces OFF a
-cooling+invalid zone. No persistent inhibit helpers are required.
+The reconciliation also covers "**reload mid-persistence**": if a reload drops a
+pending 2-min `for:` edge, the next periodic sweep re-evaluates the zone — and
+because the age basis (`last_changed`) survives the reload, a zone that has been
+cooling+invalid for ≥ 2 min is forced OFF on that sweep, while a zone that only
+*just* went invalid is left alone until its age reaches 2 min. No persistent
+inhibit helpers are required.
 
 ---
 
@@ -320,39 +442,70 @@ Diagnostic-only (NOT used here): binary_sensor.*_heat_pump_firing, sensor.*_temp
   ever command **OFF** on a cooling+invalid zone, so they converge — no opposing
   commands. Reconciliation exists solely to cover the restart/reload boundary
   where the event automation's `for:` edge is not re-fired; it shares the exact
-  `float(none) is none` validity test, so it never disagrees about validity. Its
+  **finite-value validity definition** (§3.0), so it never disagrees about
+  validity. It also shares the **same 2-minute persistence**: its `≥120 s`
+  invalid-age gate means it never forces OFF faster than the event path would —
+  removing the post-reload "instant shutdown on a blip" hazard (BLOCKER 2). Its
   start-path settle `delay` prevents startup-unavailable false positives; its
-  `/5` sweep bounds the reload blind spot below the 15-min supervisor backstop.
+  `/5` sweep + 2-minute floor bounds the worst-case response (~7 min) below the
+  15-min supervisor backstop.
 
 ---
 
-## 6. Exact sequence (unavailable → debounce → OFF → recovery)
+## 6. Exact sequence (invalid → debounce → OFF → recovery)
 
-1. `t0`: zone truth → `unavailable` (all contributors stale/absent).
+1. `t0`: zone truth → **invalid** (`unavailable`/`unknown`/parse failure/NaN/
+   ±infinity — all contributors stale/absent, or a non-finite reading). HA stamps
+   `last_changed = t0`.
 2. `t0…t0+2m`: debounce. Supervisor, if it ticks here, sees `*_truth_ok=false`
    → commands OFF (cooling branch) — early protection in-season.
-3. `t0+2m`: fail-safe fires **iff** climate entity == `cool` → `set_hvac_mode
-   off` + notify. Cross-season.
-4. Outage persists: each supervisor tick keeps the zone OFF (guard); fail-safe
-   won't re-fire unless the truth re-enters then re-exits the unavailable state
-   for >2 min while cooling (cannot, since it's OFF).
-5. `tR`: truth → numeric. Fail-safe inert. Next supervisor trigger: guard passes,
-   normal deadband resumes; COOL only if `temp > on_at` and all season/away/
-   sleep/safety gates permit.
+3. `t0+2m`: event fail-safe fires **iff** climate entity == `cool` → `set_hvac_mode
+   off` + notify. Cross-season. (If an automation reload dropped the `for:` edge,
+   the reconciliation sweep takes over: it forces OFF on the next `/5` tick at
+   which the invalid age is already ≥ 2 min — never sooner.)
+4. Outage persists: each supervisor tick keeps the zone OFF (guard); event
+   fail-safe won't re-fire unless the truth re-enters then re-exits the invalid
+   state for >2 min while cooling (cannot, since it's OFF).
+5. `tR`: truth → finite again. Event fail-safe inert; reconciliation inert
+   (invalid age resets). Next supervisor trigger: guard passes, normal deadband
+   resumes; COOL only if `temp > on_at` and all season/away/sleep/safety gates
+   permit.
 
 ---
 
 ## 7. Tests
 
 ### 7a. Static + behavioral (implemented: `tests/test_packetA_truth_unavailable_failsafe.py`)
-17 tests. **3 pass now and must stay green**; **14 are `xfail(strict=False)`**
-until the runtime change lands (Codex removes the marks at implementation).
+40 tests. **23 pass now and must stay green** (doctrine + design-proving
+behavioral checks of the canonical validity/reconciliation expressions); **17 are
+`xfail(strict=False)`** until the runtime change lands (Codex removes the marks
+at implementation). Design-only run: **156 passed, 17 xfailed** suite-wide.
 
-*Always-green (doctrine / enforcement gate):*
+*Always-green — doctrine preservation:*
 - `test_healthy_state_doctrine_unchanged` — setpoints 61, thresholds, away,
   Master sleep band all unchanged.
 - `test_healthy_deadband_behavior_unchanged` — renders the Master template:
   `>on_at`→cool, `<=off_at`→off, else HOLD, with healthy truth.
+
+*Always-green — design-proving finite-value validity (BLOCKER 1):*
+- `test_finite_validity_rejects_invalid_values` (parametrized) — proves
+  `err`, **`NaN`**, **`nan`**, **`inf`**, **`-inf`**, `Infinity`, empty,
+  `unknown`, `unavailable` are all rejected by the canonical definition.
+- `test_finite_validity_accepts_healthy_temperatures` (parametrized) — ordinary
+  **signed and decimal** temperatures (`70`, `61.5`, `-3.2`, `0`, …) stay valid.
+- `test_supervisor_and_event_validity_are_semantically_identical` — the
+  supervisor VALID form and the event/reconciliation INVALID form are exact
+  negations across every candidate ⇒ one shared definition.
+
+*Always-green — design-proving reconciliation persistence (BLOCKER 2):*
+- `test_reconciliation_decision_holds_off_when_invalid_age_under_two_minutes` —
+  invalid for 60 s / 119 s while cooling ⇒ **no OFF**.
+- `test_reconciliation_decision_forces_off_when_invalid_age_at_least_two_minutes`
+  — invalid for 120 s / 600 s (incl. `NaN`) while cooling ⇒ **OFF**.
+- `test_reconciliation_decision_ignores_healthy_and_noncooling` — healthy truth,
+  or a non-cooling unit ⇒ never OFF.
+
+*Always-green — enforceable gate:*
 - `test_packet_a_xfail_markers_removed_once_implemented` — **enforceable gate.**
   If the supervisor guard is present in YAML (implemented) it asserts **zero**
   `xfail` markers remain in this module; in design phase it asserts the markers
@@ -360,8 +513,11 @@ until the runtime change lands (Codex removes the marks at implementation).
   (the dangerous strict=False XPASS state).
 
 *xfail until implemented — supervisor guard:*
-- `test_supervisor_defines_per_zone_truth_ok` — each `*_truth_ok` uses
-  **`has_value` AND `float(none)`** (shared validity; rejects non-numeric).
+- `test_supervisor_defines_per_zone_truth_ok` — each `*_truth_ok` carries the
+  **finite-value** definition (`float(none)`, NaN self-test, ±90/200 bounds).
+- `test_supervisor_guard_rejects_nan_and_infinity` — renders each live
+  `*_truth_ok` expression and confirms **NaN / +inf / −inf** read invalid while
+  ordinary temperatures read valid.
 - `test_cooling_hvac_templates_guard_unavailable_before_cool`,
   `test_unavailable_truth_forces_off_each_zone` (behavioral render),
   `test_master_sleep_unavailable_cannot_create_cool` (behavioral render).
@@ -369,8 +525,9 @@ until the runtime change lands (Codex removes the marks at implementation).
 *xfail until implemented — event fail-safe:*
 - `test_event_failsafe_present_per_zone_validity_triggers` — **template**
   triggers, one per zone, `id` = climate entity, `for` = 2 min.
-- `test_event_failsafe_validity_covers_non_numeric` — trigger templates contain
-  `float(none) is none` (arbitrary non-numeric, not just unavailable/unknown).
+- `test_event_failsafe_validity_uses_finite_value_definition` — trigger templates
+  carry the finite-value definition and render `NaN`/`inf`/`-inf`/`err`/
+  `unavailable` as invalid (not just `unavailable`/`unknown`).
 - `test_event_failsafe_two_minute_persistence`,
   `test_event_failsafe_only_commands_off_and_gates_on_cooling`,
   `test_event_failsafe_ignores_manual_override`,
@@ -382,20 +539,28 @@ until the runtime change lands (Codex removes the marks at implementation).
 - `test_reconciliation_present_restart_and_reload_safe` — `v8_6b…` has a
   `homeassistant` **start** trigger **and** a `time_pattern` trigger.
 - `test_reconciliation_startup_settle_delay` — start path has a bounded `delay`.
-- `test_reconciliation_off_only_all_zones_on_invalid_truth` — sweeps all four
-  zones, OFF-only, gated on `cool` + invalid truth.
+- `test_reconciliation_uses_finite_value_definition` — sweeps all four zones,
+  OFF-only, with the **shared** finite-value definition.
+- `test_reconciliation_requires_two_minute_invalid_persistence` — the sweep
+  checks `last_changed` and requires **≥ 2 min** of persistent invalid truth
+  (BLOCKER 2).
+- `test_reconciliation_startup_does_not_bypass_persistence` — every OFF is inside
+  an `if` whose condition carries the `last_changed` age gate; no unconditional
+  OFF; the start path keeps its settle `delay`.
 
 ### 7b. Acceptance (runtime / trace — operator-executed)
 | # | Scenario | Expected |
 |---|---|---|
-| 1 | Std, cooling, truth→unavail | Fail-safe OFF ≤2 min; cooling not indefinite |
-| 2 | Std, off, truth→unavail | No COOL created (guard) |
-| 3 | Master sleep, off, truth→unavail | **No false-COOL** (guard) — key fix |
-| 4 | Away, truth→unavail | Explicit OFF via guard, not float-OFF accident |
+| 1 | Std, cooling, truth→invalid | Fail-safe OFF ≤2 min; cooling not indefinite |
+| 2 | Std, off, truth→invalid | No COOL created (guard) |
+| 3 | Master sleep, off, truth→invalid | **No false-COOL** (guard) — key fix |
+| 4 | Away, truth→invalid | Explicit OFF via guard, not float-OFF accident |
 | 5 | One zone fails | Other 3 controlled normally |
 | 6 | Healthy truth | `<=off_at`/`>on_at`/HOLD unchanged |
 | 7 | Cooling while season=heating/shoulder | Protective OFF allowed; no COOL |
 | 8 | Truth restored | Supervisor resumes ≤1 cycle; fail-safe doesn't restart |
+| 9 | Truth = `NaN`/`inf` string (cooling) | Treated as invalid → protective OFF |
+| 10 | Reload while truth invalid <2 min (cooling) | Reconciliation does **not** OFF until age ≥2 min |
 
 ### 7c. Recovery tests
 - Restored truth ≤ band → no inappropriate restart.
@@ -405,9 +570,12 @@ until the runtime change lands (Codex removes the marks at implementation).
   already forced OFF; nothing re-cools).
 
 ### 7d. Failure-mode tests
-- All 4 truths unavailable, all 4 cooling → all forced OFF independently.
-- Unavailable during Master sleep / during away → §7b #3/#4.
-- HA restart mid-outage → debounce rides startup; on restore, supervisor resumes.
+- All 4 truths invalid, all 4 cooling → all forced OFF independently.
+- Invalid during Master sleep / during away → §7b #3/#4.
+- Truth reports a `NaN`/`inf`/`Infinity` string → treated as invalid (BLOCKER 1).
+- HA restart mid-outage → 3-min settle then ≥2-min age gate; on restore,
+  supervisor resumes. Automation reload mid-outage → reconciliation re-evaluates
+  but only OFFs once invalid age ≥ 2 min (BLOCKER 2).
 - Fail-safe automation disabled/errors → supervisor guard still prevents
   re-cool in-season (defense in depth); cross-season gap noted.
 - Truth restores just before/at a supervisor run → guard passes; normal decision.
@@ -419,9 +587,11 @@ until the runtime change lands (Codex removes the marks at implementation).
 1. Pre-change state captured here + audit doc + trace
    `2cc51682fc628808ecb3a00c6b499204`.
 2. Revert: `git revert <commit>` or `git checkout -- automations.yaml`
-   (removes the `v8_6_…` block and the supervisor guard lines).
-3. `python -m pytest tests/` must return to the prior green set (and the two new
-   static tests are removed/skipped with the revert).
+   (removes the `v8_6_…` and `v8_6b_…` blocks and the supervisor guard lines).
+3. `python -m pytest tests/` — if the contract-test file is also reverted to the
+   design state, the suite returns to **156 passed, 17 xfailed**; if only the
+   YAML is reverted while the un-marked tests remain, the Packet A contracts will
+   fail (re-add the `xfail` marks to return to the design baseline).
 4. `ha core check` (or HA *Developer Tools → YAML check*) clean; reload
    automations.
 5. Confirm supervisor trace shows the original `float(70)` path restored.
@@ -433,121 +603,186 @@ until the runtime change lands (Codex removes the marks at implementation).
   sensor/integration, not the threshold.
 - For ≥7 days, count: fail-safe firings/zone, supervisor `*_truth_ok=false`
   ticks, and confirm **zero false shutdowns** (fail-safe fired while truth was
-  actually numeric — should be impossible by construction).
+  actually a finite number — should be impossible by construction).
 - Confirm regression comparability: healthy-state runtime/setpoint telemetry
   unchanged vs. pre-change baseline.
 
 ---
 
-## 10. Codex implementation prompt (self-contained — use only after operator approval)
+## 10. Codex implementation prompt (self-contained — two-stage, operator-gated)
 
 > **Task:** Apply **only** Packet A Design 1 (truth-unavailable cooling fail-safe)
 > to the live Moose House HAOS repo. Design source of truth:
-> `docs/packets/packetA_truth_unavailable_failsafe.md` on branch
-> `claude/compassionate-davinci-8ly5pv` (PR #135). Decisions are APPROVED:
-> 2-minute persistence, ignore manual override, Design 1 (no inhibit helpers).
+> `docs/packets/packetA_truth_unavailable_failsafe.md` (this document, pass-3
+> hardened) plus its contract tests
+> `tests/test_packetA_truth_unavailable_failsafe.py`. Decisions are APPROVED:
+> 2-minute persistence, ignore manual override, Design 1 (no inhibit helpers),
+> **shared finite-value validity** (rejects NaN/±infinity), and **reconciliation
+> that preserves the 2-minute persistence**.
 >
 > **Hard exclusions:** make **no** Packet B smoothing/control changes; **no** V9
 > compressor-cooldown changes; do **not** alter any threshold, equality operator
 > (`<= off_at`, `> on_at`, else HOLD), the 61 °F target, away logic, the Master
 > 18:00–06:00 sleep band, or four-zone independence; add no hardware; do not
-> treat `binary_sensor.*_heat_pump_firing` as physical proof.
+> treat `binary_sensor.*_heat_pump_firing` as physical proof. **Do not narrow the
+> SAFETY validity band (−90/200 °F) toward comfort values** — it is a validity
+> bound only.
 >
-> 1. **Inspect first, edit second.** Read the live `automations.yaml` in full
->    before any change. Resolve the supervisor identity: repository `id:
->    v7_5_main_supervisor` vs live entity `automation.v7_5_main_supervisor_rev_b`
->    — match by `id:`, `alias:` ("V8.3: Main Supervisor (Deadband Cooling +
->    Heating)"), and YAML source location. Confirm you are editing the single
->    canonical supervisor block before proceeding.
-> 2. **Create a Git checkpoint:** `git rev-parse HEAD` (record), and
->    `git stash list`/`git status` clean check; tag or branch as needed so the
->    pre-change state is recoverable.
-> 3. **Add four per-zone truth-validity guards** in the supervisor's first
->    `variables:` block: `lr_truth_ok`, `master_truth_ok`, `lincoln_truth_ok`,
->    `lilly_truth_ok`, each = `{{ has_value(<truth>) and states(<truth>) |
->    float(none) is not none }}` for the matching `sensor.*_temperature_truth`.
->    This validation must occur **before** any `float(70)` fallback is used as a
->    control value.
-> 4. **Guard each cooling-branch `hvac_mode` template** (LR, Master, Lincoln,
+> ### Repository workflow (run BEFORE any edit — do not assume the checkout already has PR #135)
+>
+> A. **Record the starting point:** `git branch --show-current`, `git rev-parse
+>    HEAD`, and `git status --porcelain` (must be clean). Note them in your report.
+> B. **Fetch the approved design:** `git fetch origin
+>    claude/compassionate-davinci-8ly5pv` (PR #135), **or** the branch the
+>    operator names if this correction was pushed elsewhere (e.g.
+>    `claude/awesome-babbage-bokpj0`). Do not delete or rewrite local branches.
+> C. **Verify the design commit:** confirm design commit `cac37b0` **or its
+>    pass-3 successor** is present (`git log` / `git show <sha> --stat`). If the
+>    operator points you at a successor commit, use that; record which.
+> D. **Ensure the inputs exist before implementing:** confirm
+>    `docs/packets/packetA_truth_unavailable_failsafe.md` and
+>    `tests/test_packetA_truth_unavailable_failsafe.py` are present at the design
+>    commit. If either is missing, **STOP** and report.
+> E. **Branch from current production:** create a **separate implementation
+>    branch** from the **current production base** (the live-deployed `main`/HEAD),
+>    e.g. `git switch -c codex/packetA-impl <production-base>`. Do **not** implement
+>    directly on the design branch.
+> F. **Bring in design + tests without clobbering newer config:** copy/cherry-pick
+>    **only** the Packet A doc and the contract-test file onto the implementation
+>    branch. Do **NOT** let the design branch's older `automations.yaml` /
+>    `configuration.yaml` overwrite **newer production** YAML — diff first and keep
+>    production runtime config.
+> G. **Divergence guard:** if repository history or the live `automations.yaml`
+>    has **diverged materially** from what this design assumes (supervisor block
+>    moved/renamed, thresholds changed, truth entities renamed), **STOP** and
+>    report the divergence instead of forcing the change.
+>
+> ---
+> ### STAGE 1 — Review-only implementation (NO live changes; STOP for approval)
+>
+> 1. **Inspect first, edit second.** Read the live `automations.yaml` in full.
+>    Resolve the supervisor identity: repository `id: v7_5_main_supervisor` vs a
+>    possible live entity `automation.v7_5_main_supervisor_rev_b` — match by
+>    `id:`, `alias:` ("V8.3: Main Supervisor (Deadband Cooling + Heating)"), and
+>    YAML source location. Confirm you are editing the single canonical
+>    supervisor block before proceeding.
+> 2. **Add four per-zone truth-validity guards** in the supervisor's first
+>    `variables:` block — `lr_truth_ok`, `master_truth_ok`, `lincoln_truth_ok`,
+>    `lilly_truth_ok` — each the **canonical VALID form** from §3.0 for the
+>    matching `sensor.*_temperature_truth`:
+>    `{% set x = states(<truth>) | float(none) %}{{ x is not none and x == x and
+>    -90 <= x <= 200 }}`. This validation must occur **before** any `float(70)`
+>    fallback is used as a control value. (`x == x` rejects NaN; the −90/200 band
+>    rejects ±infinity.)
+> 3. **Guard each cooling-branch `hvac_mode` template** (LR, Master, Lincoln,
 >    Lilly) by prepending `{% if not <zone>_truth_ok %}off` as the **first**
 >    branch, ahead of the existing `> on_at`/`<= off_at`/HOLD logic, which must
->    remain byte-identical otherwise. Result: unavailable/non-numeric truth ⇒
->    that zone is commanded OFF (never COOL, never HOLD-on-stale).
-> 5. **Add the event automation** `v8_6_truth_unavailable_cooling_failsafe`
->    exactly per design §3b: `mode: parallel, max: 4`; **four `template`
->    triggers** (NOT `state … to:[unavailable,unknown]`), one per zone, each
->    `value_template: {{ not has_value(<truth>) or states(<truth>) | float(none)
->    is none }}`, `for: "00:02:00"`, `id:` = the matching `climate.*_air`. This
->    validity definition must be **byte-identical in meaning** to the supervisor
->    guard so no non-numeric string is rejected by one path but missed by the
->    other. Condition `is_state(trigger.id,'cool')`. Action: **`climate.set_hvac_mode
->    off` FIRST**, then an optional notification that is **non-blocking**
->    (`continue_on_error: true`) and **secondary** — the OFF must never depend on
->    it. **No** condition referencing `timer.manual_hvac_override`; **no** action
->    issuing `cool` or restoring cooling.
-> 6. **Notifier — do not hard-code an unverified service.** Before using
->    `notify.notify`, confirm an approved notify service exists in the live
->    config (it is used elsewhere in `automations.yaml`, but verify it resolves).
->    If verified, keep it with `continue_on_error: true`. If not, **omit the
->    notify step entirely** — the protective OFF action stands alone.
-> 7. **Add the reconciliation automation** `v8_6b_truth_unavailable_cooling_reconciliation`
->    exactly per design §3c: triggers = `homeassistant` `event: start` **and**
+>    remain byte-identical otherwise. Result: invalid truth (unavailable /
+>    unknown / parse failure / NaN / ±infinity) ⇒ that zone is commanded OFF
+>    (never COOL, never HOLD-on-stale).
+> 4. **Add the event automation** `v8_6_truth_unavailable_cooling_failsafe`
+>    exactly per §3b: `mode: parallel, max: 4`; **four `template` triggers** (NOT
+>    `state … to:[unavailable,unknown]`), one per zone, each the **canonical
+>    INVALID form**: `{% set x = states(<truth>) | float(none) %}{{ x is none or x
+>    != x or x < -90 or x > 200 }}`, `for: "00:02:00"`, `id:` = the matching
+>    `climate.*_air`. This validity must be the **exact negation** of the
+>    supervisor guard so no value (incl. NaN/±infinity) is caught by one path but
+>    missed by the other. Condition `is_state(trigger.id,'cool')`. Action:
+>    **`climate.set_hvac_mode off` FIRST**, then an optional **non-blocking**
+>    notification (`continue_on_error: true`) — the OFF must never depend on it.
+>    **No** condition on `timer.manual_hvac_override`; **no** action issuing
+>    `cool` or restoring cooling.
+> 5. **Notifier — do not hard-code an unverified service.** Before using
+>    `notify.notify`, confirm an approved notify service resolves in the live
+>    config. If verified, keep it with `continue_on_error: true`. If not, **omit
+>    the notify step entirely** — the protective OFF stands alone.
+> 6. **Add the reconciliation automation** `v8_6b_truth_unavailable_cooling_reconciliation`
+>    exactly per §3c: triggers = `homeassistant` `event: start` **and**
 >    `time_pattern minutes:"/5"`; on the start path apply a bounded settle
->    `delay: "00:03:00"` (avoid startup false-positives) before sweeping; then a
->    `repeat.for_each` over the four `{truth, climate}` pairs forcing
->    `hvac_mode: off` only where `is_state(climate,'cool')` **and** truth is
->    invalid. OFF-only; preserves four-zone independence; **no** inhibit helpers.
-> 8. **Configuration validation:** run `ha core check` (HAOS) — must be clean.
-> 9. **Make the test gate enforceable — in this order:**
->    a. implement the YAML (steps 3–7);
+>    `delay: "00:03:00"` before sweeping; then a `repeat.for_each` over the four
+>    `{truth, climate}` pairs forcing `hvac_mode: off` only where the per-item
+>    `value_template` is true: unit `is_state(climate,'cool')` **and** truth is
+>    invalid (shared §3.0 definition) **and** the invalid state has persisted
+>    **≥ 120 s** via `(now() - states[truth].last_changed).total_seconds() >=
+>    120`. **The age gate is mandatory** — without it an automation reload could
+>    instantly shut a unit off on a brief blip (BLOCKER 2). OFF-only; four-zone
+>    independent; **no** inhibit helpers.
+> 7. **Static + parse validation:** parse the YAML
+>    (`python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in
+>    ['automations.yaml']]"` with the repo's custom-tag loader, or the test
+>    suite's loader) and run **`ha core check` when it is available**; report its
+>    output. If `ha core check` is unavailable in this environment, say so — do
+>    not fake it.
+> 8. **Make the test gate enforceable — in this order:**
+>    a. implement the YAML (steps 2–6);
 >    b. **remove all `xfail` markers** in
->       `tests/test_packetA_truth_unavailable_failsafe.py` (do not leave any);
+>       `tests/test_packetA_truth_unavailable_failsafe.py` (leave none);
 >    c. run the full suite `python -m pytest tests/ -rA`;
->    d. **require every Packet A test to PASS as a normal assertion** — there must
->       be **zero Packet A XFAIL and zero Packet A XPASS**. A green pytest exit
->       with remaining XPASS/XFAIL is **not** acceptance. The
->       `test_packet_a_xfail_markers_removed_once_implemented` gate will itself
->       fail the suite if markers remain after the guard is implemented.
->    Expected final result (no unrelated test-count changes): **150 passed, 0
->    xfailed, 0 xpassed** (design-only baseline is 136 passed + 14 xfailed; the 14
->    convert to passes once implemented and un-marked).
-> 10. **Reload minimally if safe:** reload the `automation` domain. The
->     reconciliation start-trigger only re-arms on a full HA restart; if your
->     environment requires a restart to register it, state that rather than
->     forcing one.
-> 11. **Verify via traces, not by endangering rooms:** confirm the supervisor
->     trace renders `off` for a simulated invalid truth and is unchanged for
->     healthy truth; confirm `v8_6_…` registers four template triggers and
->     `v8_6b_…` its start + periodic triggers. Do **not** force a real sensor
->     offline in a way that leaves an occupied room unsafe. Capture `run_id`s.
-> 12. **Exact rollback (on any failure/rejection):** `git checkout --
->     automations.yaml tests/test_packetA_truth_unavailable_failsafe.py` (or
->     `git revert <checkpoint-range>` if committed); re-run `python -m pytest
->     tests/` and `ha core check`; reload the `automation` domain; confirm the
->     trace shows the original `float(70)` path restored.
+>    d. **require every Packet A test to PASS as a normal assertion** — **zero
+>       Packet A XFAIL and zero XPASS**. A green exit with remaining XPASS/XFAIL is
+>       **not** acceptance; the `test_packet_a_xfail_markers_removed_once_implemented`
+>       gate fails the suite if markers remain after the guard is implemented.
+>    Expected final result (no unrelated test-count changes): **173 passed, 0
+>    xfailed, 0 xpassed** (design-only baseline is **156 passed + 17 xfailed**;
+>    the 17 convert to passes once implemented and un-marked).
+> 9. **Produce the exact diff and rollback plan, then STOP.** Output the full
+>    `git diff` of the implementation branch and a concrete rollback (`git
+>    checkout -- automations.yaml tests/test_packetA_truth_unavailable_failsafe.py`
+>    or `git revert <range>`; re-run pytest + `ha core check`). **Do NOT reload
+>    automations, do NOT merge, and do NOT touch live HA state.** Wait for
+>    explicit operator approval.
 >
-> Do not merge or deploy without operator sign-off. Produce a diff for review
-> first; report files changed, `ha core check` output, full pytest results
-> (showing 0 XFAIL/0 XPASS for Packet A), and the verifying `run_id`s.
+> ---
+> ### STAGE 2 — Deployment (ONLY after explicit operator approval)
+>
+> 1. **Apply/merge** the approved implementation branch to the live configuration.
+> 2. **Minimum safe reload:** reload the **`automation`** domain only. An
+>    automation reload **registers the new automations and their `time_pattern`
+>    periodic trigger without a full HA restart** — a restart is **not** required
+>    to arm the reconciliation sweep. Only the `homeassistant` **start** trigger
+>    itself waits for the next actual HA start to fire (its job is solely the
+>    post-restart settle sweep); the periodic `/5` trigger covers the interim. Do
+>    not force a restart.
+> 3. **Confirm registration:** verify `automation.v8_6_truth_unavailable_cooling_failsafe`
+>    shows four template triggers and `automation.v8_6b_truth_unavailable_cooling_reconciliation`
+>    shows its start + `/5` periodic triggers, and that the supervisor reloaded
+>    with the four `*_truth_ok` guards.
+> 4. **Observe ordinary behavior:** confirm the supervisor trace renders `off`
+>    for a (template-simulated) invalid truth and is **unchanged** for healthy
+>    truth; watch normal traces and state for one or more ordinary cycles.
+> 5. **Do not fabricate evidence by endangering rooms.** Do **not** disable a real
+>    sensor or force a unit offline to manufacture a live `run_id`. A live trigger
+>    trace is welcome **post-deployment evidence when it occurs safely on its
+>    own**, but it is **not** a prerequisite and must not be coerced.
+> 6. **Report:** files changed, reload method, registration confirmation, the
+>    pytest summary (0 XFAIL / 0 XPASS for Packet A), and any naturally-observed
+>    traces. Keep the Stage-1 rollback plan ready.
 
 ---
 
-## Decisions — APPROVED 2026-06-09
-1. **Debounce:** 2-minute persistent unavailable/non-numeric requirement on the
-   event-triggered protective-OFF automation. ✅ APPROVED. (Filters brief
-   SmartThings/template glitches; acts well before the 15-min supervisor cycle;
-   within the accepted maximum response window.)
+## Decisions — APPROVED 2026-06-09 (pass-3 hardened)
+1. **Debounce:** 2-minute persistent **invalid-truth** requirement on the
+   event-triggered protective-OFF automation, **and** the same 2-minute
+   invalid-age requirement on the reconciliation sweep (BLOCKER 2). ✅ APPROVED.
+   (Filters brief SmartThings/template glitches; acts well before the 15-min
+   supervisor cycle; reconciliation can no longer instant-OFF after a reload.)
 2. **Manual override:** the fail-safe **ignores** `timer.manual_hvac_override`,
    following the runaway-cooling / emergency-floor equipment-protection
    precedent. ✅ APPROVED.
 3. **Architecture — Design 1.** ✅ APPROVED. Per-zone `*_truth_ok` validation
    inside the V8.3 supervisor **before** any `float(70)`/deadband comparison;
-   unavailable/non-numeric truth ⇒ that zone is commanded OFF. Plus a separate
+   **invalid** truth ⇒ that zone is commanded OFF. Plus a separate
    event-triggered protective-OFF automation (2-min persistence, **OFF-only**,
-   never COOL, never independently restores cooling). Recovery authority remains
-   solely with the V8.3 supervisor once truth is numeric again. Do **not** add
-   four persistent inhibit helpers unless repository constraints prove Design 1
-   cannot be implemented safely.
+   never COOL, never independently restores cooling) and a reconciliation sweep.
+   Recovery authority remains solely with the V8.3 supervisor once truth is
+   finite again. Do **not** add four persistent inhibit helpers unless repository
+   constraints prove Design 1 cannot be implemented safely.
+4. **Validity = finite value (BLOCKER 1).** ✅ APPROVED. The shared definition
+   rejects `unknown`, `unavailable`, parse failures, **NaN**, **+infinity**, and
+   **−infinity**, using `float(none)` + self-equality + a broad **safety**
+   plausibility band (−90/200 °F) that is **not** an HVAC comfort/control
+   threshold. The supervisor guard, event automation, and reconciliation all use
+   semantically identical logic.
 
 ## Remaining unknowns (not silently resolved)
 - Live entity ID of the supervisor (`…` vs `…_rev_b`) and the `_2` suffix on the
@@ -557,6 +792,13 @@ until the runtime change lands (Codex removes the marks at implementation).
 - Whether a climate entity can report a transient `cool` during its own
   `unavailable` recovery (Samsung cloud) — minor edge; condition `cool`-gate
   handles it conservatively.
+- **`last_changed` edge:** if truth oscillates between two *different* invalid
+  values (e.g. `unavailable` → `NaN`), `last_changed` resets and the
+  reconciliation age can read <2 min even though truth was continuously invalid.
+  The event automation's template `for:` rides this (it stays true across the
+  switch); reconciliation is only the reload/restart backstop, so this is an
+  accepted minor edge. Confirm in live HA whether the truth template can emit
+  more than one distinct invalid string.
 
 **Reconciliation result:** Packet A design complete; no production change made.
 Packet B (raw vs smoothed/control) and V9 cooldown enforcement remain separate

--- a/tests/test_packetA_truth_unavailable_failsafe.py
+++ b/tests/test_packetA_truth_unavailable_failsafe.py
@@ -1,0 +1,343 @@
+"""Packet A contract tests — truth-sensor-unavailable cooling fail-safe.
+
+Design source: docs/packets/packetA_truth_unavailable_failsafe.md (PR #135).
+
+These encode the APPROVED Packet A Design 1 contract:
+  * Supervisor validates each zone's truth (has_value + numeric) BEFORE any
+    float(70) fallback / deadband comparison, and commands OFF when truth is
+    unavailable/non-numeric.
+  * A separate event-triggered automation forces a cooling unit OFF after a
+    2-minute persistent truth outage, OFF-only, ignoring manual override, never
+    restoring cooling.
+
+IMPORTANT — xfail policy:
+  The implementation-facing checks are marked ``xfail(strict=False)`` because the
+  runtime change is intentionally NOT applied on this design/test branch (no
+  automations.yaml change). They register as expected-failures today and will
+  flip to passing once Codex applies Design 1; at that point remove the xfail
+  marks (or set strict=True). The healthy-state / doctrine-preservation checks
+  are NOT xfail — they must pass now and continue to pass after implementation.
+"""
+
+import os
+
+import pytest
+import yaml
+
+PENDING = (
+    "Pending Packet A Design 1 implementation in automations.yaml "
+    "(Codex handoff). Design: docs/packets/packetA_truth_unavailable_failsafe.md"
+)
+
+SUPERVISOR_ID = "v7_5_main_supervisor"
+FAILSAFE_ID = "v8_6_truth_unavailable_cooling_failsafe"
+
+# zone-key -> (truth sensor, climate entity, truth_ok variable name)
+ZONES = {
+    "lr": (
+        "sensor.living_room_temperature_truth",
+        "climate.living_room_air",
+        "lr_truth_ok",
+    ),
+    "master": (
+        "sensor.master_bedroom_temperature_truth",
+        "climate.master_bedroom_air",
+        "master_truth_ok",
+    ),
+    "lincoln": (
+        "sensor.lincoln_s_room_temperature_truth",
+        "climate.lincoln_air",
+        "lincoln_truth_ok",
+    ),
+    "lilly": (
+        "sensor.lilly_s_room_temperature_truth",
+        "climate.lilly_air",
+        "lilly_truth_ok",
+    ),
+}
+
+
+class MooseLoader(yaml.SafeLoader):
+    pass
+
+
+def _scalar(prefix):
+    def _c(loader, node):
+        return f"{prefix}_{node.value}"
+
+    return _c
+
+
+def _empty_list(loader, node):
+    return []
+
+
+MooseLoader.add_constructor("!secret", _scalar("SECRET"))
+MooseLoader.add_constructor("!include", _scalar("INCLUDE"))
+MooseLoader.add_constructor("!input", _scalar("INPUT"))
+MooseLoader.add_constructor("!include_dir_merge_list", _empty_list)
+MooseLoader.add_constructor("!include_dir_named", _empty_list)
+
+
+@pytest.fixture(scope="module")
+def automations():
+    path = os.path.join(os.path.dirname(__file__), "..", "automations.yaml")
+    with open(path, "r") as fh:
+        return yaml.load(fh, Loader=MooseLoader)
+
+
+def _auto(automations, auto_id):
+    return next((a for a in automations if a.get("id") == auto_id), None)
+
+
+def _supervisor(automations):
+    sup = _auto(automations, SUPERVISOR_ID)
+    assert sup is not None, f"{SUPERVISOR_ID} must exist"
+    return sup
+
+
+def _cooling_branch(supervisor):
+    for step in supervisor.get("action", []):
+        if isinstance(step, dict) and "choose" in step:
+            for branch in step["choose"]:
+                for cond in branch.get("conditions", []):
+                    if "season == 'cooling'" in cond.get("value_template", ""):
+                        return branch
+    pytest.fail("Could not find the cooling-season branch in the supervisor")
+
+
+def _zone_hvac_template(branch, climate_entity):
+    for step in branch.get("sequence", []):
+        if not isinstance(step, dict):
+            continue
+        if (step.get("action") or step.get("service")) != "climate.set_temperature":
+            continue
+        target = step.get("target", {}).get("entity_id")
+        if target == climate_entity:
+            return step.get("data", {}).get("hvac_mode", "")
+    return None
+
+
+def _supervisor_control_variables(supervisor):
+    """Merge top-level + cooling-branch-direct ``variables`` (non-recursive).
+
+    Deliberately does NOT recurse into the shoulder/heating branches, which
+    redefine names like ``lr_off_at`` (as ``{{ target_lr }}``). The cooling
+    setpoint/threshold doctrine and the per-zone ``*_truth_ok`` flags both live
+    at the supervisor's top level or the cooling branch's direct sequence.
+    """
+    merged = {}
+    for step in supervisor.get("action", []):
+        if isinstance(step, dict) and isinstance(step.get("variables"), dict):
+            merged.update(step["variables"])
+    for step in _cooling_branch(supervisor).get("sequence", []):
+        if isinstance(step, dict) and isinstance(step.get("variables"), dict):
+            merged.update(step["variables"])
+    return merged
+
+
+def _render(template, **ctx):
+    jinja2 = pytest.importorskip("jinja2")
+    return jinja2.Environment().from_string(template).render(**ctx).strip()
+
+
+# Generic context covering every zone's variable names, so a single dict can
+# render any zone's hvac_mode template (extras are ignored by Jinja).
+def _ctx(**overrides):
+    base = dict(
+        lr_temp=70, master_temp=70, lincoln_temp=70, lilly_temp=70,
+        m_on_at=72, m_off_at=68, m_current="off",
+        l_on_at=72, l_off_at=68, l_current="off",
+        ly_on_at=72, ly_off_at=68, ly_current="off",
+        lr_on_at=72, lr_off_at=68, lr_current="off",
+        lr_truth_ok=True, master_truth_ok=True,
+        lincoln_truth_ok=True, lilly_truth_ok=True,
+    )
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# GROUP 1 — Healthy-state / doctrine preservation (MUST pass now and after)
+# ---------------------------------------------------------------------------
+
+def test_healthy_state_doctrine_unchanged(automations):
+    """Packet A must not change setpoints, thresholds, away, or Master sleep."""
+    v = _supervisor_control_variables(_supervisor(automations))
+    assert v.get("m_setpoint") == "{{ 61 }}"
+    assert v.get("l_setpoint") == "{{ 61 }}"
+    assert v.get("ly_setpoint") == "{{ 61 }}"
+    assert v.get("lr_setpoint") == "{{ 61 }}"
+    assert v.get("m_off_at") == "{{ 74 if away else (62 if is_master_sleep else 68) }}"
+    assert v.get("m_on_at") == "{{ 76 if away else (66 if is_master_sleep else 72) }}"
+    assert v.get("lr_off_at") == "{{ 74 if away else 68 }}"
+    assert v.get("lr_on_at") == "{{ 76 if away else 72 }}"
+    assert v.get("l_off_at") == "{{ 74 if away else 68 }}"
+    assert v.get("ly_on_at") == "{{ 76 if away else 72 }}"
+
+
+def test_healthy_deadband_behavior_unchanged(automations):
+    """With healthy truth, > on_at COOL / <= off_at OFF / else HOLD is intact.
+
+    Passes pre-implementation (no guard) and post-implementation (guard with
+    truth_ok=True passes through to the existing logic).
+    """
+    branch = _cooling_branch(_supervisor(automations))
+    tmpl = _zone_hvac_template(branch, "climate.master_bedroom_air")
+    assert tmpl, "Master cooling hvac_mode template must exist"
+    # daytime band 68/72, truth healthy
+    assert _render(tmpl, **_ctx(master_temp=73)) == "cool"             # above on_at
+    assert _render(tmpl, **_ctx(master_temp=72)) in ("off", "cool")    # equality boundary (HOLD off)
+    assert _render(tmpl, **_ctx(master_temp=72, m_current="off")) == "off"
+    assert _render(tmpl, **_ctx(master_temp=68)) == "off"              # at off_at
+    assert _render(tmpl, **_ctx(master_temp=70, m_current="off")) == "off"   # hold prior off
+    assert _render(tmpl, **_ctx(master_temp=70, m_current="cool")) == "cool"  # hold prior cool
+
+
+# ---------------------------------------------------------------------------
+# GROUP 2 — Supervisor truth-validity guard (xfail until implemented)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_supervisor_defines_per_zone_truth_ok(automations):
+    """Each zone validates truth via has_value BEFORE numeric conversion."""
+    v = _supervisor_control_variables(_supervisor(automations))
+    for _key, (truth, _clim, ok) in ZONES.items():
+        assert ok in v, f"supervisor must define {ok}"
+        assert "has_value" in v[ok], f"{ok} must validate via has_value (not float)"
+        assert truth in v[ok], f"{ok} must reference {truth}"
+
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_cooling_hvac_templates_guard_unavailable_before_cool(automations):
+    """Structural: each zone's hvac_mode guards on `not <zone>_truth_ok`,
+    and that guard precedes any `cool` decision (truth checked before deadband).
+    """
+    branch = _cooling_branch(_supervisor(automations))
+    for _key, (_truth, clim, ok) in ZONES.items():
+        tmpl = _zone_hvac_template(branch, clim) or ""
+        guard_idx = tmpl.find(f"not {ok}")
+        assert guard_idx != -1, f"{clim} hvac_mode must guard on `not {ok}`"
+        cool_idx = tmpl.find("cool")
+        assert cool_idx == -1 or guard_idx < cool_idx, (
+            f"{clim}: truth guard must come before any cool decision"
+        )
+
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_unavailable_truth_forces_off_each_zone(automations):
+    """Behavioral: with truth_ok=False and the float(70) value in/above band,
+    every zone renders OFF — no unavailable truth reaches float(70) as control.
+    """
+    branch = _cooling_branch(_supervisor(automations))
+    # current='cool' is the adversarial case (would HOLD cool without a guard)
+    for _key, (_truth, clim, ok) in ZONES.items():
+        tmpl = _zone_hvac_template(branch, clim)
+        assert tmpl, f"{clim} cooling hvac_mode template must exist"
+        ctx = _ctx(
+            **{ok: False},
+            m_current="cool", l_current="cool",
+            ly_current="cool", lr_current="cool",
+        )
+        out = _render(tmpl, **ctx)
+        assert out == "off", f"{clim}: unavailable truth must force OFF, got {out!r}"
+
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_master_sleep_unavailable_cannot_create_cool(automations):
+    """The float(70) Master-sleep false-COOL path is prevented.
+
+    Master sleep band is 62/66; float(70) > 66 would COOL without a guard.
+    """
+    branch = _cooling_branch(_supervisor(automations))
+    tmpl = _zone_hvac_template(branch, "climate.master_bedroom_air")
+    out = _render(
+        tmpl,
+        **_ctx(master_truth_ok=False, master_temp=70,
+               m_on_at=66, m_off_at=62, m_current="off"),
+    )
+    assert out == "off", f"Master sleep + unavailable truth must be OFF, got {out!r}"
+
+
+# ---------------------------------------------------------------------------
+# GROUP 3 — Event-triggered protective-OFF automation (xfail until implemented)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_event_failsafe_present_per_zone_unavailable_triggers(automations):
+    auto = _auto(automations, FAILSAFE_ID)
+    assert auto is not None, f"{FAILSAFE_ID} automation must exist"
+    triggered = {}
+    for trig in auto.get("trigger", []):
+        if trig.get("platform") != "state":
+            continue
+        to = trig.get("to")
+        to_set = set(to if isinstance(to, list) else [to])
+        if to_set & {"unavailable", "unknown"}:
+            triggered[trig.get("entity_id")] = trig
+    for _key, (truth, _clim, _ok) in ZONES.items():
+        assert truth in triggered, f"missing unavailable trigger for {truth}"
+
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_event_failsafe_two_minute_persistence(automations):
+    auto = _auto(automations, FAILSAFE_ID)
+    assert auto is not None
+    state_trigs = [t for t in auto.get("trigger", []) if t.get("platform") == "state"]
+    assert state_trigs, "fail-safe must have state triggers"
+    for trig in state_trigs:
+        for_val = trig.get("for")
+        assert for_val in ("00:02:00", 120, {"minutes": 2}, {"seconds": 120}), (
+            f"each truth trigger needs a 2-minute persistence, got {for_val!r}"
+        )
+
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_event_failsafe_only_commands_off_and_gates_on_cooling(automations):
+    auto = _auto(automations, FAILSAFE_ID)
+    assert auto is not None
+    actions = auto.get("action", [])
+    climate_calls = [
+        s for s in actions
+        if isinstance(s, dict)
+        and (s.get("action") or s.get("service"))
+        in ("climate.set_hvac_mode", "climate.set_temperature")
+    ]
+    assert climate_calls, "fail-safe must issue a climate command"
+    for call in climate_calls:
+        assert call.get("data", {}).get("hvac_mode") in ("off", False), (
+            "fail-safe may only command hvac_mode: off"
+        )
+    conds = auto.get("condition", [])
+    assert any("cool" in c.get("value_template", "") for c in conds), (
+        "fail-safe must act only when the unit is currently cooling"
+    )
+
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_event_failsafe_ignores_manual_override(automations):
+    """Approved: the safety path must NOT gate on manual override."""
+    auto = _auto(automations, FAILSAFE_ID)
+    assert auto is not None
+    import json
+
+    assert "manual_hvac_override" not in json.dumps(auto), (
+        "fail-safe must not reference timer.manual_hvac_override"
+    )
+
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_event_failsafe_recovery_never_turns_cooling_on(automations):
+    """No action in the fail-safe may command cool or otherwise restore cooling."""
+    auto = _auto(automations, FAILSAFE_ID)
+    assert auto is not None
+    for step in auto.get("action", []):
+        if not isinstance(step, dict):
+            continue
+        assert step.get("data", {}).get("hvac_mode") != "cool", (
+            "fail-safe action must never command cool"
+        )
+        service = step.get("action") or step.get("service")
+        assert service not in ("climate.turn_on",), (
+            "fail-safe must not turn climate on"
+        )

--- a/tests/test_packetA_truth_unavailable_failsafe.py
+++ b/tests/test_packetA_truth_unavailable_failsafe.py
@@ -31,6 +31,7 @@ PENDING = (
 
 SUPERVISOR_ID = "v7_5_main_supervisor"
 FAILSAFE_ID = "v8_6_truth_unavailable_cooling_failsafe"
+RECON_ID = "v8_6b_truth_unavailable_cooling_reconciliation"
 
 # zone-key -> (truth sensor, climate entity, truth_ok variable name)
 ZONES = {
@@ -136,6 +137,31 @@ def _supervisor_control_variables(supervisor):
     return merged
 
 
+def _collect_hvac_modes(node):
+    """Recursively gather every ``data.hvac_mode`` value in an action tree.
+
+    Handles nested structures: choose/sequence/default, repeat/for_each, if/then/
+    else, and plain action lists.
+    """
+    modes = []
+
+    def walk(obj):
+        if isinstance(obj, list):
+            for item in obj:
+                walk(item)
+        elif isinstance(obj, dict):
+            if isinstance(obj.get("data"), dict) and "hvac_mode" in obj["data"]:
+                modes.append(obj["data"]["hvac_mode"])
+            for key, val in obj.items():
+                if key == "data":
+                    continue
+                if isinstance(val, (list, dict)):
+                    walk(val)
+
+    walk(node)
+    return modes
+
+
 def _render(template, **ctx):
     jinja2 = pytest.importorskip("jinja2")
     return jinja2.Environment().from_string(template).render(**ctx).strip()
@@ -200,11 +226,18 @@ def test_healthy_deadband_behavior_unchanged(automations):
 
 @pytest.mark.xfail(reason=PENDING, strict=False)
 def test_supervisor_defines_per_zone_truth_ok(automations):
-    """Each zone validates truth via has_value BEFORE numeric conversion."""
+    """Each zone validates truth via has_value AND float(none) before deadband.
+
+    Both clauses are required so the guard rejects unavailable/unknown *and* any
+    arbitrary non-numeric string — the same validity the event path uses.
+    """
     v = _supervisor_control_variables(_supervisor(automations))
     for _key, (truth, _clim, ok) in ZONES.items():
         assert ok in v, f"supervisor must define {ok}"
-        assert "has_value" in v[ok], f"{ok} must validate via has_value (not float)"
+        assert "has_value" in v[ok], f"{ok} must validate via has_value"
+        assert "float(none)" in v[ok], (
+            f"{ok} must also reject arbitrary non-numeric via float(none)"
+        )
         assert truth in v[ok], f"{ok} must reference {truth}"
 
 
@@ -264,31 +297,51 @@ def test_master_sleep_unavailable_cannot_create_cool(automations):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.xfail(reason=PENDING, strict=False)
-def test_event_failsafe_present_per_zone_unavailable_triggers(automations):
+def test_event_failsafe_present_per_zone_validity_triggers(automations):
+    """Template triggers (not state-to-unavailable), one per zone, id=climate."""
     auto = _auto(automations, FAILSAFE_ID)
     assert auto is not None, f"{FAILSAFE_ID} automation must exist"
-    triggered = {}
-    for trig in auto.get("trigger", []):
-        if trig.get("platform") != "state":
-            continue
-        to = trig.get("to")
-        to_set = set(to if isinstance(to, list) else [to])
-        if to_set & {"unavailable", "unknown"}:
-            triggered[trig.get("entity_id")] = trig
-    for _key, (truth, _clim, _ok) in ZONES.items():
-        assert truth in triggered, f"missing unavailable trigger for {truth}"
+    template_trigs = {
+        t.get("id"): t
+        for t in auto.get("trigger", [])
+        if t.get("platform") == "template"
+    }
+    for _key, (truth, clim, _ok) in ZONES.items():
+        trig = template_trigs.get(clim)
+        assert trig is not None, f"missing template trigger with id={clim}"
+        vt = trig.get("value_template", "")
+        assert truth in vt, f"trigger {clim} must reference {truth}"
+
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_event_failsafe_validity_covers_non_numeric(automations):
+    """Validity must reject ANY non-numeric truth, not only unavailable/unknown.
+
+    Each trigger template must use ``float(none) is none`` (the same definition
+    as the supervisor guard), so a stray non-numeric string cannot bypass the
+    event path while being caught by the guard.
+    """
+    auto = _auto(automations, FAILSAFE_ID)
+    assert auto is not None
+    import json
+
+    blob = json.dumps(auto.get("trigger", []))
+    assert "float(none) is none" in blob, (
+        "event triggers must detect float(none) is none (arbitrary non-numeric)"
+    )
+    assert "has_value" in blob, "event triggers must also cover unavailable/unknown"
 
 
 @pytest.mark.xfail(reason=PENDING, strict=False)
 def test_event_failsafe_two_minute_persistence(automations):
     auto = _auto(automations, FAILSAFE_ID)
     assert auto is not None
-    state_trigs = [t for t in auto.get("trigger", []) if t.get("platform") == "state"]
-    assert state_trigs, "fail-safe must have state triggers"
-    for trig in state_trigs:
+    trigs = [t for t in auto.get("trigger", []) if t.get("platform") == "template"]
+    assert trigs, "fail-safe must have template triggers"
+    for trig in trigs:
         for_val = trig.get("for")
         assert for_val in ("00:02:00", 120, {"minutes": 2}, {"seconds": 120}), (
-            f"each truth trigger needs a 2-minute persistence, got {for_val!r}"
+            f"each validity trigger needs a 2-minute persistence, got {for_val!r}"
         )
 
 
@@ -340,4 +393,118 @@ def test_event_failsafe_recovery_never_turns_cooling_on(automations):
         service = step.get("action") or step.get("service")
         assert service not in ("climate.turn_on",), (
             "fail-safe must not turn climate on"
+        )
+
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_protective_off_not_blocked_by_notification(automations):
+    """Climate OFF must precede any notify, and any notify must be non-blocking.
+
+    Guarantees a missing/failed notification service cannot prevent or invalidate
+    the protective OFF.
+    """
+    auto = _auto(automations, FAILSAFE_ID)
+    assert auto is not None
+    actions = [s for s in auto.get("action", []) if isinstance(s, dict)]
+
+    def _svc(s):
+        return s.get("action") or s.get("service") or ""
+
+    off_idx = next(
+        (i for i, s in enumerate(actions)
+         if _svc(s) == "climate.set_hvac_mode"
+         and s.get("data", {}).get("hvac_mode") in ("off", False)),
+        None,
+    )
+    assert off_idx is not None, "fail-safe must issue climate.set_hvac_mode off"
+    for i, s in enumerate(actions):
+        if _svc(s).startswith("notify."):
+            assert i > off_idx, "notify must come AFTER the protective OFF"
+            assert s.get("continue_on_error") is True, (
+                "notify must be non-blocking (continue_on_error: true)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# GROUP 4 — Restart/reload reconciliation (xfail until implemented)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_reconciliation_present_restart_and_reload_safe(automations):
+    """Reconciliation has a homeassistant start trigger AND a periodic sweep.
+
+    Start trigger covers HA restart; the periodic time_pattern covers automation
+    reload (which fires no start event) and bounds any blind spot.
+    """
+    auto = _auto(automations, RECON_ID)
+    assert auto is not None, f"{RECON_ID} automation must exist"
+    platforms = {t.get("platform") for t in auto.get("trigger", [])}
+    assert "homeassistant" in platforms, "needs a homeassistant start trigger"
+    assert "time_pattern" in platforms, "needs a periodic reconciliation trigger"
+
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_reconciliation_startup_settle_delay(automations):
+    """Start path waits a bounded delay so briefly-unavailable startup entities
+    do not cause false protective shutdowns."""
+    auto = _auto(automations, RECON_ID)
+    assert auto is not None
+    import json
+
+    assert "delay" in json.dumps(auto.get("action", [])), (
+        "reconciliation start path must include a bounded settle delay"
+    )
+
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_reconciliation_off_only_all_zones_on_invalid_truth(automations):
+    """Reconciliation sweeps all four zones, OFF-only, gated on cool + invalid."""
+    auto = _auto(automations, RECON_ID)
+    assert auto is not None
+    import json
+
+    blob = json.dumps(auto.get("action", []))
+    for _key, (truth, clim, _ok) in ZONES.items():
+        assert truth in blob, f"reconciliation must consider {truth}"
+        assert clim in blob, f"reconciliation must consider {clim}"
+    assert "float(none) is none" in blob, "must use the shared invalid-truth test"
+    assert "'cool'" in blob or '"cool"' in blob, "must gate on a unit being cool"
+    # OFF-only: every hvac_mode set in the action tree is 'off'
+    for mode in _collect_hvac_modes(auto.get("action", [])):
+        assert mode in ("off", False), f"reconciliation may only set off, got {mode!r}"
+
+
+# ---------------------------------------------------------------------------
+# ENFORCEABLE GATE — must be a NORMAL test (green in both phases)
+# ---------------------------------------------------------------------------
+
+def test_packet_a_xfail_markers_removed_once_implemented(automations):
+    """Make the test gate enforceable.
+
+    ``xfail(strict=False)`` lets an XPASS slip through a green suite, so once the
+    runtime guard is implemented every Packet A marker MUST be removed and the
+    tests must run as ordinary assertions. This gate ties marker-removal to the
+    implementation signal (supervisor truth guards present in YAML):
+
+      * design phase  (guards absent): markers expected → pass.
+      * implemented   (guards present) AND markers removed: pass.
+      * implemented but markers left (the dangerous XPASS state): FAIL the suite.
+    """
+    v = _supervisor_control_variables(_supervisor(automations))
+    implemented = all(ok in v for _k, (_t, _c, ok) in ZONES.items())
+
+    marker = "@pytest.mark." + "xfail"  # built by concat so this line isn't a hit
+    with open(__file__, "r") as fh:
+        marker_count = fh.read().count(marker)
+
+    if implemented:
+        assert marker_count == 0, (
+            "Packet A runtime guard is implemented but xfail markers remain. "
+            "Remove every xfail marker so the contract tests run as enforced "
+            "assertions (zero XFAIL, zero XPASS)."
+        )
+    else:
+        assert marker_count >= 1, (
+            "Design phase expected: xfail markers should be present until the "
+            "runtime change lands."
         )

--- a/tests/test_packetA_truth_unavailable_failsafe.py
+++ b/tests/test_packetA_truth_unavailable_failsafe.py
@@ -3,23 +3,46 @@
 Design source: docs/packets/packetA_truth_unavailable_failsafe.md (PR #135).
 
 These encode the APPROVED Packet A Design 1 contract:
-  * Supervisor validates each zone's truth (has_value + numeric) BEFORE any
-    float(70) fallback / deadband comparison, and commands OFF when truth is
-    unavailable/non-numeric.
+  * Supervisor validates each zone's truth with a shared FINITE-VALUE definition
+    BEFORE any float(70) fallback / deadband comparison, and commands OFF when
+    truth is invalid (unavailable / unknown / parse failure / NaN / infinity).
   * A separate event-triggered automation forces a cooling unit OFF after a
     2-minute persistent truth outage, OFF-only, ignoring manual override, never
     restoring cooling.
+  * A restart/reload-safe reconciliation automation closes the for:-reset blind
+    spot, but ONLY forces OFF when the invalid state has persisted >= 2 minutes
+    (it must not bypass the approved 2-minute debounce after an automation
+    reload).
+
+Shared finite-value validity (BLOCKER 1):
+  The previous ``float(none) is not none`` test rejected ordinary parse failures
+  (``"err"``) but ACCEPTED ``"NaN"``/``"inf"`` because those parse to floating
+  point values. NaN collapses every threshold comparison to false (false HOLD)
+  and +/-infinity forces extreme threshold outcomes. The hardened definition
+  parses with ``float(none)`` and additionally requires the value to equal
+  itself (rejects NaN) and to fall inside a deliberately BROAD safety
+  plausibility window (rejects +/-infinity and absurd values). These bounds are
+  SAFETY-VALIDATION limits only and are intentionally far outside any HVAC
+  comfort/control threshold.
 
 IMPORTANT — xfail policy:
-  The implementation-facing checks are marked ``xfail(strict=False)`` because the
-  runtime change is intentionally NOT applied on this design/test branch (no
-  automations.yaml change). They register as expected-failures today and will
-  flip to passing once Codex applies Design 1; at that point remove the xfail
-  marks (or set strict=True). The healthy-state / doctrine-preservation checks
-  are NOT xfail — they must pass now and continue to pass after implementation.
+  The implementation-facing checks (they read automations.yaml, which is NOT
+  changed on this design/test branch) are marked ``xfail(strict=False)``. They
+  register as expected-failures today and flip to passing once Codex applies
+  Design 1; at that point every xfail mark MUST be removed (the enforceable gate
+  below fails the suite if the guard is implemented but markers remain).
+
+  The healthy-state / doctrine-preservation checks AND the design-proving
+  behavioral checks of the canonical validity + reconciliation expressions are
+  NOT xfail — they must pass now and continue to pass after implementation,
+  because they prove the chosen *definition* is sound independent of where it is
+  wired in.
 """
 
+import datetime
+import json
 import os
+import types
 
 import pytest
 import yaml
@@ -32,6 +55,19 @@ PENDING = (
 SUPERVISOR_ID = "v7_5_main_supervisor"
 FAILSAFE_ID = "v8_6_truth_unavailable_cooling_failsafe"
 RECON_ID = "v8_6b_truth_unavailable_cooling_reconciliation"
+
+# Broad SAFETY plausibility window for VALIDITY only (degrees F). These are NOT
+# comfort/control thresholds — they exist solely to reject +/-infinity and
+# absurd values while never rejecting any conceivable real indoor reading. They
+# are documented separately from every HVAC threshold (61 target; 68/72 home;
+# 74/76 away; 62/66 Master sleep; 60/58/76 safety gates).
+SAFETY_TEMP_MIN_F = -90
+SAFETY_TEMP_MAX_F = 200
+
+# Minimum duration a truth entity must remain invalid before the periodic /
+# startup reconciliation sweep is allowed to force OFF — identical to the event
+# automation's 2-minute debounce, so reconciliation never bypasses it.
+MIN_INVALID_SECONDS = 120
 
 # zone-key -> (truth sensor, climate entity, truth_ok variable name)
 ZONES = {
@@ -56,6 +92,67 @@ ZONES = {
         "lilly_truth_ok",
     ),
 }
+
+
+# ---------------------------------------------------------------------------
+# Canonical shared expressions (single source of truth for the contract).
+# The implementation in automations.yaml must be SEMANTICALLY IDENTICAL to
+# these; the xfail tests below assert the YAML carries the same fragments.
+# ---------------------------------------------------------------------------
+
+def truth_ok_expr(entity):
+    """Supervisor ``*_truth_ok`` form: truth is VALID (finite, usable)."""
+    return (
+        "{% set x = states('" + entity + "') | float(none) %}"
+        "{{ x is not none and x == x"
+        " and " + str(SAFETY_TEMP_MIN_F) + " <= x <= " + str(SAFETY_TEMP_MAX_F) + " }}"
+    )
+
+
+def truth_invalid_expr(entity):
+    """Event-trigger / reconciliation form: truth is INVALID (== not valid)."""
+    return (
+        "{% set x = states('" + entity + "') | float(none) %}"
+        "{{ x is none or x != x"
+        " or x < " + str(SAFETY_TEMP_MIN_F) + " or x > " + str(SAFETY_TEMP_MAX_F) + " }}"
+    )
+
+
+def reconciliation_decision_expr(truth_var="truth", climate_var="climate"):
+    """Per-zone reconciliation decision: force OFF iff the unit is cooling AND
+    truth is invalid AND that invalid state has persisted >= 2 minutes.
+
+    The age basis is the truth entity's current-state timestamp
+    (``last_changed``): when a numeric value transitions to an invalid state HA
+    updates ``last_changed``, so ``now() - last_changed`` is the age of the
+    current invalid episode. An automation reload does NOT reset entity states,
+    so this age survives a reload and the debounce is preserved.
+    """
+    return (
+        "{% set x = states(" + truth_var + ") | float(none) %}"
+        "{% set invalid = x is none or x != x"
+        " or x < " + str(SAFETY_TEMP_MIN_F) + " or x > " + str(SAFETY_TEMP_MAX_F) + " %}"
+        "{% set st = states[" + truth_var + "] %}"
+        "{% set invalid_age = (now() - st.last_changed).total_seconds()"
+        " if st is not none else 0 %}"
+        "{{ is_state(" + climate_var + ", 'cool')"
+        " and invalid and invalid_age >= " + str(MIN_INVALID_SECONDS) + " }}"
+    )
+
+
+# Adversarial truth values that MUST be treated as invalid (BLOCKER 1).
+INVALID_TRUTH_VALUES = [
+    "err",          # ordinary parse failure
+    "NaN", "nan",   # not-a-number (parses to a float, but x != x)
+    "inf", "-inf",  # infinities (parse to a float)
+    "Infinity", "-Infinity",
+    "",             # empty string
+    "unknown",
+    "unavailable",
+]
+
+# Ordinary signed / decimal temperatures that MUST remain valid (BLOCKER 1 / 7).
+HEALTHY_TRUTH_VALUES = ["70", "61.5", "-3.2", "0", "68.0", "75.2"]
 
 
 class MooseLoader(yaml.SafeLoader):
@@ -167,6 +264,60 @@ def _render(template, **ctx):
     return jinja2.Environment().from_string(template).render(**ctx).strip()
 
 
+def _render_validity(expr, value):
+    """Render a validity expression with ``states()`` returning ``value``."""
+    jinja2 = pytest.importorskip("jinja2")
+    return jinja2.Environment().from_string(expr).render(states=lambda _e: value).strip()
+
+
+class _FakeStates:
+    """Stands in for HA's ``states`` object: callable (``states(e)`` -> value)
+    and subscriptable (``states[e]`` -> a state object with ``last_changed``)."""
+
+    def __init__(self, value, last_changed):
+        self._value = value
+        self._last_changed = last_changed
+
+    def __call__(self, _entity_id):
+        return self._value
+
+    def __getitem__(self, _entity_id):
+        return types.SimpleNamespace(last_changed=self._last_changed)
+
+
+def _render_reconciliation(expr, *, climate_state, truth_value, invalid_age_seconds):
+    """Render the reconciliation decision with controllable state-age."""
+    jinja2 = pytest.importorskip("jinja2")
+    now = datetime.datetime(2026, 6, 9, 12, 0, 0)
+    last_changed = now - datetime.timedelta(seconds=invalid_age_seconds)
+    return (
+        jinja2.Environment()
+        .from_string(expr)
+        .render(
+            truth="sensor.t",
+            climate="climate.c",
+            states=_FakeStates(truth_value, last_changed),
+            now=lambda: now,
+            is_state=lambda _e, state: climate_state == state,
+        )
+        .strip()
+    )
+
+
+def _assert_finite_validity_fragments(text, where):
+    """Assert a YAML-embedded validity expression carries the shared finite
+    definition: parse with float(none), reject NaN via self-(in)equality, and
+    bound to the broad safety window (rejects +/-infinity)."""
+    assert "float(none)" in text, f"{where} must parse with float(none)"
+    assert ("x == x" in text or "x != x" in text), (
+        f"{where} must reject NaN via a self-(in)equality test (x == x / x != x)"
+    )
+    assert str(SAFETY_TEMP_MIN_F) in text and str(SAFETY_TEMP_MAX_F) in text, (
+        f"{where} must bound to the broad safety window "
+        f"[{SAFETY_TEMP_MIN_F}, {SAFETY_TEMP_MAX_F}] to reject infinity"
+    )
+
+
 # Generic context covering every zone's variable names, so a single dict can
 # render any zone's hvac_mode template (extras are ignored by Jinja).
 def _ctx(**overrides):
@@ -221,24 +372,126 @@ def test_healthy_deadband_behavior_unchanged(automations):
 
 
 # ---------------------------------------------------------------------------
+# GROUP 1b — Canonical finite-value validity definition (DESIGN-PROVING, green)
+# Proves the chosen definition rejects NaN/infinity/parse-failures and keeps
+# ordinary temperatures valid, independent of where it is wired in. (BLOCKER 1)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("value", INVALID_TRUTH_VALUES)
+def test_finite_validity_rejects_invalid_values(value):
+    """err / NaN / nan / inf / -inf / Infinity / unknown / unavailable / empty
+    are all INVALID under the shared finite-value definition (both forms)."""
+    entity = "sensor.living_room_temperature_truth"
+    # supervisor VALID form -> "False"; event/recon INVALID form -> "True"
+    assert _render_validity(truth_ok_expr(entity), value) == "False", (
+        f"{value!r} must NOT be a valid control temperature"
+    )
+    assert _render_validity(truth_invalid_expr(entity), value) == "True", (
+        f"{value!r} must be detected as invalid"
+    )
+
+
+@pytest.mark.parametrize("value", HEALTHY_TRUTH_VALUES)
+def test_finite_validity_accepts_healthy_temperatures(value):
+    """Ordinary signed and decimal temperatures remain valid (BLOCKER 1 / 7)."""
+    entity = "sensor.living_room_temperature_truth"
+    assert _render_validity(truth_ok_expr(entity), value) == "True", (
+        f"{value!r} is an ordinary temperature and must stay valid"
+    )
+    assert _render_validity(truth_invalid_expr(entity), value) == "False", (
+        f"{value!r} must NOT be flagged invalid"
+    )
+
+
+def test_supervisor_and_event_validity_are_semantically_identical():
+    """The supervisor VALID form and the event/reconciliation INVALID form are
+    exact logical negations across all candidates — i.e. one shared definition
+    (BLOCKER 1 test 3)."""
+    entity = "sensor.master_bedroom_temperature_truth"
+    for value in INVALID_TRUTH_VALUES + HEALTHY_TRUTH_VALUES:
+        valid = _render_validity(truth_ok_expr(entity), value)
+        invalid = _render_validity(truth_invalid_expr(entity), value)
+        assert {valid, invalid} == {"True", "False"}, (
+            f"{value!r}: valid={valid} invalid={invalid} are not negations"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GROUP 1c — Canonical reconciliation persistence decision (DESIGN-PROVING)
+# Proves the periodic/startup sweep honours the 2-minute debounce. (BLOCKER 2)
+# ---------------------------------------------------------------------------
+
+def test_reconciliation_decision_holds_off_when_invalid_age_under_two_minutes():
+    """A brief invalid state (e.g. just after a reload) must NOT force OFF."""
+    expr = reconciliation_decision_expr()
+    assert _render_reconciliation(
+        expr, climate_state="cool", truth_value="unavailable", invalid_age_seconds=60
+    ) == "False", "invalid for <2 min must not force OFF"
+    assert _render_reconciliation(
+        expr, climate_state="cool", truth_value="unavailable", invalid_age_seconds=119
+    ) == "False", "still under 2 min must not force OFF"
+
+
+def test_reconciliation_decision_forces_off_when_invalid_age_at_least_two_minutes():
+    """Sustained (>=2 min) invalid truth while cooling forces OFF — including
+    NaN/infinity, which share the finite-value definition (BLOCKER 2 test 5)."""
+    expr = reconciliation_decision_expr()
+    assert _render_reconciliation(
+        expr, climate_state="cool", truth_value="unavailable", invalid_age_seconds=120
+    ) == "True", "exactly 2 min invalid + cooling must force OFF"
+    assert _render_reconciliation(
+        expr, climate_state="cool", truth_value="unavailable", invalid_age_seconds=600
+    ) == "True"
+    assert _render_reconciliation(
+        expr, climate_state="cool", truth_value="NaN", invalid_age_seconds=600
+    ) == "True", "NaN is invalid for reconciliation too"
+
+
+def test_reconciliation_decision_ignores_healthy_and_noncooling():
+    """No OFF for healthy truth, and no OFF for a unit that is not cooling."""
+    expr = reconciliation_decision_expr()
+    assert _render_reconciliation(
+        expr, climate_state="cool", truth_value="70", invalid_age_seconds=600
+    ) == "False", "healthy truth must never force OFF"
+    assert _render_reconciliation(
+        expr, climate_state="off", truth_value="unavailable", invalid_age_seconds=600
+    ) == "False", "a non-cooling unit must never be touched"
+
+
+# ---------------------------------------------------------------------------
 # GROUP 2 — Supervisor truth-validity guard (xfail until implemented)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.xfail(reason=PENDING, strict=False)
 def test_supervisor_defines_per_zone_truth_ok(automations):
-    """Each zone validates truth via has_value AND float(none) before deadband.
-
-    Both clauses are required so the guard rejects unavailable/unknown *and* any
-    arbitrary non-numeric string — the same validity the event path uses.
-    """
+    """Each zone validates truth via the shared FINITE-VALUE definition before
+    the deadband: parse with float(none), reject NaN (self-equality), and bound
+    to the broad safety window (rejects infinity). Same definition the event
+    path uses."""
     v = _supervisor_control_variables(_supervisor(automations))
     for _key, (truth, _clim, ok) in ZONES.items():
         assert ok in v, f"supervisor must define {ok}"
-        assert "has_value" in v[ok], f"{ok} must validate via has_value"
-        assert "float(none)" in v[ok], (
-            f"{ok} must also reject arbitrary non-numeric via float(none)"
-        )
-        assert truth in v[ok], f"{ok} must reference {truth}"
+        expr = v[ok]
+        assert truth in expr, f"{ok} must reference {truth}"
+        _assert_finite_validity_fragments(expr, ok)
+
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_supervisor_guard_rejects_nan_and_infinity(automations):
+    """Behavioral: render each zone's actual ``*_truth_ok`` expression from the
+    live YAML against NaN / +inf / -inf and confirm it reports invalid (False),
+    while ordinary temperatures report valid (True). (BLOCKER 1 tests 1 & 2)"""
+    v = _supervisor_control_variables(_supervisor(automations))
+    for _key, (_truth, _clim, ok) in ZONES.items():
+        expr = v.get(ok, "")
+        for bad in ("NaN", "nan", "inf", "-inf", "err", "unavailable"):
+            assert _render_validity(expr, bad) == "False", (
+                f"{ok}: {bad!r} must be rejected by the supervisor guard"
+            )
+        for good in ("70", "61.5", "-3.2"):
+            assert _render_validity(expr, good) == "True", (
+                f"{ok}: {good!r} must remain valid"
+            )
 
 
 @pytest.mark.xfail(reason=PENDING, strict=False)
@@ -260,7 +513,7 @@ def test_cooling_hvac_templates_guard_unavailable_before_cool(automations):
 @pytest.mark.xfail(reason=PENDING, strict=False)
 def test_unavailable_truth_forces_off_each_zone(automations):
     """Behavioral: with truth_ok=False and the float(70) value in/above band,
-    every zone renders OFF — no unavailable truth reaches float(70) as control.
+    every zone renders OFF — no invalid truth reaches float(70) as control.
     """
     branch = _cooling_branch(_supervisor(automations))
     # current='cool' is the adversarial case (would HOLD cool without a guard)
@@ -273,7 +526,7 @@ def test_unavailable_truth_forces_off_each_zone(automations):
             ly_current="cool", lr_current="cool",
         )
         out = _render(tmpl, **ctx)
-        assert out == "off", f"{clim}: unavailable truth must force OFF, got {out!r}"
+        assert out == "off", f"{clim}: invalid truth must force OFF, got {out!r}"
 
 
 @pytest.mark.xfail(reason=PENDING, strict=False)
@@ -289,7 +542,7 @@ def test_master_sleep_unavailable_cannot_create_cool(automations):
         **_ctx(master_truth_ok=False, master_temp=70,
                m_on_at=66, m_off_at=62, m_current="off"),
     )
-    assert out == "off", f"Master sleep + unavailable truth must be OFF, got {out!r}"
+    assert out == "off", f"Master sleep + invalid truth must be OFF, got {out!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -314,22 +567,23 @@ def test_event_failsafe_present_per_zone_validity_triggers(automations):
 
 
 @pytest.mark.xfail(reason=PENDING, strict=False)
-def test_event_failsafe_validity_covers_non_numeric(automations):
-    """Validity must reject ANY non-numeric truth, not only unavailable/unknown.
-
-    Each trigger template must use ``float(none) is none`` (the same definition
-    as the supervisor guard), so a stray non-numeric string cannot bypass the
-    event path while being caught by the guard.
-    """
+def test_event_failsafe_validity_uses_finite_value_definition(automations):
+    """Each trigger must use the shared FINITE-VALUE definition, not the old
+    ``float(none) is not none`` test — so NaN / infinity cannot bypass the event
+    path while being caught by the supervisor guard. (BLOCKER 1 test 3)"""
     auto = _auto(automations, FAILSAFE_ID)
     assert auto is not None
-    import json
-
-    blob = json.dumps(auto.get("trigger", []))
-    assert "float(none) is none" in blob, (
-        "event triggers must detect float(none) is none (arbitrary non-numeric)"
-    )
-    assert "has_value" in blob, "event triggers must also cover unavailable/unknown"
+    trigs = [t for t in auto.get("trigger", []) if t.get("platform") == "template"]
+    assert trigs, "fail-safe must have template triggers"
+    for trig in trigs:
+        vt = trig.get("value_template", "")
+        _assert_finite_validity_fragments(vt, f"event trigger {trig.get('id')}")
+        # And it must actually flag NaN/inf/etc as invalid when rendered.
+        for bad in ("NaN", "inf", "-inf", "err", "unavailable"):
+            assert _render_validity(vt, bad) == "True", (
+                f"event trigger {trig.get('id')}: {bad!r} must read invalid"
+            )
+        assert _render_validity(vt, "70") == "False", "70 must read valid"
 
 
 @pytest.mark.xfail(reason=PENDING, strict=False)
@@ -372,8 +626,6 @@ def test_event_failsafe_ignores_manual_override(automations):
     """Approved: the safety path must NOT gate on manual override."""
     auto = _auto(automations, FAILSAFE_ID)
     assert auto is not None
-    import json
-
     assert "manual_hvac_override" not in json.dumps(auto), (
         "fail-safe must not reference timer.manual_hvac_override"
     )
@@ -449,29 +701,88 @@ def test_reconciliation_startup_settle_delay(automations):
     do not cause false protective shutdowns."""
     auto = _auto(automations, RECON_ID)
     assert auto is not None
-    import json
-
     assert "delay" in json.dumps(auto.get("action", [])), (
         "reconciliation start path must include a bounded settle delay"
     )
 
 
 @pytest.mark.xfail(reason=PENDING, strict=False)
-def test_reconciliation_off_only_all_zones_on_invalid_truth(automations):
-    """Reconciliation sweeps all four zones, OFF-only, gated on cool + invalid."""
+def test_reconciliation_uses_finite_value_definition(automations):
+    """Reconciliation sweeps all four zones, OFF-only, and uses the SAME shared
+    finite-value definition as the supervisor guard and event path."""
     auto = _auto(automations, RECON_ID)
     assert auto is not None
-    import json
-
     blob = json.dumps(auto.get("action", []))
     for _key, (truth, clim, _ok) in ZONES.items():
         assert truth in blob, f"reconciliation must consider {truth}"
         assert clim in blob, f"reconciliation must consider {clim}"
-    assert "float(none) is none" in blob, "must use the shared invalid-truth test"
+    _assert_finite_validity_fragments(blob, "reconciliation")
     assert "'cool'" in blob or '"cool"' in blob, "must gate on a unit being cool"
     # OFF-only: every hvac_mode set in the action tree is 'off'
     for mode in _collect_hvac_modes(auto.get("action", [])):
         assert mode in ("off", False), f"reconciliation may only set off, got {mode!r}"
+
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_reconciliation_requires_two_minute_invalid_persistence(automations):
+    """BLOCKER 2: the periodic/startup sweep must only force OFF once the invalid
+    state has persisted >= 2 minutes (state-age check on the truth entity's
+    current invalid-state timestamp). It must NOT force OFF on a brief invalid
+    state right after an automation reload."""
+    auto = _auto(automations, RECON_ID)
+    assert auto is not None
+    blob = json.dumps(auto.get("action", []))
+    assert "last_changed" in blob, (
+        "reconciliation must check the invalid-state age via last_changed"
+    )
+    # The 2-minute floor must be present in some accepted form.
+    assert any(
+        tok in blob
+        for tok in (str(MIN_INVALID_SECONDS), "00:02:00", "minutes=2", "minutes': 2")
+    ), "reconciliation must require >= 2 minutes of persistent invalid truth"
+
+
+@pytest.mark.xfail(reason=PENDING, strict=False)
+def test_reconciliation_startup_does_not_bypass_persistence(automations):
+    """BLOCKER 2 / test 6: startup may keep its settle delay, but after that
+    delay it must use the SAME age-gated sweep — there must be no OFF action that
+    is reachable without the >=2-minute invalid-age condition."""
+    auto = _auto(automations, RECON_ID)
+    assert auto is not None
+    actions = auto.get("action", [])
+    blob = json.dumps(actions)
+    # A settle delay exists for the start path...
+    assert "delay" in blob, "start path must retain a bounded settle delay"
+    # ...and every OFF is age-gated: each if/then that forces OFF must carry the
+    # last_changed age check in its condition.
+    ifs_with_age = []
+
+    def walk(obj):
+        if isinstance(obj, list):
+            for item in obj:
+                walk(item)
+        elif isinstance(obj, dict):
+            if "if" in obj:
+                cond_blob = json.dumps(obj.get("if"))
+                then_modes = _collect_hvac_modes(obj.get("then", []))
+                if any(m in ("off", False) for m in then_modes):
+                    ifs_with_age.append("last_changed" in cond_blob)
+            for val in obj.values():
+                if isinstance(val, (list, dict)):
+                    walk(val)
+
+    walk(actions)
+    assert ifs_with_age, "reconciliation must force OFF inside an if/then block"
+    assert all(ifs_with_age), (
+        "every reconciliation OFF must be gated by the invalid-age (last_changed) "
+        "check — startup must not bypass the 2-minute persistence"
+    )
+    # And there must be no top-level/unconditional OFF outside an if.
+    for step in actions:
+        if isinstance(step, dict) and (
+            (step.get("action") or step.get("service")) == "climate.set_hvac_mode"
+        ):
+            pytest.fail("reconciliation must not issue an unconditional climate.set_hvac_mode")
 
 
 # ---------------------------------------------------------------------------
@@ -486,7 +797,7 @@ def test_packet_a_xfail_markers_removed_once_implemented(automations):
     tests must run as ordinary assertions. This gate ties marker-removal to the
     implementation signal (supervisor truth guards present in YAML):
 
-      * design phase  (guards absent): markers expected → pass.
+      * design phase  (guards absent): markers expected -> pass.
       * implemented   (guards present) AND markers removed: pass.
       * implemented but markers left (the dangerous XPASS state): FAIL the suite.
     """


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive design audit and contract test suite for Packet A, which addresses a critical safety gap in the four-zone cooling supervisor: when a truth sensor becomes unavailable or invalid (NaN, infinity, parse failure), the supervisor's `float(70)` fallback can cause false HOLD/COOL states while truth-based safety gates become inert.

## Changes

### New Test Suite: `tests/test_packetA_truth_unavailable_failsafe.py`
- **821 lines** of design-proving contract tests covering the approved Packet A Design 1
- **GROUP 1 (Doctrine Preservation):** Validates that healthy-state behavior and existing setpoint/threshold doctrine remain unchanged
- **GROUP 1b (Canonical Validity Definition):** Design-proving tests that verify the shared finite-value validity definition correctly rejects `NaN`, `±infinity`, parse failures, and `unknown`/`unavailable` while accepting ordinary temperatures—independent of implementation location
- **GROUP 1c (Reconciliation Persistence):** Proves the periodic/startup reconciliation sweep honors the 2-minute debounce and cannot bypass it via automation reload
- **GROUP 2 (Supervisor Guard):** Implementation-facing xfail tests that verify per-zone `*_truth_ok` variables are defined and use the shared finite-value definition
- **GROUP 3 (Event Automation):** xfail tests confirming the event-triggered protective-OFF automation exists and uses the same validity definition
- **GROUP 4 (Reconciliation Automation):** xfail tests for the restart/reload-safe reconciliation sweep
- **GROUP 5 (Integration & Regression):** End-to-end behavioral tests proving the guard prevents false COOL in Master sleep mode and other scenarios

**xfail Policy:** Implementation-facing checks are marked `xfail(strict=False)` and will flip to passing once Codex applies Design 1 YAML. An enforceable gate test fails the suite if the guard is implemented but markers remain.

### Design Documentation: `docs/packets/packetA_truth_unavailable_failsafe.md`
- **805 lines** of detailed design specification (read-only, not to be applied)
- **§0:** Audit source verification against live `automations.yaml` and failure mode arithmetic
- **§1:** Recommended two-part design (supervisor guard + event automation) with rationale
- **§2:** Options comparison table (5 options evaluated; Option 2 + guard selected)
- **§3:** Proposed YAML pseudocode (illustrative only):
  - **§3.0:** Shared finite-value validity definition (canonical VALID and INVALID forms)
  - **§3a:** Supervisor per-zone `*_truth_ok` guard (prepended to hvac_mode templates)
  - **§3b:** Event-triggered protective-OFF automation with 2-minute debounce
  - **§3c:** Restart/reload-safe reconciliation automation with `last_changed` age-based persistence
- **§4–10:** Implementation notes, test gate, notifier verification, and known unknowns

### Audit Report: `docs/audits/v8_3_supervisor_audit_2026-06-09.md`
- **249 lines** of read-only architecture audit of the V8.3 supervisor
- Confirms the supervisor correctly implements the verified cooling design (deadband, setpoint, season/away/sleep modes)
- Documents entity dependency map and intermediate template layers
- Identifies three findings:
  - **Finding 1:** 15-minute compressor cooldown is defined but unused in the control path (deferred to V9 backlog)
  - **Finding 2:** Night mode (`lr_night_primary`) only affects heating season, not cooling
  - **Finding 3:** Supervisor reads raw `sensor.*_temperature_truth`, not the smoothed/control layers (routing clarification)
- Reconfirms the truth-unavailable failure mode (C1) as the motivation for Packet A

## Notable Implementation Details

1. **Shared Finite-Value Definition (BLOCKER 1):** The canonical validity test uses four conditions to reject all invalid states:
   - `float(none

https://claude.ai/code/session_01H7k1iBVc5ThL3MHZ3xvWMK