### PR TITLE
V9-E precool revision: forecast-conditioned window, two-guard model, dead code cleanup

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -34,8 +34,8 @@
 #   - input_boolean.precool_aborted_tonight (V9-E abort latch)
 #   - input_text.precool_abort_reason (V9-E abort classifier)
 #   - input_number.precool_runtime_counter / precool_previous_master_temp /
-#     precool_target_temp / precool_thermal_floor / precool_drop_rate_limit /
-#     precool_max_runtime (V9-E envelope; configuration.yaml Section 16)
+#     precool_target_temp / precool_thermal_floor
+#     (V9-E envelope; configuration.yaml Section 16)
 #   - sensor.precool_tomorrow_high (V9-E forecast cache; configuration.yaml,
 #     fed by weather.get_forecasts on weather.forecast_home)
 #
@@ -375,20 +375,27 @@
 #         measured evidence of real starvation under load.
 #
 #     V9-E MASTER PRE-COOL EXCEPTION (evidence-gated, self-terminating):
-#       Narrow runtime experiment per docs/v9_v10_goals.md §2.6. Between
-#       02:00-06:00, when the cached forecast (sensor.precool_tomorrow_high)
-#       predicts tomorrow ≥85°F, Master may be pre-cooled to the room-truth
-#       cutoff input_number.precool_target_temp (default 64°F) using the
-#       unchanged 61°F shove command setpoint. Three guards (thermal floor,
-#       15-min drop slope, runtime budget) are evaluated BEFORE any command
-#       each tick; any trip latches input_boolean.precool_aborted_tonight
-#       for the rest of the night and the Master template falls back to the
-#       standard V8.3 sleep deadband. Master Bedroom ONLY — Lincoln, Lilly,
-#       LR, Nest, Section 3 gates, Section 14, and the Sleep Priority
-#       Interlock are untouched. Evidence basis: May 17-20 + Jun 3-5 2026
-#       heatwaves; Master truth 76.1°F in the May 17 sleep window with
-#       multi-hour pull-down. Latch/counters reset nightly at 22:00 by the
-#       Section 16 reset automation.
+#       Narrow runtime experiment per docs/v9_v10_goals.md §2.6 and
+#       docs/analysis/v9e_precool_revision_spec.md. Between 02:00 and a
+#       forecast-conditioned window end (13:00 for ≥90°F, 11:00 for 85-89°F,
+#       hard backstop 14:00), when the cached forecast
+#       (sensor.precool_tomorrow_high) predicts tomorrow ≥85°F, Master may be
+#       pre-cooled to the room-truth cutoff input_number.precool_target_temp
+#       (default 64°F) using the unchanged 61°F shove command setpoint.
+#       Guards (evaluated BEFORE any command each tick):
+#         - config invariant (target > floor — operator error)
+#         - thermal floor (63.5°F — physics; the only thermal guard)
+#       Slope and runtime guards removed per spec §2/§3 (sensor quantization
+#       caused false slope aborts; window-end is the wall-clock ceiling).
+#       Runtime counter kept as telemetry only (cap 720 min).
+#       Any trip latches input_boolean.precool_aborted_tonight for the rest
+#       of the night and the Master template falls back to the standard V8.3
+#       sleep deadband. Master Bedroom ONLY — Lincoln, Lilly, LR, Nest,
+#       Section 3 gates, Section 14, and the Sleep Priority Interlock are
+#       untouched. Evidence basis: May 17-20 + Jun 3-5 2026 heatwaves;
+#       Master truth 76.1°F in the May 17 sleep window with multi-hour
+#       pull-down. Latch/counters reset nightly at 22:00 by the Section 16
+#       reset automation.
 # =============================================================================
 
 - id: v7_5_main_supervisor
@@ -425,23 +432,35 @@
         # consume precool_session_live / precool_engage. No other room,
         # safety gate, or section reads these variables.
         # =============================================================
-        is_precool_window: "{{ 2 <= now().hour < 6 }}"
+        # Forecast-conditioned window end per docs/analysis/v9e_precool_release_trigger.md.
+        # Hotter days hold longer; cooler days release earlier. Hard backstop 14:00.
+        # - ≥90°F forecast → hold until 13:00
+        # - 85-89°F forecast → hold until 11:00
+        # - <85°F (no heatwave) → original 06:00 window (is_heatwave_predicted gates this)
+        is_precool_window: >-
+          {% set h = now().hour %}
+          {% set f = states('sensor.precool_tomorrow_high') | float(0) %}
+          {{ 2 <= h < 14 and (
+            (f >= 90 and h < 13) or
+            (f >= 85 and h < 11) or
+            (h < 6)
+          ) }}
         is_heatwave_predicted: "{{ states('sensor.precool_tomorrow_high') | float(0) >= 85 }}"
         is_latch_tripped: "{{ is_state('input_boolean.precool_aborted_tonight', 'on') }}"
         precool_target_temp: "{{ states('input_number.precool_target_temp') | float(64) }}"
         precool_floor: "{{ states('input_number.precool_thermal_floor') | float(63.5) }}"
