### PR TITLE
Add Packet A truth-unavailable cooling failsafe and supervisor truth-validity guards

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -370,6 +370,18 @@
   action:
     - variables:
         outdoor: "{{ states('sensor.deck_temperature_truth') | float(50) }}"
+        lr_truth_ok: >-
+          {% set x = states('sensor.living_room_temperature_truth') | float(none) %}
+          {{ x is not none and x == x and -90 <= x <= 200 }}
+        master_truth_ok: >-
+          {% set x = states('sensor.master_bedroom_temperature_truth') | float(none) %}
+          {{ x is not none and x == x and -90 <= x <= 200 }}
+        lincoln_truth_ok: >-
+          {% set x = states('sensor.lincoln_s_room_temperature_truth') | float(none) %}
+          {{ x is not none and x == x and -90 <= x <= 200 }}
+        lilly_truth_ok: >-
+          {% set x = states('sensor.lilly_s_room_temperature_truth') | float(none) %}
+          {{ x is not none and x == x and -90 <= x <= 200 }}
         lr_temp: "{{ states('sensor.living_room_temperature_truth') | float(70) }}"
         master_temp: "{{ states('sensor.master_bedroom_temperature_truth') | float(70) }}"
         lincoln_temp: "{{ states('sensor.lincoln_s_room_temperature_truth') | float(70) }}"
@@ -424,7 +436,8 @@
               target: { entity_id: climate.master_bedroom_air }
               data:
                 hvac_mode: >-
-                  {% if master_temp > m_on_at %}cool
+                  {% if not master_truth_ok %}off
+                  {% elif master_temp > m_on_at %}cool
                   {% elif master_temp <= m_off_at %}off
                   {% elif m_current == 'cool' %}cool
                   {% else %}off{% endif %}
@@ -444,7 +457,8 @@
               target: { entity_id: climate.lincoln_air }
               data:
                 hvac_mode: >-
-                  {% if lincoln_temp > l_on_at %}cool
+                  {% if not lincoln_truth_ok %}off
+                  {% elif lincoln_temp > l_on_at %}cool
                   {% elif lincoln_temp <= l_off_at %}off
                   {% elif l_current == 'cool' %}cool
                   {% else %}off{% endif %}
@@ -464,7 +478,8 @@
               target: { entity_id: climate.lilly_air }
               data:
                 hvac_mode: >-
-                  {% if lilly_temp > ly_on_at %}cool
+                  {% if not lilly_truth_ok %}off
+                  {% elif lilly_temp > ly_on_at %}cool
                   {% elif lilly_temp <= ly_off_at %}off
                   {% elif ly_current == 'cool' %}cool
                   {% else %}off{% endif %}
@@ -485,7 +500,8 @@
               target: { entity_id: climate.living_room_air }
               data:
                 hvac_mode: >-
-                  {% if lr_temp > lr_on_at %}cool
+                  {% if not lr_truth_ok %}off
+                  {% elif lr_temp > lr_on_at %}cool
                   {% elif lr_temp <= lr_off_at %}off
                   {% elif lr_current == 'cool' %}cool
                   {% else %}off{% endif %}
@@ -525,7 +541,8 @@
                       target: { entity_id: climate.master_bedroom_air }
                       data:
                         hvac_mode: >-
-                          {% if master_temp > m_sleep_on_at %}cool
+                          {% if not master_truth_ok %}off
+                          {% elif master_temp > m_sleep_on_at %}cool
                           {% elif master_temp <= m_sleep_off_at %}off
                           {% elif m_current == 'cool' %}cool
                           {% else %}off{% endif %}
@@ -541,13 +558,13 @@
                       sequence:
                         - action: climate.set_temperature
                           target: { entity_id: climate.master_bedroom_air }
-                          data: { hvac_mode: "{{ 'cool' if master_temp > 70 else 'off' }}", temperature: 61 }
+                          data: { hvac_mode: "{{ 'off' if not master_truth_ok else ('cool' if master_temp > 70 else 'off') }}", temperature: 61 }
                         - action: climate.set_temperature
                           target: { entity_id: climate.lincoln_air }
-                          data: { hvac_mode: "{{ 'cool' if lincoln_temp > 70 else 'off' }}", temperature: 61 }
+                          data: { hvac_mode: "{{ 'off' if not lincoln_truth_ok else ('cool' if lincoln_temp > 70 else 'off') }}", temperature: 61 }
                         - action: climate.set_temperature
                           target: { entity_id: climate.lilly_air }
