### PR TITLE
Add master bedroom fan↔AC sync with self-healing reconcile

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -2303,3 +2303,69 @@
             - action: fan.turn_on
               target: { entity_id: fan.master_bedroom_switch_fan }
               data: { percentage: 100 }
+
+# =============================================================================
+# SECTION 18: MASTER BEDROOM FAN — RECONCILE (SELF-HEAL)
+# =============================================================================
+# Safety net for the Section 17 edge-driven sync. The SwitchBot fan reaches HA
+# through the SmartThings cloud, which can drop or stale a single
+# fan.turn_on / fan.turn_off. Because Section 17 only fires on a
+# climate.master_bedroom_air mode *transition*, a dropped command leaves the fan
+# out of sync until the next AC mode change — the observed failure where the fan
+# stayed `on @ 66%` after the AC went `cool -> off` and the lone turn_off never
+# landed.
+#
+# This automation re-asserts the same contract whenever the fan reports a
+# state/percentage change and on a 5-minute time pattern, so a dropped command
+# self-heals instead of persisting as a telemetry mismatch.
+#
+# Contract (identical to Section 17): AC off -> fan off; AC running (any mode)
+# -> fan on @100%. A command is issued ONLY when the fan and AC actually
+# disagree, so a correctly-synced fan generates no commands (and an offline
+# device that never updates simply receives a harmless no-op every 5 minutes
+# until connectivity returns — this path cannot move a physically dead device).
+# =============================================================================
+
+- id: master_bedroom_fan_reconcile
+  alias: "V10: Master Bedroom Fan Reconcile (self-heal)"
+  mode: single
+  max_exceeded: silent
+  trigger:
+    - platform: time_pattern
+      minutes: "/5"
+    - platform: state
+      entity_id: fan.master_bedroom_switch_fan
+  condition:
+    # Skip when the AC mode is unknown/unavailable: the correct fan state is
+    # undefined, so re-asserting would be guessing. Section 17 likewise only
+    # acts on concrete mode transitions.
+    - condition: template
+      value_template: >-
+        {{ states('climate.master_bedroom_air') not in ['unknown', 'unavailable'] }}
+  action:
+    - choose:
+        # AC is off but the fan is still reporting on -> re-issue turn_off.
+        - conditions:
+            - condition: state
+              entity_id: climate.master_bedroom_air
+              state: "off"
+            - condition: state
+              entity_id: fan.master_bedroom_switch_fan
+              state: "on"
+          sequence:
+            - action: fan.turn_off
+              target: { entity_id: fan.master_bedroom_switch_fan }
+        # AC is running (any non-off mode) but the fan is off or not at 100%
+        # -> re-issue turn_on @100% to match the Section 17 on-state.
+        - conditions:
+            - condition: template
+              value_template: >-
+                {{ states('climate.master_bedroom_air') not in ['off', 'unknown', 'unavailable'] }}
+            - condition: template
+              value_template: >-
+                {{ is_state('fan.master_bedroom_switch_fan', 'off')
+                   or (state_attr('fan.master_bedroom_switch_fan', 'percentage') | int(0)) != 100 }}
+          sequence:
+            - action: fan.turn_on
+              target: { entity_id: fan.master_bedroom_switch_fan }
+              data: { percentage: 100 }