-        precool_drop_limit: "{{ states('input_number.precool_drop_rate_limit') | float(2.5) }}"
-        precool_max_runtime: "{{ states('input_number.precool_max_runtime') | int(180) }}"
         precool_runtime: "{{ states('input_number.precool_runtime_counter') | int(0) }}"
-        precool_prev_master: "{{ states('input_number.precool_previous_master_temp') | float(0) }}"
         is_precool_permitted_base: >
           {{ is_precool_window and is_heatwave_predicted and not is_latch_tripped }}
         # --- derived guard inputs ---
         precool_master_truth_valid: "{{ states('sensor.master_bedroom_temperature_truth') | float(none) is not none }}"
-        # Slope memory is only trusted when plausible (55-85°F) and non-zero;
-        # otherwise it is reseeded below and the slope abort is skipped for
-        # this cycle (slope seeding requirement).
-        precool_prev_valid: "{{ precool_prev_master != 0 and 55 <= precool_prev_master <= 85 }}"
+        # Config invariant: the room-truth cutoff must sit above the thermal
+        # floor. The helper ranges overlap (target 62-68, floor 60-65), so an
+        # operator CAN invert them in the UI; an inverted pair would make the
+        # floor guard unreachable before the cutoff. Treated as a guard trip
+        # (latch + reason) rather than a silent disarm so the telemetry shows
+        # WHY the experiment refused to run.
+        is_config_valid: "{{ precool_target_temp > precool_floor }}"
         # Envelope constraints beyond the base gate: Master truth must be
         # valid, the house must not be away (away relaxation wins), and the
         # season branch must be one whose Master sleep path can act on the
@@ -453,33 +472,19 @@
              and not away
              and precool_master_truth_valid }}
         # --- guards (evaluated before any command; first reason wins) ---
+        # Guards: config-invalid (operator error — target must exceed floor),
+        # thermal floor (physics — hardware asymptote is ~63.4°F under the 61°F
+        # shove, so a breach is genuinely terminal). Slope guard removed per
+        # docs/analysis/v9e_precool_revision_spec.md §2 (sensor quantization
+        # caused false trips on physically-fine runs; the floor is the real net).
+        # Runtime guard removed per §3 (window-end is the wall-clock ceiling;
+        # runtime counter kept as telemetry only).
+        precool_config_tripped: "{{ precool_envelope_live_pre_guard and not is_config_valid }}"
         precool_floor_tripped: "{{ precool_envelope_live_pre_guard and master_temp < precool_floor }}"
-        # 15-minute drop check. Only armed once a pre-cool session has
-        # actually commanded this night (runtime > 0), because the slope
-        # memory is refreshed on envelope ticks only — comparing against the
-        # 22:00 reset seed would measure hours of natural drift against a
-        # 15-minute budget and false-abort every night.
-        precool_slope_tripped: >
-          {{ precool_envelope_live_pre_guard
-             and precool_prev_valid
-             and precool_runtime > 0
-             and (precool_prev_master - master_temp) >= (precool_drop_limit / 4) }}
-        # Runtime budget: abort instead of command when this tick WOULD
-        # reach/exceed the budget. Ticks can occasionally run more often
-        # than 15 minutes apart (season-change trigger); the +15-per-
-        # commanding-tick accounting then over-counts, which only shrinks
-        # the budget — the safe direction.
-        precool_runtime_tripped: >
-          {{ precool_envelope_live_pre_guard
-             and not precool_floor_tripped
-             and not precool_slope_tripped
-             and master_temp > precool_target_temp
-             and (precool_runtime + 15) >= precool_max_runtime }}
-        precool_guard_tripped: "{{ precool_floor_tripped or precool_slope_tripped or precool_runtime_tripped }}"
+        precool_guard_tripped: "{{ precool_config_tripped or precool_floor_tripped }}"
         precool_abort_reason_now: >-
-          {% if precool_floor_tripped %}Thermal floor breached
-          {% elif precool_slope_tripped %}Excessive cooling slope exceeded
-          {% else %}Continuous runtime budget exhausted{% endif %}
+          {% if precool_config_tripped %}Invalid config: target must exceed floor
+          {% else %}Thermal floor breached{% endif %}
         # --- decision surface consumed by the Master command templates ---
         # session_live false (not permitted / guard tripped) => the Master
         # templates fall back to the standard V8.3 sleep deadband for the
@@ -515,15 +520,16 @@
         - action: input_number.set_value
           target: { entity_id: input_number.precool_runtime_counter }
           data:
