### PR TITLE
Restore V8.6 truth-unavailable cooling failsafe (OFF-only safety net)

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -860,6 +860,121 @@
 # =============================================================================
 
 # -----------------------------------------------------------------------------
+# V8.6 TRUTH-UNAVAILABLE COOLING FAILSAFE
+# -----------------------------------------------------------------------------
+# If a canonical room truth sensor becomes invalid while its mini-split is
+# cooling, force that head OFF after a two-minute persistence window. This is
+# intentionally OFF-only: it prevents hidden 70°F fallbacks from sustaining
+# cooling, but never authorizes new cooling and never relies on template
+# compressor-intent sensors as physical proof.
+# -----------------------------------------------------------------------------
+- id: v8_6_truth_unavailable_cooling_failsafe
+  alias: "V8.6: Truth Unavailable Cooling Failsafe"
+  mode: queued
+  trigger:
+    - platform: template
+      id: living_room_air
+      value_template: >-
+        {% set x = states('sensor.living_room_temperature_truth') | float(none) %}
+        {{ x is none or x != x or x < -90 or x > 200 }}
+      for: "00:02:00"
+    - platform: template
+      id: master_bedroom_air
+      value_template: >-
+        {% set x = states('sensor.master_bedroom_temperature_truth') | float(none) %}
+        {{ x is none or x != x or x < -90 or x > 200 }}
+      for: "00:02:00"
+    - platform: template
+      id: lincoln_air
+      value_template: >-
+        {% set x = states('sensor.lincoln_s_room_temperature_truth') | float(none) %}
+        {{ x is none or x != x or x < -90 or x > 200 }}
+      for: "00:02:00"
+    - platform: template
+      id: lilly_air
+      value_template: >-
+        {% set x = states('sensor.lilly_s_room_temperature_truth') | float(none) %}
+        {{ x is none or x != x or x < -90 or x > 200 }}
+      for: "00:02:00"
+  action:
+    - variables:
+        climate_entity: "{{ 'climate.' ~ trigger.id }}"
+    - choose:
+        - conditions:
+            - condition: template
+              value_template: "{{ states(climate_entity) == 'cool' }}"
+          sequence:
+            - action: climate.set_hvac_mode
+              target:
+                entity_id: "{{ climate_entity }}"
+              data:
+                hvac_mode: "off"
+            - action: persistent_notification.create
+              continue_on_error: true
+              data:
+                title: "Truth unavailable cooling failsafe"
+                message: >-
+                  Forced {{ climate_entity }} off because its room truth sensor
+                  was invalid for at least two minutes while the climate entity
+                  reported cool.
+
+# -----------------------------------------------------------------------------
+# V8.6B TRUTH-UNAVAILABLE COOLING RECONCILIATION
+# -----------------------------------------------------------------------------
+# Startup/periodic reconciliation closes the race where HA restarts while a
+# truth sensor is already invalid and a template trigger's `for:` timer has not
+# been armed. It sweeps the same four truth/climate pairs and remains OFF-only.
+# -----------------------------------------------------------------------------
+- id: v8_6b_truth_unavailable_cooling_reconciliation
+  alias: "V8.6B: Truth Unavailable Cooling Reconciliation"
+  mode: single
+  trigger:
+    - platform: homeassistant
+      event: start
+    - platform: time_pattern
+      minutes: "/5"
+  action:
+    - choose:
+        - conditions:
+            - condition: template
+              value_template: "{{ trigger.platform == 'homeassistant' }}"
+          sequence:
+            - delay: "00:03:00"
+    - repeat:
+        for_each:
+          - truth: sensor.living_room_temperature_truth
+            climate: climate.living_room_air
+          - truth: sensor.master_bedroom_temperature_truth
+            climate: climate.master_bedroom_air
+          - truth: sensor.lincoln_s_room_temperature_truth
+            climate: climate.lincoln_air
+          - truth: sensor.lilly_s_room_temperature_truth
+            climate: climate.lilly_air
+        sequence:
+          - variables:
+              truth_entity: "{{ repeat.item.truth }}"
+              climate_entity: "{{ repeat.item.climate }}"
+              truth_invalid: >-
+                {% set x = states(truth_entity) | float(none) %}
+                {{ x is none or x != x or x < -90 or x > 200 }}
+              invalid_age_seconds: >-
+                {% set st = states[truth_entity] if truth_entity in states else none %}
+                {{ 0 if st is none else (as_timestamp(now()) - as_timestamp(st.last_changed, 0)) }}
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: >-
+                      {{ states(climate_entity) == 'cool'
+                         and (truth_invalid | bool)
+                         and (invalid_age_seconds | float(0)) >= 120 }}
+                sequence:
+                  - action: climate.set_hvac_mode
+                    target:
+                      entity_id: "{{ climate_entity }}"
+                    data:
+                      hvac_mode: "off"
+
+# -----------------------------------------------------------------------------
 # V9 SLEEP PRIORITY INTERLOCK
 # -----------------------------------------------------------------------------
 # Solves cross-mode contention lockout during shoulder seasons. If the Master