--- a/docs/master_bedroom_fan_sync.md
+++ b/docs/master_bedroom_fan_sync.md
@@ -1,0 +1,75 @@
+# Master Bedroom Fan ↔ AC Sync (Sections 17 & 18)
+
+**Doc Date:** 2026-06-16
+**Document Role:** Runtime note for the SwitchBot fan that follows the Master
+mini-split.
+**Status:** Living. Update when the fan↔AC contract, the actuator entity, or the
+SmartThings transport changes.
+**Scope:** Documents `automations.yaml` Section 17 (`master_bedroom_fan_sync`)
+and Section 18 (`master_bedroom_fan_reconcile`). Locked by
+`tests/test_master_fan_sync.py`.
+
+---
+
+## 1. Contract
+
+The SwitchBot fan `fan.master_bedroom_switch_fan` follows the Master mini-split
+`climate.master_bedroom_air`:
+
+- **AC off** → fan **off**.
+- **AC running** (any of `cool`, `heat`, `dry`, `fan_only`, `auto`) → fan **on
+  @ 100%**.
+
+`100%` and `off` are the **only** states either automation commands. Any other
+percentage (e.g. `66%`) is a leftover/manual speed and is, by definition, stale
+relative to the contract.
+
+## 2. Why two automations
+
+### Section 17 — edge-driven sync (`master_bedroom_fan_sync`)
+
+`mode: single`. Triggers only on `climate.master_bedroom_air` **mode
+transitions** and issues a single `fan.turn_off` / `fan.turn_on` on the edge.
+Fast, but fire-once: it does not verify the command or look at the fan again.
+
+### Section 18 — reconcile / self-heal (`master_bedroom_fan_reconcile`)
+
+`mode: single`, `max_exceeded: silent`. Triggers on the **fan's own
+state/percentage changes** and a **5-minute time pattern**, and re-asserts the
+same contract whenever the fan and AC disagree.
+
+The fan reaches HA through the **SmartThings cloud**, which can drop or stale a
+single command. When Section 17's lone `fan.turn_off` is dropped, the fan stays
+out of sync until the next AC mode change. The canonical observed failure:
+
+> AC went `cool → off` (04:45) and the supervisor confirmed the branch and
+> called `fan.turn_off`, but the fan stayed `on @ 66%` from the night before.
+> A direct `fan.turn_off` also returned *"state change could not be verified
+> within timeout."*
+
+Section 18 closes that gap: on the next fan state change or within 5 minutes it
+re-issues the missing command, so a dropped command self-heals instead of
+persisting as a telemetry mismatch (`fan_percentage = 66` while
+`Master_Air_Mode = off`).
+
+## 3. Boundaries
+
+- Reconcile issues a command **only when the fan and AC actually disagree**, so a
+  correctly-synced fan generates no traffic.
+- Reconcile **never commands the climate entity** — it reconciles the fan *to*
+  the AC, not the reverse (`tests/test_master_fan_sync.py::test_section18_reconcile_only_touches_the_fan`).
+- Reconcile skips when `climate.master_bedroom_air` is `unknown`/`unavailable`
+  (the correct fan state is undefined; re-asserting would be guessing).
+- **It cannot move a physically offline device.** If the SwitchBot is
+  unresponsive, the re-issued command is a harmless no-op until SmartThings
+  connectivity returns; recovering a genuinely dead device still needs a
+  state refresh (`homeassistant.update_entity`) or a physical check.
+
+## 4. Relationship to telemetry
+
+A stuck `fan_percentage` against a contradicting `Master_Air_Mode` is a
+**SmartThings transport artifact**, not a comfort-control failure. Treat such a
+window the way `docs/telemetry_confounders.md` treats other
+transport/stale-state artifacts: do not read it as the fan logic
+malfunctioning. Section 18 reduces how long such artifacts persist; it does not
+change the telemetry schema or any HVAC control authority.