-                          data: { hvac_mode: "{{ 'cool' if lilly_temp > 70 else 'off' }}", temperature: 61 }
+                          data: { hvac_mode: "{{ 'off' if not lilly_truth_ok else ('cool' if lilly_temp > 70 else 'off') }}", temperature: 61 }
                         - action: climate.set_hvac_mode
                           target: { entity_id: [climate.living_room_air, climate.dining_room] }
                           data: { hvac_mode: "off" }
@@ -688,6 +705,121 @@
 # Design rule: comfort policy lives in Section 2. Runaway protection lives
 # here. The two should not overlap. If they do, the controller is broken.
 # =============================================================================
+
+# -----------------------------------------------------------------------------
+# V8.6 TRUTH-UNAVAILABLE COOLING FAILSAFE
+# -----------------------------------------------------------------------------
+# If a canonical room truth sensor becomes invalid while its mini-split is
+# cooling, force that head OFF after a two-minute persistence window. This is
+# intentionally OFF-only: it prevents hidden 70°F fallbacks from sustaining
+# cooling, but never authorizes new cooling and never relies on template
+# compressor-intent sensors as physical proof.
+# -----------------------------------------------------------------------------
+- id: v8_6_truth_unavailable_cooling_failsafe
+  alias: "V8.6: Truth Unavailable Cooling Failsafe"
+  mode: queued
+  trigger:
+    - platform: template
+      id: living_room_air
+      value_template: >-
+        {% set x = states('sensor.living_room_temperature_truth') | float(none) %}
+        {{ x is none or x != x or x < -90 or x > 200 }}
+      for: "00:02:00"
+    - platform: template
+      id: master_bedroom_air
+      value_template: >-
+        {% set x = states('sensor.master_bedroom_temperature_truth') | float(none) %}
+        {{ x is none or x != x or x < -90 or x > 200 }}
+      for: "00:02:00"
+    - platform: template
+      id: lincoln_air
+      value_template: >-
+        {% set x = states('sensor.lincoln_s_room_temperature_truth') | float(none) %}
+        {{ x is none or x != x or x < -90 or x > 200 }}
+      for: "00:02:00"
+    - platform: template
+      id: lilly_air
+      value_template: >-
+        {% set x = states('sensor.lilly_s_room_temperature_truth') | float(none) %}
+        {{ x is none or x != x or x < -90 or x > 200 }}
+      for: "00:02:00"
+  action:
+    - variables:
+        climate_entity: "{{ 'climate.' ~ trigger.id }}"
+    - choose:
+        - conditions:
+            - condition: template
+              value_template: "{{ states(climate_entity) == 'cool' }}"
+          sequence:
+            - action: climate.set_hvac_mode
+              target:
+                entity_id: "{{ climate_entity }}"
+              data:
+                hvac_mode: "off"
+            - action: persistent_notification.create
+              continue_on_error: true
+              data:
+                title: "Truth unavailable cooling failsafe"
+                message: >-
+                  Forced {{ climate_entity }} off because its room truth sensor
+                  was invalid for at least two minutes while the climate entity
+                  reported cool.
+
+# -----------------------------------------------------------------------------
+# V8.6B TRUTH-UNAVAILABLE COOLING RECONCILIATION
+# -----------------------------------------------------------------------------
+# Startup/periodic reconciliation closes the race where HA restarts while a
+# truth sensor is already invalid and a template trigger's `for:` timer has not
+# been armed. It sweeps the same four truth/climate pairs and remains OFF-only.
+# -----------------------------------------------------------------------------
+- id: v8_6b_truth_unavailable_cooling_reconciliation
+  alias: "V8.6B: Truth Unavailable Cooling Reconciliation"
+  mode: single
+  trigger:
+    - platform: homeassistant
+      event: start
+    - platform: time_pattern
+      minutes: "/5"
+  action:
+    - choose:
+        - conditions:
+            - condition: template
+              value_template: "{{ trigger.platform == 'homeassistant' }}"
+          sequence:
+            - delay: "00:03:00"
+    - repeat:
+        for_each:
+          - truth: sensor.living_room_temperature_truth
+            climate: climate.living_room_air
+          - truth: sensor.master_bedroom_temperature_truth
+            climate: climate.master_bedroom_air
+          - truth: sensor.lincoln_s_room_temperature_truth
+            climate: climate.lincoln_air
+          - truth: sensor.lilly_s_room_temperature_truth
+            climate: climate.lilly_air
+        sequence:
+          - variables:
+              truth_entity: "{{ repeat.item.truth }}"
+              climate_entity: "{{ repeat.item.climate }}"
+              truth_invalid: >-
+                {% set x = states(truth_entity) | float(none) %}
+                {{ x is none or x != x or x < -90 or x > 200 }}
+              invalid_age_seconds: >-
+                {% set st = states[truth_entity] if truth_entity in states else none %}
+                {{ 0 if st is none else (as_timestamp(now()) - as_timestamp(st.last_changed, 0)) }}
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: >-
+                      {{ states(climate_entity) == 'cool'
+                         and (truth_invalid | bool)
+                         and (invalid_age_seconds | float(0)) >= 120 }}
+                sequence:
+                  - action: climate.set_hvac_mode
+                    target:
+                      entity_id: "{{ climate_entity }}"
+                    data:
+                      hvac_mode: "off"
 
 # -----------------------------------------------------------------------------
 # V9 SLEEP PRIORITY INTERLOCK

