### PR TITLE
V9-E: Evidence-gated Master pre-cool runtime experiment

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -431,6 +431,10 @@
         precool_target_temp: "{{ states('input_number.precool_target_temp') | float(64) }}"
         precool_floor: "{{ states('input_number.precool_thermal_floor') | float(63.5) }}"
         precool_drop_limit: "{{ states('input_number.precool_drop_rate_limit') | float(2.5) }}"
+        # The drop-rate tunable is °F/hr; the slope guard compares against a
+        # 15-minute window, so the per-tick limit is the hourly limit over
+        # 0.25 h. Named here so the guard below carries no unit conversion.
+        precool_slope_limit_15min: "{{ precool_drop_limit / 4 }}"
         precool_max_runtime: "{{ states('input_number.precool_max_runtime') | int(180) }}"
         precool_runtime: "{{ states('input_number.precool_runtime_counter') | int(0) }}"
         precool_prev_master: "{{ states('input_number.precool_previous_master_temp') | float(0) }}"
@@ -438,6 +442,13 @@
           {{ is_precool_window and is_heatwave_predicted and not is_latch_tripped }}
         # --- derived guard inputs ---
         precool_master_truth_valid: "{{ states('sensor.master_bedroom_temperature_truth') | float(none) is not none }}"
+        # Config invariant: the room-truth cutoff must sit above the thermal
+        # floor. The helper ranges overlap (target 62-68, floor 60-65), so an
+        # operator CAN invert them in the UI; an inverted pair would make the
+        # floor guard unreachable before the cutoff. Treated as a guard trip
+        # (latch + reason) rather than a silent disarm so the telemetry shows
+        # WHY the experiment refused to run.
+        is_config_valid: "{{ precool_target_temp > precool_floor }}"
         # Slope memory is only trusted when plausible (55-85°F) and non-zero;
         # otherwise it is reseeded below and the slope abort is skipped for
         # this cycle (slope seeding requirement).
@@ -453,6 +464,7 @@
              and not away
              and precool_master_truth_valid }}
         # --- guards (evaluated before any command; first reason wins) ---
+        precool_config_tripped: "{{ precool_envelope_live_pre_guard and not is_config_valid }}"
         precool_floor_tripped: "{{ precool_envelope_live_pre_guard and master_temp < precool_floor }}"
         # 15-minute drop check. Only armed once a pre-cool session has
         # actually commanded this night (runtime > 0), because the slope
@@ -463,7 +475,7 @@
           {{ precool_envelope_live_pre_guard
              and precool_prev_valid
              and precool_runtime > 0
-             and (precool_prev_master - master_temp) >= (precool_drop_limit / 4) }}
+             and (precool_prev_master - master_temp) >= precool_slope_limit_15min }}
         # Runtime budget: abort instead of command when this tick WOULD
         # reach/exceed the budget. Ticks can occasionally run more often
         # than 15 minutes apart (season-change trigger); the +15-per-
@@ -475,9 +487,10 @@
              and not precool_slope_tripped
              and master_temp > precool_target_temp
              and (precool_runtime + 15) >= precool_max_runtime }}
-        precool_guard_tripped: "{{ precool_floor_tripped or precool_slope_tripped or precool_runtime_tripped }}"
+        precool_guard_tripped: "{{ precool_config_tripped or precool_floor_tripped or precool_slope_tripped or precool_runtime_tripped }}"
         precool_abort_reason_now: >-
-          {% if precool_floor_tripped %}Thermal floor breached
+          {% if precool_config_tripped %}Invalid config: target must exceed floor
+          {% elif precool_floor_tripped %}Thermal floor breached
           {% elif precool_slope_tripped %}Excessive cooling slope exceeded
           {% else %}Continuous runtime budget exhausted{% endif %}
         # --- decision surface consumed by the Master command templates ---