--- a/tests/test_master_fan_sync.py
+++ b/tests/test_master_fan_sync.py
@@ -1,0 +1,184 @@
+"""
+Contract tests for the Master Bedroom fan <-> AC sync (Section 17) and its
+self-healing reconcile safety net (Section 18).
+
+Background: the SwitchBot fan (fan.master_bedroom_switch_fan) reaches HA through
+the SmartThings cloud, which can drop or stale a single command. Section 17 is
+edge-driven (mode: single, triggers only on climate.master_bedroom_air mode
+transitions), so a dropped command leaves the fan out of sync until the next AC
+mode change — observed as the fan stuck `on @ 66%` while the AC read `off`.
+Section 18 re-asserts the same contract on the fan's own state changes and a
+5-minute time pattern so a dropped command self-heals.
+
+These checks are conservative structural assertions against the parsed YAML; they
+do not require an HA runtime. References: automations.yaml Sections 17 & 18.
+"""
+
+import os
+
+import pytest
+import yaml
+
+
+class MooseSafetyLoader(yaml.SafeLoader):
+    pass
+
+
+def yaml_include(loader, node):
+    return f"INCLUDE_{node.value}"
+
+
+def yaml_secret(loader, node):
+    return f"SECRET_{node.value}"
+
+
+def yaml_input(loader, node):
+    return f"INPUT_{node.value}"
+
+
+def include_dir_merge_list_constructor(loader, node):
+    return []
+
+
+MooseSafetyLoader.add_constructor("!include", yaml_include)
+MooseSafetyLoader.add_constructor("!secret", yaml_secret)
+MooseSafetyLoader.add_constructor("!input", yaml_input)
+MooseSafetyLoader.add_constructor("!include_dir_merge_list", include_dir_merge_list_constructor)
+MooseSafetyLoader.add_constructor("!include_dir_named", include_dir_merge_list_constructor)
+
+
+FAN_ENTITY = "fan.master_bedroom_switch_fan"
+CLIMATE_ENTITY = "climate.master_bedroom_air"
+
+
+@pytest.fixture(scope="module")
+def automations_data():
+    filepath = os.path.join(os.path.dirname(__file__), "..", "automations.yaml")
+    if not os.path.exists(filepath):
+        pytest.skip("automations.yaml not found.")
+        return []
+
+    with open(filepath, "r") as file:
+        try:
+            return yaml.load(file, Loader=MooseSafetyLoader)
+        except Exception as e:  # pragma: no cover - parse failure is a hard fail
+            pytest.fail(f"Could not parse automations.yaml: {e}")
+
+
+def _by_id(automations_data, auto_id):
+    for auto in automations_data:
+        if auto.get("id") == auto_id:
+            return auto
+    return None
+
+
+def _triggers(auto):
+    triggers = auto.get("trigger", [])
+    if isinstance(triggers, dict):
+        triggers = [triggers]
+    return triggers
+
+
+def _flatten_actions(node):
+    """Yield every dict action under a (possibly nested choose/sequence) action block."""
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _flatten_actions(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _flatten_actions(item)
+
+
+def _fan_calls(auto):
+    actions = auto.get("action", [])
+    calls = []
+    for action in _flatten_actions(actions):
+        service = action.get("action") or action.get("service")
+        if service not in ("fan.turn_on", "fan.turn_off"):
+            continue
+        target = action.get("target", {}) or {}
+        data = action.get("data", {}) or {}
+        entity = target.get("entity_id") or data.get("entity_id")
+        calls.append((service, entity, data))
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Section 17 — edge-driven sync
+# ---------------------------------------------------------------------------
+
+def test_section17_fan_sync_present(automations_data):
+    auto = _by_id(automations_data, "master_bedroom_fan_sync")
+    assert auto is not None, "Section 17 master_bedroom_fan_sync automation is missing."
+    assert auto.get("mode") == "single"
+
+    # Triggers must watch the AC mode transitions, not the fan.
+    watched = {t.get("entity_id") for t in _triggers(auto) if t.get("platform") == "state"}
+    assert watched == {CLIMATE_ENTITY}, (
+        "Section 17 should trigger only on climate.master_bedroom_air mode transitions."
+    )
+
+
+def test_section17_on_state_is_full_speed(automations_data):
+    """The defined on-state is 100% — never 33/66. A stuck 66% is therefore stale,
+    confirming the failure mode Section 18 heals."""
+    auto = _by_id(automations_data, "master_bedroom_fan_sync")
+    on_calls = [c for c in _fan_calls(auto) if c[0] == "fan.turn_on"]
+    assert on_calls, "Section 17 must turn the fan on when the AC runs."
+    for _service, entity, data in on_calls:
+        assert entity == FAN_ENTITY
+        assert data.get("percentage") == 100, "Section 17 must command 100%, the only on-state."
+
+
+# ---------------------------------------------------------------------------
+# Section 18 — self-healing reconcile
+# ---------------------------------------------------------------------------
+
+def test_section18_reconcile_present(automations_data):
+    auto = _by_id(automations_data, "master_bedroom_fan_reconcile")
+    assert auto is not None, (
+        "Section 18 master_bedroom_fan_reconcile self-heal automation is missing."
+    )
+    assert auto.get("mode") == "single"
+
+
+def test_section18_reconcile_triggers_on_fan_and_time_pattern(automations_data):
+    """The whole point of the safety net: it must re-evaluate independent of AC
+    mode transitions, otherwise a dropped command stays dropped."""
+    auto = _by_id(automations_data, "master_bedroom_fan_reconcile")
+    triggers = _triggers(auto)
+
+    has_fan_state = any(
+        t.get("platform") == "state" and t.get("entity_id") == FAN_ENTITY for t in triggers
+    )
+    has_time_pattern = any(t.get("platform") == "time_pattern" for t in triggers)
+
+    assert has_fan_state, "Reconcile must trigger on the fan's own state changes."
+    assert has_time_pattern, "Reconcile must trigger on a time pattern to catch stuck state."
+
+
+def test_section18_reconcile_reasserts_both_directions(automations_data):
+    """Reconcile must be able to push the fan off (AC off) and on@100% (AC running)."""
+    auto = _by_id(automations_data, "master_bedroom_fan_reconcile")
+    calls = _fan_calls(auto)
+    services = {c[0] for c in calls}
+
+    assert "fan.turn_off" in services, "Reconcile must re-issue turn_off when the AC is off."
+    on_calls = [c for c in calls if c[0] == "fan.turn_on"]
+    assert on_calls, "Reconcile must re-issue turn_on when the AC is running."
+    for _service, entity, data in on_calls:
+        assert entity == FAN_ENTITY
+        assert data.get("percentage") == 100, "Reconcile on-state must match Section 17 (100%)."
+
+
+def test_section18_reconcile_only_touches_the_fan(automations_data):
+    """Safety boundary: the reconcile loop must never command the climate entity.
+    It reconciles the fan to the AC, not the other way around."""
+    auto = _by_id(automations_data, "master_bedroom_fan_reconcile")
+    for action in _flatten_actions(auto.get("action", [])):
+        service = action.get("action") or action.get("service")
+        if service and service.startswith("climate."):
+            pytest.fail(
+                f"Reconcile must not command climate state; found '{service}'."
+            )


### PR DESCRIPTION
## Summary

Implements a two-tier automation system to keep the Master bedroom SwitchBot fan synchronized with the mini-split AC unit, with a self-healing safety net to recover from dropped SmartThings cloud commands.

## Changes

- **Section 17 (`master_bedroom_fan_sync`)**: Edge-driven sync that triggers on AC mode transitions and commands the fan to match the AC state (off when AC is off; on @ 100% when AC is running).

- **Section 18 (`master_bedroom_fan_reconcile`)**: Self-healing reconcile automation that re-asserts the same contract whenever the fan reports a state change or on a 5-minute time pattern. This closes the gap when Section 17's command is dropped by the SmartThings cloud, preventing the fan from staying stuck out of sync.

- **Contract tests** (`tests/test_master_fan_sync.py`): Comprehensive structural assertions validating:
  - Section 17 triggers only on AC mode transitions with `mode: single`
  - Section 17 commands 100% (the only on-state) when turning on
  - Section 18 triggers on both fan state changes and time patterns
  - Section 18 re-asserts both directions (off and on @ 100%)
  - Section 18 never commands the climate entity (reconciles fan *to* AC, not reverse)

- **Runtime documentation** (`docs/master_bedroom_fan_sync.md`): Living document explaining the contract, why two automations are needed, boundaries, and relationship to telemetry artifacts.

## Implementation Details

- Both automations use `mode: single` to prevent concurrent execution
- Section 18 uses `max_exceeded: silent` to avoid log spam on the 5-minute pattern
- Section 18 skips when AC state is `unknown`/`unavailable` (correct fan state is undefined)
- Commands are issued only when fan and AC actually disagree, so a correctly-synced fan generates no traffic
- The observed failure mode (fan stuck `on @ 66%` after AC went `off`) is now self-healing within 5 minutes

https://claude.ai/code/session_01HMdFL4AeVMvUS6iyguWrHk