--- a/docs/packets/packetA_truth_unavailable_failsafe.md
+++ b/docs/packets/packetA_truth_unavailable_failsafe.md
@@ -1,0 +1,57 @@
+# Packet A — Truth-Unavailable Cooling Failsafe
+
+Stage-1 implementation contract for Packet A Design 1.
+
+## Intent
+
+The V8.3 supervisor historically converted an invalid room truth sensor to the
+same `float(70)` fallback used for ordinary numeric control. During cooling, that
+can hide total truth failure and let a mini-split remain in `cool` through the
+healthy-state deadband HOLD branch.
+
+Packet A keeps the healthy deadband doctrine intact, but adds an explicit truth
+validity layer:
+
+1. The supervisor computes per-zone truth-validity variables before any
+   `float(70)` temperature fallback is used for control.
+2. Cooling `hvac_mode` templates are OFF-biased when the associated truth sensor
+   is invalid.
+3. An independent Section 3 failsafe forces a climate entity OFF if its truth
+   sensor remains invalid for two minutes while the climate entity reports
+   `cool`.
+4. A startup/periodic reconciliation sweep closes the restart race without
+   adding inhibit helpers or authorizing cooling.
+
+## Validity contract
+
+A room truth sensor is valid for Packet A control only when it parses as a finite
+ordinary temperature in the supported operating envelope:
+
+```jinja
+{% set x = states('<truth_entity>') | float(none) %}
+{{ x is not none and x == x and -90 <= x <= 200 }}
+```
+
+The invalid form is the exact complement used by the failsafe triggers and
+reconciliation sweep:
+
+```jinja
+{% set x = states('<truth_entity>') | float(none) %}
+{{ x is none or x != x or x < -90 or x > 200 }}
+```
+
+This rejects `unknown`, `unavailable`, non-numeric strings, NaN, positive
+infinity, negative infinity, and implausible temperatures outside `[-90, 200]`.
+
+## Non-goals / exclusions
+
+Packet A does not change thresholds, setpoints, away behavior, the master sleep
+band, Packet B smoothing/control architecture, V9 cooldown work,
+`configuration.yaml`, hardware mappings, or the four-zone topology. It does not
+treat template firing sensors as physical compressor proof.
+
+## Stage-2 live verification requirement
+
+The repository cannot resolve the live Home Assistant entity suffix situation.
+Before deployment, Codex inside HA must verify the live supervisor automation
+entity and any `_rev_b` suffix behavior against the approved repository diff.