-            value: "{{ [precool_runtime + 15, 300] | min }}"
+            value: "{{ [precool_runtime + 15, 720] | min }}"
     - if:
         - condition: template
           value_template: "{{ precool_envelope_live_pre_guard }}"
       then:
-        # Slope memory write/seed: refresh on every live-envelope tick AFTER
-        # guards were evaluated against the previous value. Clamped to the
-        # helper's 50-90 range so an outlier truth reading cannot fail the
-        # service call.
+        # Telemetry write: refresh Master truth on every live-envelope tick.
+        # Formerly consumed by the slope guard (removed per revision spec §2);
+        # kept as a telemetry column (Precool_Previous_Master_Temp) for
+        # diagnostics and energy analysis. Clamped to the helper's 50-90 range
+        # so an outlier truth reading cannot fail the service call.
         - action: input_number.set_value
           target: { entity_id: input_number.precool_previous_master_temp }
           data:

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1281,7 +1281,7 @@ input_number:
     name: "Precool Runtime Counter"
     icon: mdi:timer-outline
     min: 0
-    max: 300
+    max: 720
     step: 15
     unit_of_measurement: "min"
   precool_previous_master_temp:
@@ -1307,19 +1307,4 @@ input_number:
     step: 0.5
     initial: 63.5
     unit_of_measurement: "°F"
-  precool_drop_rate_limit:
-    name: "Precool Drop Rate Limit"
-    icon: mdi:speedometer
-    min: 1
-    max: 5
-    step: 0.1
-    initial: 2.5
-    unit_of_measurement: "°F/hr"
-  precool_max_runtime:
-    name: "Precool Max Runtime"
-    icon: mdi:timer-lock-outline
-    min: 60
-    max: 300
-    step: 15
-    initial: 180
-    unit_of_measurement: "min"
+  precool_previous_master_temp:

--- a/docs/v9_v10_goals.md
+++ b/docs/v9_v10_goals.md
@@ -129,7 +129,8 @@ contaminated evidence.
 Shape (Master Bedroom only; `automations.yaml` Section 2 + Section 16,
 `configuration.yaml` Section 16 helpers + forecast cache):
 
-- **Arming:** 02:00–06:00 window AND cached forecast high for tomorrow
+- **Arming:** 02:00–forecast-conditioned window end (13:00 for ≥90°F forecast,
+  11:00 for 85–89°F, hard backstop 14:00) AND cached forecast high for tomorrow
   (`sensor.precool_tomorrow_high`, via `weather.get_forecasts`) ≥ 85°F AND
   nightly abort latch off. Away mode and non-cooling/shoulder seasons
   disarm it. The supervisor's `timer.manual_hvac_override == idle` gate is
@@ -138,9 +139,15 @@ Shape (Master Bedroom only; `automations.yaml` Section 2 + Section 16,
   (default 64°F, room-truth cutoff) → cool with the unchanged 61°F shove
   command setpoint; at/below cutoff → off.
 - **Self-termination (guards, evaluated before any command each tick):**
-  thermal floor (`precool_thermal_floor`, 63.5°F), 15-minute drop slope
-  (`precool_drop_rate_limit`/4), continuous runtime budget
-  (`precool_max_runtime`, 180 min in 15-min increments). Any trip latches
+  config invariant (`precool_target_temp` must exceed
+  `precool_thermal_floor` — the helper ranges overlap, so an inverted pair
+  aborts with a recorded reason instead of silently disarming), thermal
+  floor (`precool_thermal_floor`, 63.5°F — the only thermal guard). Slope
+  and runtime guards removed per
+  [`docs/analysis/v9e_precool_revision_spec.md`](./analysis/v9e_precool_revision_spec.md)
+  §2/§3 (sensor quantization caused false slope aborts; window-end is the
+  wall-clock ceiling). Runtime counter kept as telemetry only (cap 720 min).
+  Any trip latches
   `input_boolean.precool_aborted_tonight` with a reason in
   `input_text.precool_abort_reason` and falls back to the standard V8.3
   Master sleep deadband for the rest of the night. A 22:00 reset automation
@@ -164,8 +171,10 @@ V9 is **not**:
 - Targeted Pre-Chill (aggressive 61°F Master / Turbo at 17:00). Per
   [`./6_proposals.md`](./6_proposals.md) this is deferred until forensic
   recurrence evidence supports it. (The §2.6 evidence-gated pre-cool
-  exception is a different, narrower shape — overnight window, forecast
-  gate, hard guard envelope — and does not reopen this item.)
+  exception is a different, narrower shape — overnight/morning window
+  with daytime hold, forecast gate, forecast-conditioned release, hard
+  guard envelope (thermal floor + config invariant) — and does not
+  reopen this item.)
 - Generic HVAC best-practices reshaping of the deadband contract.
 - Multi-head capacity arbitration without telemetry proof. Already retired
   per [`./3_regression_appendix.md`](./3_regression_appendix.md) §4.5.