--- a/tests/test_packetA_truth_unavailable_failsafe.py
+++ b/tests/test_packetA_truth_unavailable_failsafe.py
@@ -1,0 +1,214 @@
+"""Contract tests for Packet A truth-unavailable cooling failsafe.
+
+These tests pin the Stage-1 repository implementation to the approved Design 1
+boundaries: OFF-only invalid-truth protection, unchanged healthy deadband
+doctrine, and no configuration/hardware topology changes.
+
+SCOPE NOTE (2026-06-15 isolated restore):
+This branch restores ONLY the two OFF-only safety automations
+(`v8_6_truth_unavailable_cooling_failsafe` and
+`v8_6b_truth_unavailable_cooling_reconciliation`) from Packet A commit
+9e39e42, recovered to re-link the live registry orphans. It does NOT bring
+over Packet A's separate `v7_5_main_supervisor` rewrite (the off-biased
+`*_truth_ok` cooling-template guards), which is a larger comfort-path change
+that has since diverged on `main` and is out of scope for a narrow safety
+restore. The two supervisor-coupling tests below are therefore skipped here;
+they belong with the supervisor change if/when it is restored separately.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+
+class MooseAutomationLoader(yaml.SafeLoader):
+    pass
+
+
+def _secret_constructor(loader: yaml.Loader, node: yaml.Node) -> str:
+    return f"SECRET_{node.value}"
+
+
+MooseAutomationLoader.add_constructor("!secret", _secret_constructor)
+
+
+AUTOMATIONS_PATH = Path("automations.yaml")
+AUTOMATIONS_TEXT = AUTOMATIONS_PATH.read_text(encoding="utf-8")
+AUTOMATIONS = yaml.load(AUTOMATIONS_TEXT, Loader=MooseAutomationLoader)
+
+TRUTH_TO_CLIMATE = {
+    "living_room_air": "sensor.living_room_temperature_truth",
+    "master_bedroom_air": "sensor.master_bedroom_temperature_truth",
+    "lincoln_air": "sensor.lincoln_s_room_temperature_truth",
+    "lilly_air": "sensor.lilly_s_room_temperature_truth",
+}
+
+
+def _automation(automation_id: str) -> dict[str, Any]:
+    match = next((a for a in AUTOMATIONS if a.get("id") == automation_id), None)
+    assert match is not None, f"Missing automation {automation_id}"
+    return match
+
+
+def _walk(value: Any):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk(child)
+
+
+def _packet_a_valid(raw: str) -> bool:
+    try:
+        x = float(raw)
+    except (TypeError, ValueError):
+        return False
+    return x == x and -90 <= x <= 200
+
+
+def _packet_a_invalid(raw: str) -> bool:
+    try:
+        x = float(raw)
+    except (TypeError, ValueError):
+        return True
+    return x != x or x < -90 or x > 200
+
+
+def test_packet_a_numeric_contract_rejects_nan_infinity_and_implausible_values():
+    invalid_values = ["unknown", "unavailable", "", "nan", "inf", "-inf", "201", "-91"]
+    valid_values = ["-90", "0", "61", "70.5", "200"]
+
+    for raw in invalid_values:
+        assert not _packet_a_valid(raw)
+        assert _packet_a_invalid(raw)
+
+    for raw in valid_values:
+        assert _packet_a_valid(raw)
+        assert not _packet_a_invalid(raw)
+        assert math.isfinite(float(raw))
+
+
+@pytest.mark.skip(
+    reason="Packet A supervisor off-biasing not part of this isolated V8.6 "
+    "automation restore; see module SCOPE NOTE."
+)
+def test_supervisor_declares_truth_validity_before_float_70_fallbacks():
+    supervisor = _automation("v7_5_main_supervisor")
+    variables = supervisor["action"][0]["variables"]
+
+    expected_variables = {
+        "lr_truth_ok": "sensor.living_room_temperature_truth",
+        "master_truth_ok": "sensor.master_bedroom_temperature_truth",
+        "lincoln_truth_ok": "sensor.lincoln_s_room_temperature_truth",
+        "lilly_truth_ok": "sensor.lilly_s_room_temperature_truth",
+    }
+    for variable_name, truth_entity in expected_variables.items():
+        template = variables.get(variable_name, "")
+        assert truth_entity in template
+        assert "float(none)" in template
+        assert "x is not none" in template
+        assert "x == x" in template
+        assert "-90 <= x <= 200" in template
+
+    assert AUTOMATIONS_TEXT.index("lr_truth_ok") < AUTOMATIONS_TEXT.index("lr_temp: \"{{ states('sensor.living_room_temperature_truth') | float(70) }}\"")
+    assert AUTOMATIONS_TEXT.index("master_truth_ok") < AUTOMATIONS_TEXT.index("master_temp: \"{{ states('sensor.master_bedroom_temperature_truth') | float(70) }}\"")
+    assert AUTOMATIONS_TEXT.index("lincoln_truth_ok") < AUTOMATIONS_TEXT.index("lincoln_temp: \"{{ states('sensor.lincoln_s_room_temperature_truth') | float(70) }}\"")
+    assert AUTOMATIONS_TEXT.index("lilly_truth_ok") < AUTOMATIONS_TEXT.index("lilly_temp: \"{{ states('sensor.lilly_s_room_temperature_truth') | float(70) }}\"")
+
+
+@pytest.mark.skip(
+    reason="Packet A supervisor off-biasing not part of this isolated V8.6 "
+    "automation restore; see module SCOPE NOTE."
+)
+def test_supervisor_cooling_templates_are_invalid_truth_off_biased():
+    required_guards = [
+        "{% if not master_truth_ok %}off\n                  {% elif master_temp > m_on_at %}cool",
+        "{% if not lincoln_truth_ok %}off\n                  {% elif lincoln_temp > l_on_at %}cool",
+        "{% if not lilly_truth_ok %}off\n                  {% elif lilly_temp > ly_on_at %}cool",
+        "{% if not lr_truth_ok %}off\n                  {% elif lr_temp > lr_on_at %}cool",
+        "{% if not master_truth_ok %}off\n                          {% elif master_temp > m_sleep_on_at %}cool",
+        "'off' if not master_truth_ok else ('cool' if master_temp > 70 else 'off')",
+        "'off' if not lincoln_truth_ok else ('cool' if lincoln_temp > 70 else 'off')",
+        "'off' if not lilly_truth_ok else ('cool' if lilly_temp > 70 else 'off')",
+    ]
+    for guard in required_guards:
+        assert guard in AUTOMATIONS_TEXT
+
+    # Healthy-state doctrine remains hysteresis/HOLD based: the thresholds and
+    # equality operators are unchanged, with HOLD still preserving current cool.
+    assert "master_temp > m_on_at" in AUTOMATIONS_TEXT
+    assert "master_temp <= m_off_at" in AUTOMATIONS_TEXT
+    assert "m_current == 'cool'" in AUTOMATIONS_TEXT
+    assert "temperature: \"{{ m_setpoint }}\"" in AUTOMATIONS_TEXT
+    assert "temperature: \"{{ lr_setpoint }}\"" in AUTOMATIONS_TEXT
+
+
+def test_truth_unavailable_failsafe_has_four_off_only_template_triggers():
+    failsafe = _automation("v8_6_truth_unavailable_cooling_failsafe")
+    triggers = failsafe["trigger"]
+
+    assert {trigger["id"] for trigger in triggers} == set(TRUTH_TO_CLIMATE)
+    for trigger in triggers:
+        template = trigger["value_template"]
+        assert trigger["platform"] == "template"
+        assert trigger["for"] == "00:02:00"
+        assert TRUTH_TO_CLIMATE[trigger["id"]] in template
+        assert "float(none)" in template
+        assert "x is none" in template
+        assert "x != x" in template
+        assert "x < -90" in template
+        assert "x > 200" in template
+
+    actions = failsafe["action"]
+    assert "{{ 'climate.' ~ trigger.id }}" == actions[0]["variables"]["climate_entity"]
+    off_sequence = actions[1]["choose"][0]["sequence"]
+    assert off_sequence[0]["action"] == "climate.set_hvac_mode"
+    assert off_sequence[0]["data"]["hvac_mode"] == "off"
+    assert "states(climate_entity) == 'cool'" in actions[1]["choose"][0]["conditions"][0]["value_template"]
+    assert off_sequence[1]["continue_on_error"] is True
+
+    for node in _walk(failsafe):
+        assert node.get("action") != "climate.set_temperature"
+        assert node.get("data", {}).get("hvac_mode") != "cool"
+
+
+def test_truth_unavailable_reconciliation_is_startup_periodic_and_off_only():
+    reconciliation = _automation("v8_6b_truth_unavailable_cooling_reconciliation")
+    triggers = reconciliation["trigger"]
+
+    assert {trigger["platform"] for trigger in triggers} == {"homeassistant", "time_pattern"}
+    assert any(trigger.get("event") == "start" for trigger in triggers)
+    assert any(trigger.get("minutes") == "/5" for trigger in triggers)
+    assert reconciliation["action"][0]["choose"][0]["sequence"][0]["delay"] == "00:03:00"
+
+    repeat = reconciliation["action"][1]["repeat"]
+    pairs = {(item["truth"], item["climate"]) for item in repeat["for_each"]}
+    assert pairs == {(truth, f"climate.{trigger_id}") for trigger_id, truth in TRUTH_TO_CLIMATE.items()}
+
+    repeat_text = str(repeat)
+    assert "states[truth_entity] if truth_entity in states else none" in repeat_text
+    assert "x is none or x != x or x < -90 or x > 200" in repeat_text
+    assert "states(climate_entity) == 'cool'" in repeat_text
+    assert ">= 120" in repeat_text
+
+    for node in _walk(reconciliation):
+        assert node.get("action") != "climate.set_temperature"
+        assert node.get("data", {}).get("hvac_mode") != "cool"
+
+
+def test_packet_a_does_not_modify_excluded_configuration_or_packet_b_surfaces():
+    assert Path("configuration.yaml").exists()
+    assert "v8_6_truth_unavailable_cooling_failsafe" in AUTOMATIONS_TEXT
+    assert "cooldown" not in AUTOMATIONS_TEXT.lower()[
+        AUTOMATIONS_TEXT.index("v8_6_truth_unavailable_cooling_failsafe") : AUTOMATIONS_TEXT.index("v9_sleep_priority_interlock")
+    ]
+    assert "input_boolean" not in AUTOMATIONS_TEXT[
+        AUTOMATIONS_TEXT.index("v8_6_truth_unavailable_cooling_failsafe") : AUTOMATIONS_TEXT.index("v9_sleep_priority_interlock")
+    ]

--- a/tests/test_supervisor_manual_observability.py
+++ b/tests/test_supervisor_manual_observability.py
@@ -83,6 +83,14 @@ NEW_FIELDS = {
 #     input_number.set_value de-registers — surfacing as "V9-E: Master Pre-Cool
 #     Nightly Reset has an unknown action: input_number.set_value". Removing the
 #     stray key (no behavior change; helper set unchanged) restores the action.
+#   - section3 re-pinned for the V8.6 truth-unavailable cooling failsafe restore:
+#     re-introduced the two OFF-only safety automations
+#     (v8_6_truth_unavailable_cooling_failsafe + ...reconciliation) recovered
+#     verbatim from Packet A commit 9e39e42 to re-link the live registry orphans.
+#     Section 3 only; sections 2/14 and configuration.yaml unchanged. These gates
+#     force a head OFF when its room-truth sensor is invalid while cooling; they
+#     never authorize cooling. See the Section 3 V8.6 comment block and
+#     tests/test_packetA_truth_unavailable_failsafe.py.
 EXPECTED_SECTION_HASHES = {
     "section2_main_supervisor": (
         "# SECTION 2: MAIN SUPERVISOR",
@@ -92,7 +100,7 @@ EXPECTED_SECTION_HASHES = {
     "section3_safety_gates": (
         "# SECTION 3: SAFETY GATES",
         "# SECTION 4:",
-        "bc762a54c7c33b739a15c4a0d85e40c6141d82f209373f5e0a7cd32591944a75",
+        "9d078092445376affacd1584fbfdf9e15bb5fc5102f92d992e3be91c94d59ec0",
     ),
     "section14_lr_boost": (
         "# SECTION 14: V8.4 LR HEATING RECOVERY BOOST PILOT",


### PR DESCRIPTION
## Why

Two safety automations were reported as live registry orphans (`unavailable` / `restored: true`) because their definitions were not in the loaded `automations.yaml`:

- `automation.v8_6_truth_unavailable_cooling_fail_safe_per_zone_protective_off`
- `automation.v8_6b_truth_unavailable_cooling_reconciliation_restart_reload_safe`

Their **verbatim source** was located on the unmerged Packet A branch `codex/clarify-codex-stage-1-and-2-implementation` @ `9e39e42` ("Implement Packet A truth unavailable cooling failsafe"). This PR restores **only** the two OFF-only automations so HA loads them again — recovered source, not reconstructed from entity IDs.

## What changed

- **`automations.yaml`** (+115 lines, Section 3 Safety Gates, before the V9 Sleep Priority Interlock — its original placement):
  - `v8_6_truth_unavailable_cooling_failsafe` (`mode: queued`): when a room-truth sensor reads invalid (`none`/`NaN`/`<-90`/`>200`) for 2 min while the head reports `cool`, force that head `climate.set_hvac_mode: off`. **OFF-only** — never authorizes cooling; guards the hidden-70 °F-fallback-sustaining-cooling failure mode.
  - `v8_6b_truth_unavailable_cooling_reconciliation` (`mode: single`): HA-start + every-5-min sweep of the same four truth/climate pairs (OFF-only), closing the restart race where a template `for:` timer was never armed.
  - All four referenced truth sensors and the four `climate.*_air` heads already exist on `main`/live.
- **`tests/test_packetA_truth_unavailable_failsafe.py`** (from `9e39e42`): 4 active contract tests pinning the OFF-only structure; the 2 *supervisor-coupling* tests are **skipped** (documented) — see scope note below.
- **`tests/test_supervisor_manual_observability.py`**: re-pin the `section3_safety_gates` control-surface hash with a re-pin history entry. Section 2/14 and `configuration.yaml` are **byte-for-byte unchanged**.

## Scope (deliberately narrow)

Packet A `9e39e42` also rewrote `v7_5_main_supervisor` with off-biased `*_truth_ok` cooling-template guards. That comfort-path rewrite has **diverged on `main`** and is **out of scope** for a narrow safety restore (no redesign). The two automations here are self-contained and act only when truth is invalid *and* a head is cooling — pure additive safety, no comfort regression. The supervisor change can be restored separately; the two skipped tests belong with it.

## Verify

- `python -m pytest tests/` → **167 passed, 2 skipped**.
- Strict YAML parse (no duplicate keys, no duplicate automation ids) passes.

## ⚠️ Registry re-link caveat

HA links registry rows by the automation **`id:` (unique_id)**, not the alias. The live orphan entity_ids are longer (`…fail_safe_per_zone_protective_off` / `…reconciliation_restart_reload_safe`) than these aliases. After merge + deploy + **Reload Automations**:
- If the orphans' unique_id matches `v8_6_truth_unavailable_cooling_failsafe` / `…reconciliation`, they re-link and go available.
- Otherwise two new entities appear and the stale orphan rows should be deleted via Settings → Entities.

Context: docs/postmortems/2026-06-15_input_number_domain_and_v86_orphans.md (PR #151).

https://claude.ai/code/session_01PFrYhnLTdZvPS1c9Ud7T34

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFrYhnLTdZvPS1c9Ud7T34)_