--- a/tests/test_packetA_truth_unavailable_failsafe.py
+++ b/tests/test_packetA_truth_unavailable_failsafe.py
@@ -1,0 +1,194 @@
+"""Contract tests for Packet A truth-unavailable cooling failsafe.
+
+These tests pin the Stage-1 repository implementation to the approved Design 1
+boundaries: OFF-only invalid-truth protection, unchanged healthy deadband
+doctrine, and no configuration/hardware topology changes.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class MooseAutomationLoader(yaml.SafeLoader):
+    pass
+
+
+def _secret_constructor(loader: yaml.Loader, node: yaml.Node) -> str:
+    return f"SECRET_{node.value}"
+
+
+MooseAutomationLoader.add_constructor("!secret", _secret_constructor)
+
+
+AUTOMATIONS_PATH = Path("automations.yaml")
+AUTOMATIONS_TEXT = AUTOMATIONS_PATH.read_text(encoding="utf-8")
+AUTOMATIONS = yaml.load(AUTOMATIONS_TEXT, Loader=MooseAutomationLoader)
+
+TRUTH_TO_CLIMATE = {
+    "living_room_air": "sensor.living_room_temperature_truth",
+    "master_bedroom_air": "sensor.master_bedroom_temperature_truth",
+    "lincoln_air": "sensor.lincoln_s_room_temperature_truth",
+    "lilly_air": "sensor.lilly_s_room_temperature_truth",
+}
+
+
+def _automation(automation_id: str) -> dict[str, Any]:
+    match = next((a for a in AUTOMATIONS if a.get("id") == automation_id), None)
+    assert match is not None, f"Missing automation {automation_id}"
+    return match
+
+
+def _walk(value: Any):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk(child)
+
+
+def _packet_a_valid(raw: str) -> bool:
+    try:
+        x = float(raw)
+    except (TypeError, ValueError):
+        return False
+    return x == x and -90 <= x <= 200
+
+
+def _packet_a_invalid(raw: str) -> bool:
+    try:
+        x = float(raw)
+    except (TypeError, ValueError):
+        return True
+    return x != x or x < -90 or x > 200
+
+
+def test_packet_a_numeric_contract_rejects_nan_infinity_and_implausible_values():
+    invalid_values = ["unknown", "unavailable", "", "nan", "inf", "-inf", "201", "-91"]
+    valid_values = ["-90", "0", "61", "70.5", "200"]
+
+    for raw in invalid_values:
+        assert not _packet_a_valid(raw)
+        assert _packet_a_invalid(raw)
+
+    for raw in valid_values:
+        assert _packet_a_valid(raw)
+        assert not _packet_a_invalid(raw)
+        assert math.isfinite(float(raw))
+
+
+def test_supervisor_declares_truth_validity_before_float_70_fallbacks():
+    supervisor = _automation("v7_5_main_supervisor")
+    variables = supervisor["action"][0]["variables"]
+
+    expected_variables = {
+        "lr_truth_ok": "sensor.living_room_temperature_truth",
+        "master_truth_ok": "sensor.master_bedroom_temperature_truth",
+        "lincoln_truth_ok": "sensor.lincoln_s_room_temperature_truth",
+        "lilly_truth_ok": "sensor.lilly_s_room_temperature_truth",
+    }
+    for variable_name, truth_entity in expected_variables.items():
+        template = variables.get(variable_name, "")
+        assert truth_entity in template
+        assert "float(none)" in template
+        assert "x is not none" in template
+        assert "x == x" in template
+        assert "-90 <= x <= 200" in template
+
+    assert AUTOMATIONS_TEXT.index("lr_truth_ok") < AUTOMATIONS_TEXT.index("lr_temp: \"{{ states('sensor.living_room_temperature_truth') | float(70) }}\"")
+    assert AUTOMATIONS_TEXT.index("master_truth_ok") < AUTOMATIONS_TEXT.index("master_temp: \"{{ states('sensor.master_bedroom_temperature_truth') | float(70) }}\"")
+    assert AUTOMATIONS_TEXT.index("lincoln_truth_ok") < AUTOMATIONS_TEXT.index("lincoln_temp: \"{{ states('sensor.lincoln_s_room_temperature_truth') | float(70) }}\"")
+    assert AUTOMATIONS_TEXT.index("lilly_truth_ok") < AUTOMATIONS_TEXT.index("lilly_temp: \"{{ states('sensor.lilly_s_room_temperature_truth') | float(70) }}\"")
+
+
+def test_supervisor_cooling_templates_are_invalid_truth_off_biased():
+    required_guards = [
+        "{% if not master_truth_ok %}off\n                  {% elif master_temp > m_on_at %}cool",
+        "{% if not lincoln_truth_ok %}off\n                  {% elif lincoln_temp > l_on_at %}cool",
+        "{% if not lilly_truth_ok %}off\n                  {% elif lilly_temp > ly_on_at %}cool",
+        "{% if not lr_truth_ok %}off\n                  {% elif lr_temp > lr_on_at %}cool",
+        "{% if not master_truth_ok %}off\n                          {% elif master_temp > m_sleep_on_at %}cool",
+        "'off' if not master_truth_ok else ('cool' if master_temp > 70 else 'off')",
+        "'off' if not lincoln_truth_ok else ('cool' if lincoln_temp > 70 else 'off')",
+        "'off' if not lilly_truth_ok else ('cool' if lilly_temp > 70 else 'off')",
+    ]
+    for guard in required_guards:
+        assert guard in AUTOMATIONS_TEXT
+
+    # Healthy-state doctrine remains hysteresis/HOLD based: the thresholds and
+    # equality operators are unchanged, with HOLD still preserving current cool.
+    assert "master_temp > m_on_at" in AUTOMATIONS_TEXT
+    assert "master_temp <= m_off_at" in AUTOMATIONS_TEXT
+    assert "m_current == 'cool'" in AUTOMATIONS_TEXT
+    assert "temperature: \"{{ m_setpoint }}\"" in AUTOMATIONS_TEXT
+    assert "temperature: \"{{ lr_setpoint }}\"" in AUTOMATIONS_TEXT
+
+
+def test_truth_unavailable_failsafe_has_four_off_only_template_triggers():
+    failsafe = _automation("v8_6_truth_unavailable_cooling_failsafe")
+    triggers = failsafe["trigger"]
+
+    assert {trigger["id"] for trigger in triggers} == set(TRUTH_TO_CLIMATE)
+    for trigger in triggers:
+        template = trigger["value_template"]
+        assert trigger["platform"] == "template"
+        assert trigger["for"] == "00:02:00"
+        assert TRUTH_TO_CLIMATE[trigger["id"]] in template
+        assert "float(none)" in template
+        assert "x is none" in template
+        assert "x != x" in template
+        assert "x < -90" in template
+        assert "x > 200" in template
+
+    actions = failsafe["action"]
+    assert "{{ 'climate.' ~ trigger.id }}" == actions[0]["variables"]["climate_entity"]
+    off_sequence = actions[1]["choose"][0]["sequence"]
+    assert off_sequence[0]["action"] == "climate.set_hvac_mode"
+    assert off_sequence[0]["data"]["hvac_mode"] == "off"
+    assert "states(climate_entity) == 'cool'" in actions[1]["choose"][0]["conditions"][0]["value_template"]
+    assert off_sequence[1]["continue_on_error"] is True
+
+    for node in _walk(failsafe):
+        assert node.get("action") != "climate.set_temperature"
+        assert node.get("data", {}).get("hvac_mode") != "cool"
+
+
+def test_truth_unavailable_reconciliation_is_startup_periodic_and_off_only():
+    reconciliation = _automation("v8_6b_truth_unavailable_cooling_reconciliation")
+    triggers = reconciliation["trigger"]
+
+    assert {trigger["platform"] for trigger in triggers} == {"homeassistant", "time_pattern"}
+    assert any(trigger.get("event") == "start" for trigger in triggers)
+    assert any(trigger.get("minutes") == "/5" for trigger in triggers)
+    assert reconciliation["action"][0]["choose"][0]["sequence"][0]["delay"] == "00:03:00"
+
+    repeat = reconciliation["action"][1]["repeat"]
+    pairs = {(item["truth"], item["climate"]) for item in repeat["for_each"]}
+    assert pairs == {(truth, f"climate.{trigger_id}") for trigger_id, truth in TRUTH_TO_CLIMATE.items()}
+
+    repeat_text = str(repeat)
+    assert "states[truth_entity] if truth_entity in states else none" in repeat_text
+    assert "x is none or x != x or x < -90 or x > 200" in repeat_text
+    assert "states(climate_entity) == 'cool'" in repeat_text
+    assert ">= 120" in repeat_text
+
+    for node in _walk(reconciliation):
+        assert node.get("action") != "climate.set_temperature"
+        assert node.get("data", {}).get("hvac_mode") != "cool"
+
+
+def test_packet_a_does_not_modify_excluded_configuration_or_packet_b_surfaces():
+    assert Path("configuration.yaml").exists()
+    assert "v8_6_truth_unavailable_cooling_failsafe" in AUTOMATIONS_TEXT
+    assert "cooldown" not in AUTOMATIONS_TEXT.lower()[
+        AUTOMATIONS_TEXT.index("v8_6_truth_unavailable_cooling_failsafe") : AUTOMATIONS_TEXT.index("v9_sleep_priority_interlock")
+    ]
+    assert "input_boolean" not in AUTOMATIONS_TEXT[
+        AUTOMATIONS_TEXT.index("v8_6_truth_unavailable_cooling_failsafe") : AUTOMATIONS_TEXT.index("v9_sleep_priority_interlock")
+    ]

--- a/tests/test_supervisor_manual_observability.py
+++ b/tests/test_supervisor_manual_observability.py
@@ -57,19 +57,19 @@ NEW_FIELDS = {
     "Manual_Override_Remaining_Sec",
 }
 
-# These hashes intentionally lock the untouched control surfaces for this
-# observability-only change. If this test fails, the PR is no longer limited to
-# telemetry/provenance/docs and needs explicit control-behavior review.
+# These hashes intentionally lock reviewed control surfaces. Packet A changes
+# Section 2/3 for truth-unavailable cooling safety; any future drift still needs
+# explicit control-behavior review.
 EXPECTED_SECTION_HASHES = {
     "section2_main_supervisor": (
         "# SECTION 2: MAIN SUPERVISOR",
         "# SECTION 3:",
-        "6d409d3c584cbd5eafa76fd9c9ac9c36e2c616a90c7c271bfd59ad512e0925e5",
+        "8e0cce9dc62e32f6e2a7bc48267d22a7efb2bb978c275a3dfa6fc5fea1adaaeb",
     ),
     "section3_safety_gates": (
         "# SECTION 3: SAFETY GATES",
         "# SECTION 4:",
-        "bc762a54c7c33b739a15c4a0d85e40c6141d82f209373f5e0a7cd32591944a75",
+        "9d078092445376affacd1584fbfdf9e15bb5fc5102f92d992e3be91c94d59ec0",
     ),
     "section14_lr_boost": (
         "# SECTION 14: V8.4 LR HEATING RECOVERY BOOST PILOT",
@@ -231,7 +231,7 @@ def test_no_automation_reads_google_sheets_tabs(automations_data):
 def test_control_surfaces_and_truth_configuration_are_byte_for_byte_unchanged(automations_text):
     for name, (start, end, expected_hash) in EXPECTED_SECTION_HASHES.items():
         digest = hashlib.sha256(_section(automations_text, start, end).encode()).hexdigest()
-        assert digest == expected_hash, f"{name} changed in an observability-only PR"
+        assert digest == expected_hash, f"{name} changed without updating the reviewed control-surface contract"
 
     configuration_digest = hashlib.sha256(CONFIGURATION.read_bytes()).hexdigest()
     assert configuration_digest == EXPECTED_CONFIGURATION_HASH, (


### PR DESCRIPTION
### Motivation

- Prevent hidden `float(70)` fallbacks from allowing a mini-split to remain in `cool` when the canonical room truth sensor is invalid or returns NaN/±inf. 
- Preserve the existing healthy deadband/HOLD doctrine while introducing an OFF-only safety path for invalid truth readings. 
- Close the HA restart race where template `for:` timers may not have been armed by adding a startup/periodic reconciliation sweep. 

### Description

- Added per-zone truth-validity variables (`lr_truth_ok`, `master_truth_ok`, `lincoln_truth_ok`, `lilly_truth_ok`) computed before any `float(70)` fallback is used by the main supervisor. 
- Modified cooling `hvac_mode` templates in the `v7_5_main_supervisor` to bias to `off` when the associated truth validity variable is false while leaving existing hysteresis and HOLD logic unchanged. 
- Added `v8_6_truth_unavailable_cooling_failsafe` which uses four template triggers (two-minute persistence) to force `climate.*` heads `off` when their truth sensor is invalid and the climate entity reports `cool`, with notification as a secondary, `continue_on_error: true` action; the automation is OFF-only. 
- Added `v8_6b_truth_unavailable_cooling_reconciliation` which runs on HA start (3-minute settle) and every 5 minutes to sweep the same truth/climate pairs and force `off` only when invalid-age ≥ 120s, handling missing state objects safely. 
- Added `docs/packets/packetA_truth_unavailable_failsafe.md` documenting intent, validity contract, non-goals, and Stage-2 live verification requirement, and `tests/test_packetA_truth_unavailable_failsafe.py` with contract tests; updated the reviewed control-surface hash in `tests/test_supervisor_manual_observability.py` to reflect the intentionally-reviewed Section 2/3 change. 

### Testing

- Ran `python -m pytest tests/ -rA` and all repository tests passed: `139 passed`. 
- Ran the new packet-level tests plus YAML syntax checks (`tests/test_yaml_syntax.py` and `tests/test_packetA_truth_unavailable_failsafe.py`) which passed (`8 passed` for the packet-specific run and `2 passed` for the YAML syntax subset). 
- Ran `git diff --check` and style/YAML parse checks which passed locally, and committed the changes on branch `codex/packetA-impl-review`. 
- `ha core check` is deferred to Stage 2 inside the live Home Assistant environment and must be run during the Stage-2 apply step after backing up live files and verifying live entity suffix behavior (e.g., `_rev_b`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2881c6c8488323845ee273bb45be15)