--- a/docs/v9_v10_goals.md
+++ b/docs/v9_v10_goals.md
@@ -138,8 +138,12 @@ Shape (Master Bedroom only; `automations.yaml` Section 2 + Section 16,
   (default 64°F, room-truth cutoff) → cool with the unchanged 61°F shove
   command setpoint; at/below cutoff → off.
 - **Self-termination (guards, evaluated before any command each tick):**
-  thermal floor (`precool_thermal_floor`, 63.5°F), 15-minute drop slope
-  (`precool_drop_rate_limit`/4), continuous runtime budget
+  config invariant (`precool_target_temp` must exceed
+  `precool_thermal_floor` — the helper ranges overlap, so an inverted pair
+  aborts with a recorded reason instead of silently disarming), thermal
+  floor (`precool_thermal_floor`, 63.5°F), 15-minute drop slope
+  (`precool_drop_rate_limit`/4, named `precool_slope_limit_15min`),
+  continuous runtime budget
   (`precool_max_runtime`, 180 min in 15-min increments). Any trip latches
   `input_boolean.precool_aborted_tonight` with a reason in
   `input_text.precool_abort_reason` and falls back to the standard V8.3

--- a/tests/test_supervisor_manual_observability.py
+++ b/tests/test_supervisor_manual_observability.py
@@ -68,11 +68,17 @@ NEW_FIELDS = {
 #     configuration.yaml gained the Section 16 helpers and forecast cache.
 #     Section 3 (safety gates) and Section 14 hashes were NOT re-pinned —
 #     those surfaces remain byte-for-byte unchanged.
+#   - section2 re-pinned again for two V9-E review refinements: the slope
+#     guard's magic /4 became the named variable precool_slope_limit_15min
+#     (no behavior change), and a config invariant guard (target must
+#     exceed floor) was added that latches the abort with reason
+#     "Invalid config" instead of silently disarming. configuration.yaml,
+#     Section 3, and Section 14 unchanged.
 EXPECTED_SECTION_HASHES = {
     "section2_main_supervisor": (
         "# SECTION 2: MAIN SUPERVISOR",
         "# SECTION 3:",
-        "ac90562fc16d4a081437e341cdeaa9b1528e36ade12a2229baba84128f012c14",
+        "a8cd7012bff0493e987ec76e33a67551c8a68ce05f8a99ae88d090268bab0b13",
     ),
     "section3_safety_gates": (
         "# SECTION 3: SAFETY GATES",


### PR DESCRIPTION
## Scope note (2026-06-13)

The original V9-E implementation described below **already landed on main** via `24183d2` + merge `5cfc15d`. This PR's branch has been rebuilt onto main and now carries **only the review refinements** (single commit `9f1178a`, +29/−6 across `automations.yaml`, `docs/v9_v10_goals.md`, and the hash-pin test). The "Key Changes" section below is retained as historical context for the experiment as a whole.

## Review Refinements (commit 9f1178a — the actual diff of this PR)

Two surgical changes from the architecture review:

1. **`precool_slope_limit_15min` named variable** — the slope guard's magic `/4` (°F/hr → °F/15min unit conversion) is now a named, commented variable in the supervisor variable block. No behavior change.
2. **`is_config_valid` invariant guard** — `precool_target_temp` must exceed `precool_thermal_floor`. The helper ranges overlap (target 62–68, floor 60–65), so the UI permits an inverted pair; that now trips the abort latch with reason `"Invalid config: target must exceed floor"` instead of running with an unreachable floor guard. First-reason-wins ordering puts the config check ahead of floor/slope/runtime.

Reviewed and intentionally NOT changed:
- **Runtime budget fencepost (165 vs 180 min):** 180 is a ceiling, not a guaranteed allowance. The `(runtime + 15) >= max` check under-runs by one tick, which is the safe error direction for a guard whose job is to contract conservatively.
- **Forecast refresh cadence:** hourly + HA-start triggers retained (a daily refresh would leave the 02:00–06:00 decision window on stale data).

Section 2 hash re-pinned with rationale (`a8cd7012…`); configuration hash untouched (matches main's current `bdf2d0eb…` from the laundry multi-radio work). Section 3 and Section 14 hashes unchanged. Full suite: 140/140.

---

## Historical context — original V9-E implementation (now on main)

### Summary

Implements the V9 Exception Master pre-cool runtime experiment (docs/v9_v10_goals.md §2.6), an evidence-gated control exception for the Master Bedroom during predicted heatwaves. This is a narrowly-scoped experiment triggered by May–June 2026 telemetry showing Master truth reaching 76.1°F during sleep windows on high-temperature days.

### Key Changes

**automations.yaml:**
- Added Section 16 automation (`v9e_precool_nightly_reset`) that re-arms the pre-cool envelope daily at 22:00, resetting the abort latch, runtime counter, slope memory, and abort reason
- Extended Section 1 observability with six new `Precool_*` columns for telemetry export (tomorrow's forecast high, abort status/reason, runtime counter, previous Master temp, target temp)
- Added comprehensive V9-E pre-cool logic to Section 2 Main Supervisor:
  - Window gate (02:00–06:00), heatwave forecast gate (≥85°F), and abort latch check
  - Self-terminating guards: config invariant (target > floor), thermal floor (63.5°F), 15-minute drop slope (2.5°F/hr), and runtime budget (180 min)
  - State writes for latch/reason/counters before any climate command
  - Modified Master hvac_mode templates in both cooling and shoulder-night branches to consult pre-cool decision surface
- Pre-cool commands use unchanged 61°F shove setpoint; cutoff is room-truth based (default 64°F)

**configuration.yaml:**
- Added Section 16 forecast cache: trigger-based `sensor.precool_tomorrow_high` that calls `weather.get_forecasts` hourly and on HA start, with fallback ladder (tomorrow's forecast → last cached value → 70°F safe default)
- Added Section 16 helpers:
  - `input_boolean.precool_aborted_tonight`: nightly abort latch (no initial value to survive mid-night restarts)
  - `input_text.precool_abort_reason`: forensic reason memory (no initial value)
  - `input_number` tunables with initial values: `precool_target_temp` (64°F), `precool_thermal_floor` (63.5°F), `precool_drop_rate_limit` (2.5°F/hr), `precool_max_runtime` (180 min)
  - `input_number` state/memory helpers without initial values: `precool_runtime_counter`, `precool_previous_master_temp` (slope memory)

**docs/v9_v10_goals.md:**
- Documented §2.6 as a live runtime exception with full shape, evidence basis, and guard envelope
- Clarified distinction from retired Targeted Pre-Chill (no 17:00 trigger, no Turbo, unchanged 61°F setpoint)
- Updated §3 Non-Goals to note this exception does not reopen aggressive pre-chill proposals

### Notable Implementation Details

- **Guard evaluation is pure-template** before any climate command, ensuring atomic decision-making on each tick
- **Slope memory seeding requirement:** previous Master temp is only trusted when plausible (55–85°F) and non-zero; otherwise the slope guard is skipped for that cycle
- **Runtime accounting is command-gated:** budget increments only on ticks where `precool_engage` is true (actual cool command issued)
- **Latch persistence:** abort latch and reason omit `initial:` values so they survive HA restarts mid-night; the 22:00 reset automation re-initializes them daily
- **Forecast fallback:** if weather source is dead, sensor defaults to 70°F

https://claude.ai/code/session_01WG78tQN9ntH2pbsBvZtELw