--- a/tests/test_supervisor_manual_observability.py
+++ b/tests/test_supervisor_manual_observability.py
@@ -68,11 +68,18 @@ NEW_FIELDS = {
 #     configuration.yaml gained the Section 16 helpers and forecast cache.
 #     Section 3 (safety gates) and Section 14 hashes were NOT re-pinned —
 #     those surfaces remain byte-for-byte unchanged.
+#   - section2 + configuration re-pinned for V9-E revision
+#     (impl/v9e-precool-revision): window gate changed to forecast-conditioned
+#     release (02:00-13:00/11:00/06:00 with hard 14:00 backstop), slope guard
+#     and runtime guard removed, config-invariant guard added, precool_max_runtime
+#     retired, runtime counter cap raised to 720 min. See
+#     docs/analysis/v9e_precool_revision_spec.md and
+#     docs/analysis/v9e_precool_release_trigger.md.
 EXPECTED_SECTION_HASHES = {
     "section2_main_supervisor": (
         "# SECTION 2: MAIN SUPERVISOR",
         "# SECTION 3:",
-        "ac90562fc16d4a081437e341cdeaa9b1528e36ade12a2229baba84128f012c14",
+        "47944cb2c61989b9534092168d37cff1adf0dc90807a98907d9d21356bcaaff2",
     ),
     "section3_safety_gates": (
         "# SECTION 3: SAFETY GATES",
@@ -85,7 +92,7 @@ EXPECTED_SECTION_HASHES = {
         "fcb18b5953a9bfb9f1d1e9f10ba8217cc46c7db63cb268bfab5daa6ffd2b71c3",
     ),
 }
-EXPECTED_CONFIGURATION_HASH = "bdf2d0ebc9ddb50721c621055c12e17625e8b326a07d332c44e8d7cd93c2543e"
+EXPECTED_CONFIGURATION_HASH = "3346a420f2208e7178c34636c14e4fc966e61505329c2d9e206fe41ef33d5788"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary

Revises the V9-E Master pre-cool guard model per the Fable-researched spec at `docs/analysis/v9e_precool_revision_spec.md` and `docs/analysis/v9e_precool_release_trigger.md`. Recommendation-only docs were committed to `claude/fable-v9e-precool-tuning-jdke1a`; this PR implements the agreed changes.

## Changes

### Window gate — forecast-conditioned release
- **Before:** `2 <= now().hour < 6` (fixed 02:00–06:00)
- **After:** Forecast-conditioned: ≥90°F → hold until 13:00, 85–89°F → 11:00, hard backstop 14:00. Sub-85°F days unchanged (06:00, gated by `is_heatwave_predicted`).
- Design rationale: the 02:00–06:00 window was nearly redundant with the sleep deadband and released the cooling charge at ~1°F/hr, crossing comfort threshold by 14:00–15:00 — hours before the evening peak. The forecast-conditioned hold carries the charge past the 18:00 peak.

### Guard model — reduced to two non-overlapping guards
- **Removed:** slope guard (`precool_slope_tripped`) — sensor quantization caused false aborts on physically-fine runs (see §2 evidence).
- **Removed:** runtime guard (`precool_runtime_tripped`) — window-end is the wall-clock ceiling; the cap could only either clip legitimate hot-day operation or be redundant with the window gate (see §3).
- **Kept:** config invariant (`is_config_valid`) — target must exceed floor (operator error guard).
- **Kept:** thermal floor (63.5°F) — now the sole physics guard; hardware asymptote under 61°F shove is ~63.4°F.
- **Result:** `precool_guard_tripped = precool_config_tripped OR precool_floor_tripped`. Both are genuinely terminal — no re-arm logic needed.

### Telemetry
- Runtime counter cap raised: 300 → 720 min (recording fidelity only — no longer a guard).
- `precool_max_runtime` helper retired.
- `precool_drop_rate_limit` helper removed (slope guard removed).
- Previous Master temp write retained for `Precool_Previous_Master_Temp` column.

### Dead code cleanup
- Removed unused `precool_prev_master` and `precool_prev_valid` template variables.
- Removed stale slope-memory comment block.
- Updated slope-memory write comment to reflect telemetry-only purpose.

### Docs
- `docs/v9_v10_goals.md` §2.6: window/guard model updated.
- `docs/v9_v10_goals.md` §3: "overnight window" → "overnight/morning window with daytime hold" to match the behavioral change.

## Test status
140/140 passed. Section 2 and configuration.yaml hash pins updated.

## Open item (post-merge)
The energy/duty cost of the daytime hold is UNKNOWN per spec §3/§6. Monitor `Precool_Runtime` and kWh over the first 2–3 ≥90°F runs before trusting unattended; that data would also justify the 14:00 extension or a full telemetry-driven release.